### PR TITLE
Preserve markup newlines 352

### DIFF
--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -3,6 +3,8 @@ class MarkdownService
   self.md = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(safe_links_only: true), strikethrough: true, lax_spacing: true, no_intra_emphasis: true)
 
   def self.markdown(value)
-    Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(md.render(value))[1]
+    rendered_html = md.render(value)
+    outer_p_tags_removed = Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(rendered_html)
+    outer_p_tags_removed.nil? ? rendered_html : outer_p_tags_removed[1]
   end
 end

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -3,6 +3,6 @@ class MarkdownService
   self.md = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(safe_links_only: true), strikethrough: true, lax_spacing: true, no_intra_emphasis: true)
 
   def self.markdown(value)
-    md.render(value).gsub(/^<p>/, "").gsub(/<\/p>$/, "")
+    Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(md.render(value))[1]
   end
 end

--- a/spec/services/markdown_service_spec.rb
+++ b/spec/services/markdown_service_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe MarkdownService do
-  let(:html) { "This is _italics_ and this is __bold__ and this is ~~strikethrough~~" }
+  let(:html) { "\n\nThis is _italics_ and this is\n\na paragraph\n\n__bold__ and this is ~~strikethrough~~" }
 
   it "renders html from markdown" do
-    expect(described_class.markdown(html)).to eq("This is <em>italics</em> and this is <strong>bold</strong> and this is <del>strikethrough</del>\n")
+    expect(described_class.markdown(html)).to eq("This is <em>italics</em> and this is</p>\n\n<p>a paragraph</p>\n\n<p><strong>bold</strong> and this is <del>strikethrough</del>")
   end
 end


### PR DESCRIPTION
I'm not 100% sure we even need to be removing p tags like this.

Jon's styles seem to handle any mess or extra space with the extra <p> tags right now except in headings.
Would it be better to handle those with styling?
