### PR TITLE
maybe disable downloads based on metadata, #287

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,0 +1,46 @@
+class DownloadsController < ApplicationController
+  include CurationConcerns::DownloadBehavior
+
+  def show
+    if thumbnail? || webm? || sound? || allow_download?
+      super
+    else
+      render 'curation_concerns/base/unauthorized', status: :unauthorized
+    end
+  end
+
+  def allow_download?
+    @file_set ||= FileSet.find(params[:id])
+    if @file_set.allow_download == 'yes'
+      true
+    else
+      false
+    end
+  end
+
+  def thumbnail?
+    if params[:file] == 'thumbnail'
+      true
+    else
+      false
+    end
+  end
+
+  def webm?
+    # video "previews"
+    if params[:file] == 'webm'
+      true
+    else
+      false
+    end
+  end
+
+  def sound?
+    # sound "previews"
+    if params[:file] == 'mp3' || params[:file] == 'ogg'
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -40,5 +40,13 @@ module CurationConcerns
     def link_name
       current_ability.can?(:read, id) ? Array(solr_document['label_tesim']).first : 'File'
     end
+
+    def allow_download?
+      if allow_download == 'yes' || allow_download.first == 'yes'
+        true
+      else
+        false
+      end
+    end
   end
 end

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,0 +1,12 @@
+<% if CurationConcerns.config.display_media_download_link && file_set.allow_download? %>
+    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
+        <figure>
+            <%= image_tag "default.png", alt: "No preview available", class: "img-responsive" %>
+            <figcaption>Download the document</figcaption>
+        </figure>
+    <% end %>
+<% else %>
+    <figure>
+        <%= image_tag "default.png", alt: "No preview available", class: "img-responsive" %>
+    </figure>
+<% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,0 +1,16 @@
+<% if CurationConcerns.config.display_media_download_link && file_set.allow_download? %>
+    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized image" do %>
+        <figure>
+            <%= image_tag thumbnail_url(file_set),
+                          class: "img-responsive",
+                          alt: "Download the full-sized image of #{file_set.to_s}" %>
+            <figcaption>Download the full-sized image</figcaption>
+        </figure>
+    <% end %>
+<% else %>
+    <figure>
+        <%= image_tag thumbnail_url(file_set),
+                      class: "img-responsive",
+                      alt: "Thumbnail of #{file_set.to_s}" %>
+    </figure>
+<% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,0 +1,16 @@
+<% if CurationConcerns.config.display_media_download_link && file_set.allow_download? %>
+    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
+        <figure>
+            <%= image_tag thumbnail_url(file_set),
+                          class: "img-responsive",
+                          alt: "Download the document #{file_set.to_s}" %>
+            <figcaption>Download the document</figcaption>
+        </figure>
+    <% end %>
+<% else %>
+    <figure>
+        <%= image_tag thumbnail_url(file_set),
+                      class: "img-responsive",
+                      alt: "Thumbnail of #{file_set.to_s}" %>
+    </figure>
+<% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,16 @@
+<% if CurationConcerns.config.display_media_download_link && file_set.allow_download? %>
+    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized PDF" do %>
+        <figure>
+            <%= image_tag thumbnail_url(file_set),
+                          class: "img-responsive",
+                          alt: "Download the full-sized PDF of #{file_set.to_s}" %>
+            <figcaption>Download the full-sized PDF</figcaption>
+        </figure>
+    <% end %>
+<% else %>
+    <figure>
+        <%= image_tag thumbnail_url(file_set),
+                      class: "img-responsive",
+                      alt: "Thumbnail of #{file_set.to_s}" %>
+    </figure>
+<% end %>

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -21,6 +21,11 @@
     }).addLayer(L.tileLayer.iiif("<%= riiif.info_path(@presenter.id) %>"));
   });
   </script>
+
+  <% if @presenter.allow_download? %>
+    <%= link_to "Download the full-sized image", main_app.download_path(@presenter.id), target: "_new" %>
+  <% end %>
+  
 <% else %>
   <%= media_display @presenter %>
 <% end %>

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe DownloadsController do
+  let(:user) { create(:user) }
+  before do
+    sign_in user
+  end
+
+  describe "#show" do
+    context "when allow_download is yes" do
+      let(:file_set) { create(:file_set,
+                              user: user,
+                              allow_download: 'yes',
+                              content: File.open(File.join(fixture_path, 'csv', 'miranda.jpg'))) }
+      it "sends the file" do
+        get :show, id: file_set
+        expect(response.body).to eq file_set.original_file.content
+      end
+    end
+
+    context "when allow_download is not yes" do
+      let(:file_set) { create(:file_set,
+                              user: user,
+                              allow_download: 'no',
+                              content: File.open(File.join(fixture_path, 'csv', 'miranda.jpg'))) }
+      it "shows the unauthorized message" do
+        get :show, id: file_set
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,10 +2,17 @@ FactoryGirl.define do
   factory :file_set do
     transient do
       user { FactoryGirl.create(:user) }
+      content nil
     end
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    after(:create) do |file, evaluator|
+      if evaluator.content
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
+      end
     end
 
     sequence(:title) { |n| ["Test FileSet #{n}"] }

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe CurationConcerns::FileSetPresenter do
+  let(:ability) { double('ability') }
+  let(:presenter) { described_class.new(fileset_doc, ability) }
+
+  describe '#allow_download?' do
+    let(:fileset_doc) { SolrDocument.new(id: 'fs', has_model_ssim: ['FileSet'], allow_download_ssim: 'yes') }
+    it "can download" do
+      expect(presenter.allow_download?).to be true
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,8 +42,6 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
-  # config.include Devise::TestHelpers, type: :controller
-  # config.include Devise::TestHelpers, type: :view
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Warden::Test::Helpers, type: :feature
 end


### PR DESCRIPTION
For #287, this works for images, office docs and pdfs but not video or audio.