### PR TITLE
add custom footer at the press, monograph, and asset level

### DIFF
--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -5,6 +5,54 @@
   margin-bottom: 0;
 }
 
+// footer
+// generic press
+footer.press {
+  background-color: #262626;
+  color: #fff;
+  margin-top: 5em;
+
+  img {
+    width: 100px;
+    height: auto;
+  }
+
+  .col-wrap {
+    overflow: hidden;
+  }
+
+  .col {
+    margin-bottom: -99999px;
+    padding-bottom: 99999px;
+  }
+
+  .social {
+    padding-left: 30px;
+  }
+
+  .social,
+  .footer-nav {
+    padding-top: 30px;
+    background-color: #171717;
+  }
+
+  .platform {
+    padding-top: 30px;
+    color: #BABABA;
+  }
+
+  .copyright {
+    background-color: #000;
+    padding: 10px;
+
+      p {
+        font-size: 16px;
+      }
+
+  }
+
+}
+
 // press
 .jumbotron {
 

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -41,6 +41,14 @@ module CurationConcerns
       Array(solr_document['press_name_ssim']).first
     end
 
+    def press_logo
+      Press.find_by(subdomain: subdomain).logo_path
+    end
+
+    def press_url
+      Press.find_by(subdomain: subdomain).press_url
+    end
+
     def page_title
       Array(solr_document['label_tesim']).first
     end

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -34,6 +34,14 @@ module CurationConcerns
       Array(solr_document['press_name_ssim']).first
     end
 
+    def press_logo
+      Press.find_by(subdomain: subdomain).logo_path
+    end
+
+    def press_url
+      Press.find_by(subdomain: subdomain).press_url
+    end
+
     private
 
       def ordered_member_docs

--- a/app/views/layouts/curation_concerns.html.erb
+++ b/app/views/layouts/curation_concerns.html.erb
@@ -1,0 +1,32 @@
+<% provide :body do %>
+
+<%= render 'shared/header' %>
+<%= render 'shared/flash_message' %>
+
+  <div id="main" role="main" class="container <%= yield(:page_class) if content_for?(:page_class)%>">
+  <% if content_for?(:page_header) %>
+    <div class="row">
+      <div class="col-md-12 main-header ">
+        <%= yield(:page_header) %>
+      </div>
+    </div>
+  <% end %>
+
+    <%= content_for?(:main) ? yield(:main) : yield %>
+  </div>
+
+  <% if defined?(@press.subdomain) %>
+    <%= render 'shared/brand_press_footer' %>
+  <% elsif defined?(@monograph_presenter.subdomain) %>
+    <%= render 'shared/brand_press_footer' %>
+  <% elsif defined?(@presenter.monograph.subdomain) %>
+    <%= render 'shared/brand_press_footer' %>
+  <% else %>
+    <%= render 'shared/footer' %>
+  <% end %>
+
+
+
+<% end %>
+
+<%= render template: 'layouts/boilerplate' %>

--- a/app/views/shared/_brand_press_footer.html.erb
+++ b/app/views/shared/_brand_press_footer.html.erb
@@ -1,0 +1,64 @@
+<footer class="press">
+  <div class="container-fluid">
+    <div class="row col-wrap">
+      <div class="col-sm-4 social col">
+        <p>
+          <% if defined?(@press.logo_path) %>
+            <%= image_tag @press.logo_path, alt: @press.name, class: 'img-thumbnail img-responsive' %><br /><br />
+          <% elsif defined?(@monograph_presenter.press_logo) %>
+            <%= image_tag @monograph_presenter.press_logo, alt: @monograph_presenter.press, class: 'img-thumbnail img-responsive' %><br /><br />
+          <% elsif defined?(@presenter.monograph.press_logo) %>
+            <%= image_tag @presenter.monograph.press_logo, alt: @presenter.monograph.press, class: 'img-thumbnail img-responsive' %><br /><br />
+          <% end %>
+          <% if defined?(@press.press_url) %>
+            <a class="brand" href="<%= @press.press_url %>"><%= @press.name %></a>
+          <% elsif defined?(@monograph_presenter.press_url) %>
+            <a class="brand" href="<%= @monograph_presenter.press_url %>"><%= @monograph_presenter.press %></a>
+          <% elsif defined?(@presenter.monograph.press_url) %>
+            <a class="brand" href="<%= @presenter.monograph.press_url %>"><%= @presenter.monograph.press %></a>
+          <% else %>
+            <a class="brand" href="#" >University Press</a>
+          <% end %>
+        </p>
+        <!-- <ul class="list-inline">
+          <li><a href="#">FB</a></li>
+          <li><a href="#">I</a></li>
+          <li><a href="#">T</a></li>
+          <li><a href="#">YT</a></li>
+        </ul> -->
+      </div>
+      <div class="col-sm-4 footer-nav col">
+        <!-- <ul class="list-unstyled">
+          <li><a href="#">Home</a></li>
+          <li><a href="#">Search</a></li>
+          <li><a href="#">Browse All Books</a></li>
+          <li><a href="#">Browse All Book Materials</a></li>
+          <li><a href="#">About</a></li>
+        </ul> -->
+      </div>
+      <div class="col-sm-4 platform col">
+        <p>Powered by <a href="#">Fulcrum</a></p>
+        <ul class="list-unstyled">
+          <!-- <li><a href="#">Help</a></li> -->
+          <li><a href="http://fulcrum.org/about/">About</a></li>
+          <li><a href="http://fulcrum.org/blog/">Blog</a></li>
+          <li><a href="mailto:fulcrum-info@umich.edu">Contact</a></li>
+          <li><a href="https://github.com/mlibrary/heliotrope">Contribute</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="row copyright">
+      <div class="col-sm-12">
+        <% if defined?(@press.name) %>
+          <p>&copy; <%= @press.name %> 2016</p>
+        <% elsif defined?(@monograph_presenter.press) %>
+          <p>&copy; <%= @monograph_presenter.press %> 2016</p>
+        <% elsif defined?(@presenter.monograph.press) %>
+          <p>&copy; <%= @presenter.monograph.press %> 2016</p>
+        <% else %>
+          <p>&copy; University Press 2016</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_brand_press_jumbotron.html.erb
+++ b/app/views/shared/_brand_press_jumbotron.html.erb
@@ -7,6 +7,6 @@
           </div>
         <% end %>
 
-        <p class="lead"><%= @press.description %></p>
+        <p class="lead"><%= render_markdown @press.description %></p>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,10 @@
+<footer id="footer" class="container">
+  <div class="row">
+    <div class="footer-text col-md-12">
+      <p>
+        Powered by <a href="https://github.com/projecthydra-labs/curation_concerns">CurationConcerns</a>.<br />
+        Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
+      </p>
+    </div>
+  </div>
+</footer>

--- a/db/migrate/20160811101311_add_press_url_to_presses.rb
+++ b/db/migrate/20160811101311_add_press_url_to_presses.rb
@@ -1,0 +1,7 @@
+#Add press url to presses db
+class AddPressUrlToPresses < ActiveRecord::Migration
+  def change
+    add_column(:presses, :press_url, :string)
+    
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160805201611) do
+ActiveRecord::Schema.define(version: 20160811101311) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20160805201611) do
     t.string   "subdomain"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "press_url"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,25 +3,30 @@
 #
 Press.create!(name: 'University of Michigan Press',
               logo_path: 'http://www.press.umich.edu/images/umpre/logo.png',
-              description: 'The University of Michigan Press (www.press.umich.edu/) Publishes academic and general books about contemporary political, social, and cultural issues.',
-              subdomain: 'michigan')
+              description: '[The University of Michigan Press](http://www.press.umich.edu/) publishes academic and general books about contemporary political, social, and cultural issues.',
+              subdomain: 'michigan',
+              press_url: 'http://www.press.umich.edu')
 
 Press.create!(name: 'Penn State University Press',
               logo_path: 'http://www.psupress.org/site_images/logo_psupress.gif',
-              description: 'The Penn State University Press (www.psupress.org/) Publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.',
-              subdomain: 'pennstate')
+              description: '[The Penn State University Press](http://www.psupress.org/) publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.',
+              subdomain: 'pennstate',
+              press_url: 'http://www.psupress.org')
 
 Press.create!(name: 'Indiana University Press',
               logo_path: 'https://assets.iu.edu/brand/2.x/trident-large.png',
               description: "Indiana University Press's mission is to inform and inspire scholars, students, and thoughtful general readers by disseminating ideas and knowledge of global significance, regional importance, and lasting value.",
-              subdomain: 'indiana')
+              subdomain: 'indiana',
+              press_url: 'http://www.iupress.indiana.edu')
 
 Press.create!(name: 'Northwestern University Press',
               logo_path: 'http://www.nupress.northwestern.edu/sites/all/themes/nupress/images/northwestern-press-logo-old.png',
               description: "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the university’s mission to a community of readers throughout the world.",
-              subdomain: 'northwestern')
+              subdomain: 'northwestern',
+              press_url: 'http://nupress.northwestern.edu/')
 
 Press.create!(name: 'University of Minnesota Press',
               logo_path: 'http://www.upress.umn.edu/++theme++ump.theme/_images/logo.gif',
-              description: "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest",
-              subdomain: 'minnesota')
+              description: "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest.",
+              subdomain: 'minnesota',
+              press_url: 'http://www.upress.umn.edu/')


### PR DESCRIPTION
Resolves #314 

NOTE: adds a new column `press_url` to the `presses` table to capture the presses url (ie http://www.press.umich.edu).  So you will need to run:

`bundle exec rake db:migrate`

then

`bundle exec rake db:seeds`

to populate the updated presses table.

TODO: @sethaj I can't figure out how to get the press logo (`logo_path`) and the press url (`press_url`) into the presenters for the monograph and asset, or what the best way to go about doing this is (probably don't need to be indexed in solr, do they?). The footer design looks for the press logo and url and inserts them in the footer if they exist.