### PR TITLE
modify monograph catalog ui to look like elderberry wireframes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require leaflet-iiif
 
 //= require 'edit_users'
+//= require 'short_monograph_description'
 //= require 'file_set_sort_date'
 //= require 'disable_video_download'
 //= require_tree .

--- a/app/assets/javascripts/short_monograph_description.js
+++ b/app/assets/javascripts/short_monograph_description.js
@@ -1,0 +1,27 @@
+jQuery(function(){
+
+    var minimized_elements = $('p.description');
+
+    minimized_elements.each(function(){
+        var t = $(this).text();
+        if(t.length < 500) return;
+
+        $(this).html(
+            t.slice(0,500)+'<span>... </span><a href="#" class="more">More</a>'+
+            '<span style="display:none;">'+ t.slice(100,t.length)+' <a href="#" class="less">Less</a></span>'
+        );
+
+    });
+
+    $('a.more', minimized_elements).click(function(event){
+        event.preventDefault();
+        $(this).hide().prev().hide();
+        $(this).next().show();
+    });
+
+    $('a.less', minimized_elements).click(function(event){
+        event.preventDefault();
+        $(this).parent().hide().prev().show().prev().show();
+    });
+
+});

--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -1,5 +1,60 @@
 // custom styles for heliotrope
 
+.monograph {
+
+  .monograph-info {
+
+    h2 {
+      font-size: 1.5em;
+    }
+
+    h3 {
+      font-size: 1.3em;
+    }
+
+    .description,
+    .isbn {
+      margin-bottom: 1.5em;
+    }
+
+  }
+
+  .top-panel-heading {
+    padding-top: 0;
+    padding-left: 0;
+  }
+
+  #documents {
+    .document {
+
+      margin-bottom: 2em;
+      padding-top: 1.5em;
+
+      .document-thumbnail {
+        img {
+        margin-top: .9em;
+        }
+      }
+
+      .documentHeader {
+
+        p {
+            font-size: 1.15em;
+            font-weight: 500;
+        }
+
+      }
+
+      .document-metadata {
+        width: auto;
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+  }
+
+}
+
 .asset {
 
   // leaflet-images

--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -5,17 +5,36 @@ class MonographCatalogController < ::CatalogController
     config.search_builder_class = MonographSearchBuilder
 
     config.facet_fields.tap do
+      # solr facet fields not to be displayed in the index (search results) view
       config.facet_fields.delete('human_readable_type_sim')
+      config.facet_fields.delete('creator_full_name_sim')
+      config.facet_fields.delete('tag_sim')
+      config.facet_fields.delete('subject_sim')
+      config.facet_fields.delete('language_sim')
     end
 
-    config.add_facet_field solr_name('resource_type', :facetable), label: "Resource Type", limit: 5
-    config.add_facet_field solr_name('keywords', :facetable), label: "Keyword", limit: 5
-    config.add_facet_field solr_name('section_title', :facetable), label: "Section", limit: 5, sort: 'index'
-    config.add_facet_field solr_name('sort_date', :facetable), date: { format: '%Y' }, label: "Year", limit: 5
+    config.index_fields.tap do
+      # solr fields not to be displayed in the index (search results) view
+      config.index_fields.delete('creator_full_name_tesim')
+      config.index_fields.delete('language_tesim')
+      config.index_fields.delete('contributor_tesim')
+      config.index_fields.delete('human_readable_type_tesim')
+      config.index_fields.delete('copyright_holder_tesim')
+      config.index_fields.delete('caption_tesim')
+      config.index_fields.delete('alt_text_tesim')
+      config.index_fields.delete('content_type_tesim')
+      config.index_fields.delete('keywords_tesim')
+    end
+
+    config.add_facet_field solr_name('section_title', :facetable), label: "Section", limit: 5, sort: 'index', url_method: :facet_url_helper
+    config.add_facet_field solr_name('keywords', :facetable), label: "Keyword", limit: 5, url_method: :facet_url_helper
+    config.add_facet_field solr_name('creator_full_name', :facetable), label: 'Creator', limit: 5, url_method: :facet_url_helper
+    config.add_facet_field solr_name('resource_type', :facetable), label: "Format", limit: 5, url_method: :facet_url_helper
+    config.add_facet_field solr_name('sort_date', :facetable), date: { format: '%Y' }, label: "Year", limit: 5, url_method: :facet_url_helper
     config.add_facet_field solr_name('exclusive_to_platform', :facetable), label: "Exclusivity", helper_method: :exclusivity_facet
     config.add_facet_fields_to_solr_request!
 
-    config.index.partials = [:index_header, :thumbnail, :index]
+    config.index.partials = [:thumbnail, :index_header, :index]
   end
 
   def facet

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,0 +1,4 @@
+<% # container for a single doc -%>
+<div class="row document <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
+  <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter %>
+</div>

--- a/app/views/monograph_catalog/_document_list.html.erb
+++ b/app/views/monograph_catalog/_document_list.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index list view -%>
+<div id="documents" class="documents-<%= document_index_view_type %>">
+  <%= render documents, :as => :document %>
+</div>

--- a/app/views/monograph_catalog/_index_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_file_set.html.erb
@@ -1,11 +1,11 @@
 <%# default partial to display solr document fields in catalog index view -%>
-<dl class="document-metadata dl-horizontal dl-invert">
+  <div class="document-metadata">
 
-  <% index_fields(document).each do |field_name, field| -%>
-    <% if should_render_index_field? document, field %>
-	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
-	    <dd class="blacklight-<%= field_name.parameterize %>"><%= render_markdown render_index_field_value document, field: field_name %></dd>
+    <% index_fields(document).each do |field_name, field| -%>
+      <% if should_render_index_field? document, field %>
+  	    <p class="blacklight-<%= field_name.parameterize %>"><%= render_markdown render_index_field_value document, field: field_name %></p>
+      <% end -%>
     <% end -%>
-  <% end -%>
 
-</dl>
+  </div>
+</div>

--- a/app/views/monograph_catalog/_index_header_list_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_header_list_file_set.html.erb
@@ -1,12 +1,11 @@
 <% # header bar for doc items in index view -%>
-<div class="documentHeader">
-  <h4 class="index_title">
-    <% counter = document_counter_with_offset(document_counter) %>
-    <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
-
+<div class="col-sm-9">
+  <div class="documentHeader">
+    <h4 class="index_title">
+      <% counter = document_counter_with_offset(document_counter) %>
+      <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+    </h4>
     <% if document.section_id.present? %>
-      <p>From <%= render_markdown link_to document.section_title.first, curation_concerns_section_path(document.section_id) %></p>
+      <p>From <%= render_markdown document.section_title.first %></p>
     <% end %>
-
-  </h4>
-</div>
+  </div>

--- a/app/views/monograph_catalog/_thumbnail_file_set.html.erb
+++ b/app/views/monograph_catalog/_thumbnail_file_set.html.erb
@@ -1,0 +1,5 @@
+<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+<div class="document-thumbnail col-sm-3">
+  <%= tn %>
+</div>
+<%- end %>

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -1,59 +1,59 @@
 <% provide :page_title, @monograph_presenter.title.first || "Title" %>
-<% provide :page_class, 'search' %>
+<% provide :page_class, 'search monograph' %>
 
 <% provide :page_header do %>
 
 <% end %>
 
 <% provide :sidebar do %>
-  <%= render 'curation_concerns/base/representative_media', presenter: @monograph_presenter %>
+  <div class="monograph-info">
+    <div class="monograph-cover">
+      <%= render 'curation_concerns/base/representative_media', presenter: @monograph_presenter %>
+    </div><!-- /.monograph-cover -->
+    <div class="monograph-metadata">
+      <h2><%= render_markdown @monograph_presenter.title.first || '' %></h2>
+      <% if can?(:edit, @monograph_presenter.id) %>
+        <%= link_to "Manage Monograph and Files", main_app.monograph_show_path(@monograph_presenter.id), class: 'btn btn-primary', id: 'manage-monograph-button' %>
+      <% end %>
+      <h3><%= @monograph_presenter.creator_given_name.first %> <%= @monograph_presenter.creator_family_name.first %></h3>
+      <p class="description"><%= render_markdown @monograph_presenter.description.first || '' %></p>
+      <div class="isbn">
+        <% if defined?(@monograph_presenter.isbn) %>
+        <ul class="isbn-hardcover list-unstyled">
+          <% @monograph_presenter.isbn.each do |isbn| %>
+            <li>ISBN (Hardcover): <%= isbn %></li>
+          <% end %>
+        </ul>
+        <% end %>
+        <% if defined?(@monograph_presenter.isbn_paper) %>
+        <ul class="isbn-paper list-unstyled">
+          <% @monograph_presenter.isbn_paper.each do |isbn_paper| %>
+            <li>ISBN (Paper): <%= isbn_paper %></li>
+          <% end %>
+        </ul>
+        <% end %>
+        <% if defined?(@monograph_presenter.isbn_ebook) %>
+        <ul class="isbn-ebook list-unstyled">
+          <% @monograph_presenter.isbn_ebook.each do |isbn_ebook| %>
+            <li>ISBN (E-Book): <%= isbn_ebook %></li>
+          <% end %>
+        </ul>
+        <% end %>
+      </div> <!-- /.isbn -->
 
-  <h2><%= render_markdown @monograph_presenter.title.first || '' %></h2>
-
-  <% if can?(:edit, @monograph_presenter.id) %>
-    <%= link_to "Manage Monograph and Files", main_app.monograph_show_path(@monograph_presenter.id), class: 'btn btn-primary', id: 'manage-monograph-button' %>
+      <% if defined?(@monograph_presenter.buy_url) %>
+      <div class="btn-toolbar" role="toolbar" aria-label="">
+        <div class="btn-group" role="group" aria-label="">
+            <a href="<%= @monograph_presenter.buy_url.first %>" target="_blank" title="Buy <%= @monograph_presenter.title.first %>" role="button" class="btn btn-default btn-small">Buy Book</a>
+        </div>
+      </div>
+      <% end %>
+    </div><!-- /.monograph-metadata -->
+  </div><!-- /.monograph-info -->
+  <hr>
+  <%= render 'catalog/search_sidebar' %>
   <% end %>
 
-  <h3><%= @monograph_presenter.creator_given_name.first %> <%= @monograph_presenter.creator_family_name.first %></h3>
-
-  <p><%= render_markdown @monograph_presenter.description.first || '' %></h3>
-
-    <% if defined?(@monograph_presenter.isbn) %>
-      <ul class="isbn list-unstyled">
-        <% @monograph_presenter.isbn.each do |isbn| %>
-          <li>ISBN (Hardcover): <%= isbn %></li>
-        <% end %>
-      </ul>
-    <% end %>
-
-    <% if defined?(@monograph_presenter.isbn_paper) %>
-      <ul class="isbn list-unstyled">
-        <% @monograph_presenter.isbn_paper.each do |isbn_paper| %>
-          <li>ISBN (Paper): <%= isbn_paper %></li>
-        <% end %>
-      </ul>
-    <% end %>
-
-    <% if defined?(@monograph_presenter.isbn_ebook) %>
-      <ul class="isbn list-unstyled">
-        <% @monograph_presenter.isbn_ebook.each do |isbn_ebook| %>
-          <li>ISBN (E-Book): <%= isbn_ebook %></li>
-        <% end %>
-      </ul>
-    <% end %>
-
-
-    <% if defined?(@monograph_presenter.buy_url) %>
-    <div class="btn-toolbar" role="toolbar" aria-label="">
-      <div class="btn-group" role="group" aria-label="">
-          <a href="<%= @monograph_presenter.buy_url.first %>" target="_blank" title="Buy <%= @monograph_presenter.title.first %>" role="button" class="btn btn-default btn-small">Buy Book</a>
-      </div>
-    </div>
-    <% end %>
-
-  <%= render 'catalog/search_sidebar' %>
-<% end %>
-
-<div id="content">
-  <%= render 'catalog/search_results' %>
-</div>
+  <div class="content">
+    <%= render 'catalog/search_results' %>
+  </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -3,6 +3,8 @@ en:
     application_name: 'Blacklight'
 
     search:
+      facets:
+        title: 'Filter materials'
       fields:
         date_published_tesim: "Date Published"
         isbn_tesim: "ISBN (Hardcover)"


### PR DESCRIPTION
Closes #330 

Removes, re-labels, and re-orders facets; removes unneeded metadata fields in document index (we only want description); adds custom styles to control display and re-orders document partials; creates a new js function to limit monograph descriptions greater than 500 characters; removes link to section show page