### PR TITLE
indexing sort_date for file_sets/assets, #200

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,9 +12,11 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery-ui/datepicker
 //= require turbolinks//
 // Required by Blacklight
 //= require blacklight/blacklight
 
 //= require 'edit_users'
+//= require 'file_set_sort_date'
 //= require_tree .

--- a/app/assets/javascripts/file_set_sort_date.js
+++ b/app/assets/javascripts/file_set_sort_date.js
@@ -1,0 +1,6 @@
+$(document).on('page:load', function() {
+  // date picker for the file_set sort date field
+  $( "#file_set_sort_date" ).datepicker({
+    dateFormat: "yy-mm-dd"
+  });
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,7 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
+ *= require jquery-ui/datepicker
  *= require_tree .
  *= require_self
  */

--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -8,7 +8,7 @@ module CurationConcerns
         :visibility_during_embargo, :embargo_release_date,
         :visibility_after_embargo, :visibility_during_lease,
         :lease_expiration_date, :visibility_after_lease, :visibility,
-        :creator_family_name, :creator_given_name,
+        :creator_family_name, :creator_given_name, :sort_date,
         resource_type: [], caption: [], alt_text: [], copyright_holder: [],
         description: [], content_type: [],
         contributor: [],

--- a/app/forms/heliotrope/forms/file_set_edit_form.rb
+++ b/app/forms/heliotrope/forms/file_set_edit_form.rb
@@ -3,6 +3,7 @@ module Heliotrope::Forms
     self.terms += [:resource_type, :caption, :alt_text, :copyright_holder,
                    :description, :content_type, :date_created, :keywords,
                    :language, :identifier, :relation, :external_resource,
-                   :persistent_id, :creator_family_name, :creator_given_name]
+                   :persistent_id, :creator_family_name, :creator_given_name,
+                   :sort_date]
   end
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -10,31 +10,49 @@ class FileSet < ActiveFedora::Base
   property :caption, predicate: ::RDF::Vocab::SCHEMA.caption do |index|
     index.as :stored_searchable
   end
+
   property :alt_text, predicate: ::RDF::Vocab::SCHEMA.accessibilityFeature do |index|
     index.as :stored_searchable
   end
+
   property :content_type, predicate: ::RDF::Vocab::SCHEMA.contentType do |index|
     index.as :stored_searchable
   end
+
   property :keywords, predicate: ::RDF::Vocab::DC.subject do |index|
     index.as :stored_searchable, :facetable
   end
+
   property :relation, predicate: ::RDF::Vocab::DC.relation do |index|
     index.as :stored_searchable
   end
+
   property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
     index.as :stored_searchable
   end
+
   property :copyright_holder, predicate: ::RDF::Vocab::SCHEMA.copyrightHolder do |index|
     index.as :stored_searchable
   end
+
   property :date_published, predicate: ::RDF::Vocab::SCHEMA.datePublished do |index|
     index.as :stored_searchable
   end
+
   property :external_resource, predicate: ::RDF::Vocab::DC.source do |index|
     index.as :symbol
   end
+
   property :persistent_id, predicate: ::RDF::Vocab::DC.URI do |index|
     index.as :symbol
   end
+
+  property :sort_date, predicate: ::RDF::Vocab::DC.date, multiple: false do |index|
+    index.as :stored_searchable
+  end
+  validates :sort_date, format: {
+    with: /\A\d\d\d\d-\d\d-\d\d\z/,
+    message: "Your sort date must be in YYYY-MM-DD format",
+    allow_blank: true
+  }
 end

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -66,6 +66,8 @@
           </span>
           <%= text_field_tag 'file_set[date_created][]', curation_concern.date_created.first, class: 'form-control' %>
 
+          <%= f.input :sort_date, input_html: { class: 'form-control' }, placeholder: 'YYYY-MM-DD' %>
+
           <%= f.input :keywords, as: :multi_value, input_html: { class: 'form-control' } %>
 
           <span class="control-label">

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe FileSet do
+  let(:file_set) { described_class.new }
+  let(:sort_date) { '2014-01-03' }
+  let(:bad_sort_date) { 'NOT-A-DATE' }
+
+  before do
+    described_class.destroy_all
+  end
+
+  it 'has a valid sort_date' do
+    file_set.sort_date = sort_date
+    file_set.apply_depositor_metadata('admin@example.com')
+    expect(file_set.save!).to be true
+    expect(file_set.reload.sort_date).to eq sort_date
+  end
+
+  it 'does not have an invalid sort date' do
+    file_set.sort_date = bad_sort_date
+    file_set.apply_depositor_metadata('admin@example.com')
+    expect { file_set.save! }.to raise_error(ActiveFedora::RecordInvalid)
+  end
+end


### PR DESCRIPTION
Resolves #200 

This enforces a sort_date format of YYYY-MM-DD, so it won't accept YYYY or YYYY-MM. Is that ok with everyone?
