### PR TITLE
updates to monograph metadata/edit UI

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -59,6 +59,8 @@ class CatalogController < ApplicationController
     # Heliotrope
     config.add_index_field solr_name('date_published', :stored_searchable)
     config.add_index_field solr_name('isbn', :stored_searchable)
+    config.add_index_field solr_name('isbn_softcover', :stored_searchable)
+    config.add_index_field solr_name('isbn_ebook', :stored_searchable)
     config.add_index_field solr_name('editor', :stored_searchable)
     config.add_index_field solr_name('copyright_holder', :stored_searchable)
     config.add_index_field solr_name('buy_url', :symbol)

--- a/app/forms/curation_concerns/monograph_form.rb
+++ b/app/forms/curation_concerns/monograph_form.rb
@@ -3,7 +3,9 @@
 module CurationConcerns
   class MonographForm < CurationConcerns::Forms::WorkForm
     self.model_class = ::Monograph
-    self.terms += [:press, :date_published, :isbn, :editor, :copyright_holder, :buy_url, :sub_brand, :creator_family_name, :creator_given_name]
+    self.terms += [:press, :date_published, :isbn, :isbn_softcover, :isbn_ebook,
+                   :editor, :copyright_holder, :buy_url, :sub_brand,
+                   :creator_family_name, :creator_given_name]
     self.required_fields += [:press]
 
     delegate :current_user, to: :current_ability

--- a/app/models/monograph.rb
+++ b/app/models/monograph.rb
@@ -27,6 +27,14 @@ class Monograph < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :isbn_softcover, predicate: ::RDF::Vocab::SCHEMA.isbn do |index|
+    index.as :stored_searchable
+  end
+
+  property :isbn_ebook, predicate: ::RDF::Vocab::SCHEMA.isbn do |index|
+    index.as :stored_searchable
+  end
+
   property :editor, predicate: ::RDF::Vocab::SCHEMA.editor do |index|
     index.as :stored_searchable
   end

--- a/app/models/monograph.rb
+++ b/app/models/monograph.rb
@@ -27,11 +27,11 @@ class Monograph < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :isbn_softcover, predicate: ::RDF::Vocab::SCHEMA.isbn do |index|
+  property :isbn_softcover, predicate: ::RDF::URI.new('http://fulcrum.org/ns#isbnSoftcover') do |index|
     index.as :stored_searchable
   end
 
-  property :isbn_ebook, predicate: ::RDF::Vocab::SCHEMA.isbn do |index|
+  property :isbn_ebook, predicate: ::RDF::URI.new('http://fulcrum.org/ns#isbnEbook') do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -60,6 +60,8 @@ class SolrDocument
     'editor',
     'identifier',
     'isbn',
+    'isbn_softcover',
+    'isbn_ebook',
     'keywords',
     'primary_creator_role',
     'relation',

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -4,9 +4,10 @@ module CurationConcerns
 
     delegate :title, :date_created, :date_modified, :date_uploaded,
              :description, :creator, :editor, :contributor, :subject,
-             :publisher, :date_published, :language, :isbn, :copyright_holder,
-             :buy_url, :embargo_release_date, :lease_expiration_date, :rights,
-             :creator_full_name, :creator_given_name, :creator_family_name,
+             :publisher, :date_published, :language, :isbn, :isbn_softcover,
+             :isbn_ebook, :copyright_holder, :buy_url, :embargo_release_date,
+             :lease_expiration_date, :rights, :creator_full_name,
+             :creator_given_name, :creator_family_name,
              to: :solr_document
 
     def section_docs

--- a/app/views/curation_concerns/monographs/_form_additional_information.html.erb
+++ b/app/views/curation_concerns/monographs/_form_additional_information.html.erb
@@ -2,11 +2,11 @@
   <legend>Additional Information</legend>
   <%= f.input :sub_brand, collection: @form.select_sub_brand, include_blank: true, input_html: {  multiple: true, class: 'form-control' } %>
   <%= f.input :subject,                as: :multi_value, input_html: { class: 'form-control' } %>
-  <%= f.input :publisher,              as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :date_published,         as: :multi_value, input_html: { class: 'form-control' } %>
-  <%= f.input :source,                 as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :language,               as: :multi_value, input_html: { class: 'form-control' } %>
-  <%= f.input :isbn,                   as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :isbn,                   as: :multi_value, input_html: { class: 'form-control' }, label: 'ISBN (Hardcover)' %>
+  <%= f.input :isbn_softcover,         as: :multi_value, input_html: { class: 'form-control', label: 'ISBN (Softcover)' } %>
+  <%= f.input :isbn_ebook,             as: :multi_value, input_html: { class: 'form-control', label: 'ISBN (E-Book)' } %>  
   <%= f.input :editor,                 as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :copyright_holder,       as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :buy_url,                as: :multi_value, input_html: { class: 'form-control' } %>

--- a/app/views/curation_concerns/monographs/_form_required_information.html.erb
+++ b/app/views/curation_concerns/monographs/_form_required_information.html.erb
@@ -2,9 +2,9 @@
   <legend>Required Information</legend>
 
   <%= f.input :title, as: :multi_value %>
-  <%= f.input :press, collection: @form.select_press, input_html: { class: 'required' } %>
-  <%= f.input :creator_family_name, label: 'Primary Creator (family name)' %>
-  <%= f.input :creator_given_name, label: 'Primary Creator (given name)' %>
-  <%= f.input :contributor, as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :press, collection: @form.select_press, input_html: { class: 'required' }, label: 'Publisher' %>
+  <%= f.input :creator_family_name, label: 'Author (last name)' %>
+  <%= f.input :creator_given_name, label: 'Author (first name)' %>
+  <%= f.input :contributor, as: :multi_value, input_html: { class: 'form-control' }, label: 'Additional Authors' %>
   <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'} %>
 </fieldset>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -5,13 +5,15 @@ en:
     search:
       fields:
         date_published_tesim: "Date Published"
-        isbn_tesim: "ISBN"
+        isbn_tesim: "ISBN (Hardcover)"
+        isbn_softcover_tesim: "ISBN (Softcover)"
+        isbn_ebook_tesim: "ISBN (E-Book)"
         editor_tesim: "Editor"
         copyright_holder_tesim: "Copyright Holder"
         copyright_status_tesim: "Copyright Status"
         rights_granted_tesim: "Rights Granted"
         rights_granted_creative_commons_tesim: "Rights Granted - Creative Commons"
-        buy_url_ssim: "Buy Book"
+        buy_url_ssim: "Buy Book URL"
         caption_tesim: "Caption"
         alt_text_tesim: "Alternative Text"
         content_type_tesim: "Content Type"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,9 @@ en:
   simple_form:
     labels:
       defaults:
-        isbn: "ISBN"
+        isbn: "ISBN (Hardcover)"
+        isbn_softcover: "ISBN (Softcover)"
+        isbn_ebook: "ISBN (E-Book)"
         editor: "Editor"
         buy_url: "Buy Book URL"
         copyright_holder: "Copyright Holder"
@@ -66,4 +68,3 @@ en:
   manage_assets:
     monograph_link_text: "Organize Sections and Assets"
     section_link_text: "Organize Assets"
-

--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -14,7 +14,7 @@ feature 'Create a file set' do
       # Start by creating a Monograph
       visit new_curation_concerns_monograph_path
       fill_in 'Title', with: 'Test monograph'
-      select press.name, from: 'Press'
+      select press.name, from: 'Publisher'
       fill_in 'Date Published', with: 'Oct 20th'
       click_button 'Create Monograph'
       # Go to monograph show page (not monograph catalog page)

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -12,8 +12,8 @@ feature 'Create a monograph' do
     scenario do
       visit new_curation_concerns_monograph_path
       fill_in 'Title', with: 'Test monograph'
-      select press.name, from: 'Press'
-      fill_in 'ISBN', with: '123-456-7890'
+      select press.name, from: 'Publisher'
+      fill_in 'ISBN (Hardcover)', with: '123-456-7890'
       click_button 'Create Monograph'
       expect(page).to have_content 'Test monograph'
       expect(page).to have_content '123-456-7890'

--- a/spec/forms/curation_concerns/monograph_form_spec.rb
+++ b/spec/forms/curation_concerns/monograph_form_spec.rb
@@ -39,6 +39,8 @@ describe CurationConcerns::MonographForm do
                             :press,
                             :date_published,
                             :isbn,
+                            :isbn_softcover,
+                            :isbn_ebook,
                             :editor,
                             :copyright_holder,
                             :buy_url,


### PR DESCRIPTION
Closes #253 

* Adds multi value ISBN fields to monograph to capture different format ISBNs
* alters labels for primary creator, contributor, press
* removes source and publisher field

![monograph-ui-edits](https://cloud.githubusercontent.com/assets/1686111/17308086/1ce7ad08-5806-11e6-807b-67880d609cd1.png)
