### PR TITLE
Update solr config for solr6 compatibility.

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -103,7 +103,7 @@
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-      geo="true" distErrPct="0.025" maxDistErr="0.000009" units="degrees" />
+      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
     
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>


### PR DESCRIPTION
units -> distanceUnits makes solr 6 happy.
The units parameter name was deprecated in  solr 5.5 and removed in 6.0.