### PR TITLE
add default search fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,7 +4,7 @@ class CatalogController < ApplicationController
     config.search_builder_class = ::SearchBuilder
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
-      qf: 'title_tesim creator_full_name_tesim subject_tesim',
+      qf: 'title_tesim creator_full_name_tesim subject_tesim description_tesim keywords_tesim contributor_tesim caption_tesim transcript_tesim translation_tesim alt_text_tesim',
       qt: 'search',
       rows: 10
     }

--- a/spec/features/monograph_catalog_search_spec.rb
+++ b/spec/features/monograph_catalog_search_spec.rb
@@ -20,18 +20,66 @@ feature 'Monograph Catalog Search' do
     click_link 'Manage Monograph and Files'
     click_link 'Attach a File'
     fill_in 'Title', with: 'Strange Marshes'
+    fill_in 'Caption', with: 'onion'
+    fill_in 'Alternative Text', with: 'garlic'
+    fill_in 'Description', with: 'tomato'
+    fill_in 'Contributor', with: 'potato'
+    fill_in 'Keywords', with: 'squash'
+    fill_in 'Transcript', with: 'broccoli'
+    fill_in 'Translation(s)', with: 'cauliflower'
     attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
     click_button 'Attach to Monograph'
 
     click_link 'Manage Monograph and Files'
     click_link 'Attach a File'
     fill_in 'Title', with: 'Unruly Puddles'
+    fill_in 'Caption', with: 'monkey'
+    fill_in 'Alternative Text', with: 'lizard'
+    fill_in 'Description', with: 'elephant'
+    fill_in 'Contributor', with: 'rhino'
+    fill_in 'Keywords', with: 'snake'
+    fill_in 'Transcript', with: 'tiger'
+    fill_in 'Translation(s)', with: 'mouse'
     attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
     click_button 'Attach to Monograph'
 
     fill_in 'catalog_search', with: 'Unruly'
     click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
 
+    fill_in 'catalog_search', with: 'monkey'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'lizard'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'elephant'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'rhino'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'snake'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'tiger'
+    click_button 'keyword-search-submit'
+    expect(page).to have_content 'Unruly Puddles'
+    expect(page).to_not have_content 'Strange Marshes'
+
+    fill_in 'catalog_search', with: 'mouse'
+    click_button 'keyword-search-submit'
     expect(page).to have_content 'Unruly Puddles'
     expect(page).to_not have_content 'Strange Marshes'
   end


### PR DESCRIPTION
Resolves #358 

Not every single indexed field is added to the default search. This PR addresses primary use cases. We can add more fields to the default search as needed.