### PR TITLE
Disable right click over video elements

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,4 +22,5 @@
 
 //= require 'edit_users'
 //= require 'file_set_sort_date'
+//= require 'disable_video_src'
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,5 +22,5 @@
 
 //= require 'edit_users'
 //= require 'file_set_sort_date'
-//= require 'disable_video_src'
+//= require 'disable_video_download'
 //= require_tree .

--- a/app/assets/javascripts/disable_video_download.js
+++ b/app/assets/javascripts/disable_video_download.js
@@ -1,0 +1,4 @@
+//disable right click over video
+$(document).ready(function(){
+   $('#video').bind('contextmenu',function() { return false; });
+});

--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -1,10 +1,15 @@
 // custom styles for heliotrope
 
-
 .asset {
-  // leaflet
+
+  // leaflet-images
   #image {
     height: 540px;
+    width: 97%;
+  }
+
+  // video
+  video {
     width: 97%;
   }
 

--- a/app/views/curation_concerns/file_sets/media_display/_video.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_video.html.erb
@@ -1,0 +1,5 @@
+  <video id="video" controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+    <source src="<%= main_app.download_path(file_set, file: 'webm') %>" type="video/webm" />
+    <source src="<%= main_app.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>


### PR DESCRIPTION
Disabling `src` attribute on multiple `source` elements resulted in undesirable behavior -- mainly the video not loading for playback. Instead of removing the `src` attribute, I've disabled the right click, which is at least something we can show NW to gauge their level of comfort. 

I would venture to guess that with right-click disabled and no "download" button on the page, we're effectively preventing download for 90-95% of users.

There is also a side fix in here that makes the video player responsive and sizes it to the width of the asset column.