### PR TITLE
Custom navbar to match Elderberry wireframes

### DIFF
--- a/app/assets/javascripts/short_monograph_description.js
+++ b/app/assets/javascripts/short_monograph_description.js
@@ -8,7 +8,7 @@ jQuery(function(){
 
         $(this).html(
             t.slice(0,500)+'<span>... </span><a href="#" class="more">More</a>'+
-            '<span style="display:none;">'+ t.slice(100,t.length)+' <a href="#" class="less">Less</a></span>'
+            '<span style="display:none;">'+ t.slice(500,t.length)+' <a href="#" class="less">Less</a></span>'
         );
 
     });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,10 +10,10 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
+ *= require_tree .
+ *= require_self
  *= require jquery-ui/datepicker
  *= require leaflet
  *= require heliotrope
  *= require themes
- *= require_tree .
- *= require_self
  */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,7 @@
  *= require jquery-ui/datepicker
  *= require leaflet
  *= require heliotrope
+ *= require themes
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -1,10 +1,34 @@
 // custom styles for heliotrope
 
-// navigation menu
+// sitewide
 
+// navigation menu
+.navbar {
+  margin-bottom: 0;
+}
+
+// press
+.jumbotron {
+
+  .container {
+    margin-top: 3em;
+  }
+
+  .logo {
+
+    img {
+      width: 180px;
+      height: auto;
+      margin: 0 1em 1em 0;
+    }
+
+  }
+
+}
 
 // monograph
 .monograph {
+  margin-top: 5em;
 
   .monograph-info {
 
@@ -61,6 +85,7 @@
 
 // asset pages
 .asset {
+  margin-top: 5em;
 
   // leaflet-images
   #image {

--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -2,6 +2,7 @@
 
 // navigation menu
 
+
 // monograph
 .monograph {
 

--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -1,5 +1,8 @@
 // custom styles for heliotrope
 
+// navigation menu
+
+// monograph
 .monograph {
 
   .monograph-info {
@@ -25,8 +28,8 @@
   }
 
   #documents {
-    .document {
 
+    .document {
       margin-bottom: 2em;
       padding-top: 1.5em;
 
@@ -37,12 +40,10 @@
       }
 
       .documentHeader {
-
         p {
             font-size: 1.15em;
             font-weight: 500;
         }
-
       }
 
       .document-metadata {
@@ -50,11 +51,14 @@
         padding-left: 0;
         padding-right: 0;
       }
+
     }
+
   }
 
 }
 
+// asset pages
 .asset {
 
   // leaflet-images

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -1,6 +1,6 @@
-/* Press themes are collected here */
+// Press themes are collected here
 
 // Northwestern University Press
-.nwup {
+.northwestern {
 
 }

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -1,0 +1,6 @@
+/* Press themes are collected here */
+
+// Northwestern University Press
+.nwup {
+
+}

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -33,6 +33,14 @@ module CurationConcerns
              :display_date, :sort_date, :search_year, :transcript, :translation, :file_format,
              to: :solr_document
 
+    def subdomain
+      Array(solr_document['press_tesim']).first
+    end
+
+    def press
+      Array(solr_document['press_name_ssim']).first
+    end
+
     def page_title
       Array(solr_document['label_tesim']).first
     end

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -26,6 +26,14 @@ module CurationConcerns
       end.compact
     end
 
+    def subdomain
+      Array(solr_document['press_tesim']).first
+    end
+
+    def press
+      Array(solr_document['press_name_ssim']).first
+    end
+
     private
 
       def ordered_member_docs

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -12,8 +12,15 @@
     <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'application' %>
   </head>
+<% if defined?(@press.subdomain) %>
+  <body class="<%= @press.subdomain %>">
+<% elsif defined?(@monograph_presenter.subdomain) %>
+  <body class="<%= @monograph_presenter.subdomain %>">
+<% elsif defined?(@presenter.monograph.subdomain) %>
+  <body class="<%= @presenter.monograph.subdomain %>">
+<% else %>
   <body>
-
+<% end %>
     <%= content_for?(:body) ? yield(:body) : yield %>
 
     <%= render 'shared/ajax_modal' %>

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+    <meta name="viewport" content="width=device-width">
+    <%= csrf_meta_tag %>
+    <%= stylesheet_link_tag 'application' %>
+    <%= javascript_include_tag 'application' %>
+  </head>
+  <body>
+
+    <%= content_for?(:body) ? yield(:body) : yield %>
+
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/press_catalog/_press_search.html.erb
+++ b/app/views/press_catalog/_press_search.html.erb
@@ -1,11 +1,11 @@
-<%= form_tag main_app.press_catalog_path(@press), method: :get, class: "search-form navbar-form" do %>
+<%= form_tag main_app.press_catalog_path(@press), method: :get, class: "search-form navbar-left navbar-form" do %>
   <fieldset>
     <% search_label = t('press_catalog.search_form.q.label', press_name: @press.name) %>
     <legend class="sr-only"><%= search_label %></legend>
     <%= label_tag :catalog_search, search_label, class: "sr-only" %>
 
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-    
+
     <div class="input-group">
       <%= text_field_tag(:q, params[:q], class: "q search-query form-control", id: "catalog_search",
                          placeholder: t('curation_concerns.search.form.q.placeholder'), tabindex: "1", type: "search") %>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -1,18 +1,18 @@
 <% provide :page_title, @press.name %>
-<% provide :page_class, 'search' %>
+<% provide :page_class, 'press' %>
 
-<% provide :page_header do %>
-  <% if @press.logo_path %>
-    <p><%= image_tag @press.logo_path, alt: @press.name %></p>
-  <% end %>
-  <p><%= @press.description %></p>
+<!-- Main jumbotron for a primary heading image -->
+    <div class="jumbotron">
+      <div class="container">
+        <% if @press.logo_path %>
+          <div class="logo">
+            <%= image_tag @press.logo_path, alt: @press.name, class: 'img-thumbnail' %>
+          </div>
+        <% end %>
 
-  <%= render 'catalog/navbar' %>
-<% end %>
-
-<% provide :sidebar do %>
-  <%= render 'catalog/search_sidebar' %>
-<% end %>
+        <p class="lead"><%= @press.description %></p>
+      </div>
+    </div>
 
 <div id="content">
   <%= render 'catalog/search_results' %>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -1,19 +1,6 @@
 <% provide :page_title, @press.name %>
 <% provide :page_class, 'press' %>
 
-<!-- Main jumbotron for a primary heading image -->
-    <div class="jumbotron">
-      <div class="container">
-        <% if @press.logo_path %>
-          <div class="logo">
-            <%= image_tag @press.logo_path, alt: @press.name, class: 'img-thumbnail' %>
-          </div>
-        <% end %>
-
-        <p class="lead"><%= @press.description %></p>
-      </div>
-    </div>
-
 <div id="content">
   <%= render 'catalog/search_results' %>
 </div>

--- a/app/views/shared/_brand_bar.html.erb
+++ b/app/views/shared/_brand_bar.html.erb
@@ -1,5 +1,5 @@
 <nav id="brand-bar" class="navbar navbar-default navbar-inverse navbar-static-top">
-  <div class="container-fluid">
+  <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#brand-bar-nav" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>

--- a/app/views/shared/_brand_bar.html.erb
+++ b/app/views/shared/_brand_bar.html.erb
@@ -1,0 +1,19 @@
+<nav id="brand-bar" class="navbar navbar-default navbar-inverse navbar-static-top">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#brand-bar-nav" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <%= link_to application_name, main_app.root_path, id: 'home-link', class: 'navbar-brand' %>
+    </div>
+
+    <div class="collapse navbar-collapse" id="brand-bar-nav">
+      <div class="navbar-right">
+        <%= render 'shared/site_actions' if show_site_actions? %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_brand_press_bar.html.erb
+++ b/app/views/shared/_brand_press_bar.html.erb
@@ -1,0 +1,35 @@
+<nav id="brand-bar" class="navbar navbar-default navbar-static-top">
+  <div class="container">
+    <!-- brand and toggle grouped together -->
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#brand-bar-nav" aria-expanded="false" aria-controls="navbar">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <% if defined?(@press.name) %>
+        <a class="navbar-brand" href="/<%= @press.subdomain %>"><%= @press.name %></a>
+      <% elsif defined?(@monograph_presenter.press) %>
+        <a class="navbar-brand" href="/<%= @monograph_presenter.subdomain %>"><%= @monograph_presenter.press %></a>
+      <% elsif defined?(@presenter.monograph.press) %>
+        <a class="navbar-brand" href="/<%= @presenter.monograph.press %>"><%= @presenter.monograph.press %></a>
+      <% else %>
+        <a class="navbar-brand" href="#">University Press</a>
+      <% end %>
+    </div>
+
+    <!-- search -->
+    <% if show_site_search? %>
+      <%= render 'shared/site_search' %>
+    <% elsif respond_to?(:show_press_search?) && show_press_search? %>
+      <%= render 'press_catalog/press_search' %>
+    <% end %>
+
+    <div class="collapse navbar-collapse" id="brand-bar-nav">
+      <div class="navbar-right">
+        <%= render 'shared/site_actions' if show_site_actions? %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_brand_press_bar.html.erb
+++ b/app/views/shared/_brand_press_bar.html.erb
@@ -13,7 +13,7 @@
       <% elsif defined?(@monograph_presenter.press) %>
         <a class="navbar-brand" href="/<%= @monograph_presenter.subdomain %>"><%= @monograph_presenter.press %></a>
       <% elsif defined?(@presenter.monograph.press) %>
-        <a class="navbar-brand" href="/<%= @presenter.monograph.press %>"><%= @presenter.monograph.press %></a>
+        <a class="navbar-brand" href="/<%= @presenter.monograph.subdomain %>"><%= @presenter.monograph.press %></a>
       <% else %>
         <a class="navbar-brand" href="#">University Press</a>
       <% end %>

--- a/app/views/shared/_brand_press_jumbotron.html.erb
+++ b/app/views/shared/_brand_press_jumbotron.html.erb
@@ -1,0 +1,12 @@
+<!-- Main jumbotron for a primary heading image -->
+    <div class="jumbotron">
+      <div class="container">
+        <% if @press.logo_path %>
+          <div class="logo pull-left">
+            <%= image_tag @press.logo_path, alt: @press.name, class: 'img-thumbnail' %>
+          </div>
+        <% end %>
+
+        <p class="lead"><%= @press.description %></p>
+      </div>
+    </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,6 @@
+<header id="banner" role="banner">
+  <hgroup>
+    <%= render 'shared/brand_bar' %>
+    <%= render 'shared/title_bar' %>
+  </hgroup>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,13 @@
 <header id="banner" role="banner">
   <hgroup>
-    <%= render 'shared/brand_bar' %>
-    <%= render 'shared/title_bar' %>
+    <% if defined?(@press.subdomain) %>
+      <%= render 'shared/brand_press_bar' %>
+    <% elsif defined?(@monograph_presenter.subdomain) %>
+      <%= render 'shared/brand_press_bar' %>
+    <% elsif defined?(@presenter.monograph.subdomain) %>
+      <%= render 'shared/brand_press_bar' %>
+    <% else %>
+      <%= render 'shared/brand_bar' %>
+    <% end %>
   </hgroup>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,3 +11,6 @@
     <% end %>
   </hgroup>
 </header>
+<% if defined?(@press.subdomain) %>
+  <%= render 'shared/brand_press_jumbotron' %>
+<% end %>

--- a/app/views/shared/_press_branding.html.erb
+++ b/app/views/shared/_press_branding.html.erb
@@ -1,7 +1,0 @@
-<h2><%= @press.name %></h2>
-
-<% if @press.logo_path %>
-  <p><%= image_tag @press.logo_path %></p>
-<% end %>
-
-<p><%= @press.description %></p>

--- a/app/views/shared/_site_search.html.erb
+++ b/app/views/shared/_site_search.html.erb
@@ -4,7 +4,7 @@
   <% catalog_url = main_app.search_catalog_path %>
 <% end %>
 
-<%= form_tag catalog_url, method: :get, class: "search-form navbar-form" do %>
+<%= form_tag catalog_url, method: :get, class: "search-form navbar-left navbar-form" do %>
   <fieldset>
     <legend class="sr-only">Search <%= application_name %></legend>
     <%= label_tag :catalog_search, t('curation_concerns.search.form.q.label'), class: "sr-only" %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -1,0 +1,3 @@
+en:
+  curation_concerns:
+    product_name: "Fulcrum"

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -15,24 +15,26 @@ feature 'Press Catalog' do
       let!(:colors) { create(:public_monograph, title: ['Red and Blue are Colors'], press: psu.subdomain) }
 
       scenario 'visits the catalog page for a press' do
+        # jmcglone: disabling the main catalog test because we won't launch with this.
+        # TODO: reenable this test once we bring back the main catalog search
         # The main catalog
-        visit search_catalog_path
+        # visit search_catalog_path
 
         # I should see all the public monographs
-        expect(page).to have_selector('#documents .document', count: 3)
-        expect(page).to have_link red.title.first
-        expect(page).to have_link blue.title.first
-        expect(page).to have_link colors.title.first
+        # expect(page).to have_selector('#documents .document', count: 3)
+        # expect(page).to have_link red.title.first
+        # expect(page).to have_link blue.title.first
+        # expect(page).to have_link colors.title.first
 
         # Search the catalog
-        fill_in 'q', with: 'Red'
-        click_button 'Search'
+        # fill_in 'q', with: 'Red'
+        # click_button 'Search'
 
         # I should see search results from all presses
-        expect(page).to have_selector('#documents .document', count: 2)
-        expect(page).to     have_link red.title.first
-        expect(page).to_not have_link blue.title.first
-        expect(page).to     have_link colors.title.first
+        # expect(page).to have_selector('#documents .document', count: 2)
+        # expect(page).to     have_link red.title.first
+        # expect(page).to_not have_link blue.title.first
+        # expect(page).to     have_link colors.title.first
 
         # The catalog for a certain press
         visit Rails.application.routes.url_helpers.press_catalog_path(umich)


### PR DESCRIPTION
Closes #315 

In addition to modifying partials to bring the header, navigation, and press header inline with Elderberry wireframes, this PR:

- Introduces a class based approach to handle "press themes" in Fulcrum. 
- Search is removed from the top-level now and only available at the Press level and below.
- Maintains the parent press navigation at the Monograph and Asset level
