### PR TITLE
Refactor migrations for sub brands table.

### DIFF
--- a/db/migrate/20160506173307_create_sub_brands.rb
+++ b/db/migrate/20160506173307_create_sub_brands.rb
@@ -1,8 +1,9 @@
 class CreateSubBrands < ActiveRecord::Migration
+  # Altered this migration in place 2016-08-04.  Blame grosscol.
   def change
     create_table :sub_brands do |t|
       t.references :press, index: true, foreign_key: true, null: false
-      t.references :parent, index: true, foreign_key: true
+      t.integer :parent_id, index: true
       t.string :title, null: false
       t.text :description
 

--- a/db/migrate/20160805201611_add_parent_to_sub_brands.rb
+++ b/db/migrate/20160805201611_add_parent_to_sub_brands.rb
@@ -1,0 +1,8 @@
+class AddParentToSubBrands < ActiveRecord::Migration
+  # Adds a foreign key to sub_brands from itself.
+  # Which is weird.  Consider not being weird.
+  def up
+    
+    add_foreign_key :sub_brands, :sub_brands, column: :parent_id, primary_key: "id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506173307) do
+ActiveRecord::Schema.define(version: 20160805201611) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false


### PR DESCRIPTION
The sub brands table has a self referential foreign key.  The foreign key constraint is a requirement of active record associations belongs_to or has_one.  

Creating the table and the foreign key constraint all in one statement fails, because the target of the foreign key needs to exist first.  So, splitting up the create and adding foreign key constraints into sequential steps solves this problem and allows `db:migrate` to run on MySQL.

I have qualms about modifying an existing migration in place, because that means all the devs need to drop the db and rerun all the migrations.  On the other hand, it was a bad migration to begin with, so deleting it and making two more would also have necessitated dropping the db.  In short, blow away the db and start over after this PR is merged.

**Prior to merging this PR, test that the functionality is as expected in the staging environment.**

Closes #234