### PR TITLE
replace imagemagick iiif calls with netpbm calls for tiffs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'spec/test_app_templates/**/*'
     - 'vendor/**/*'
     - 'tmp/**/*'
+    - 'app/models/riiif/file.rb'
 
 Lint/ImplicitStringConcatenation:
   Exclude:

--- a/app/models/riiif/file.rb
+++ b/app/models/riiif/file.rb
@@ -1,0 +1,108 @@
+require 'open3'
+module Riiif
+  class File
+    include Open3
+    include ActiveSupport::Benchmarkable
+
+    attr_reader :path
+
+    delegate :logger, to: :Rails
+
+    # @param input_path [String] The location of an image file
+    def initialize(input_path, tempfile = nil)
+      @path = input_path
+      @tempfile = tempfile # ensures that the tempfile will stick around until this file is garbage collected.
+    end
+
+    def self.read(stream, ext)
+      create(ext) do |f|
+        while chunk = stream.read(8192)
+          f.write(chunk)
+        end
+      end
+    end
+
+    def self.create(ext = nil, _validate = true, &block)
+
+      tempfile = Tempfile.new(['mini_magick', ext.to_s.downcase])
+      tempfile.binmode
+      block.call(tempfile)
+      tempfile.close
+      image = new(tempfile.path, tempfile)
+    ensure
+      tempfile.close if tempfile
+    end
+
+    def extract(options)
+      mime_type = IO.popen(["file", "--brief", "--mime-type", path], in: :close, err: :close).read.chomp
+      tifftopnm = `which tifftopnm`.chomp
+      if mime_type.match(/tiff/) && tifftopnm
+        extract_tifftopnm(options)
+      else
+        extract_imagemagick(options)
+      end
+    end
+
+    def extract_tifftopnm(options)
+      command = ["tifftopnm -byrow #{path}"]
+      if options[:crop]
+        w, h, x, y = options[:crop].split(/[x\+]/)
+        command << "pamcut #{x} #{y} #{w} #{h}"
+      end
+
+      if options[:size]
+        w, h = options[:size].split("x")
+        command << "pnmscalefixed -xysize #{w} #{h}" if h.present? and w.present?
+        command << "pnmscalefixed -xsize #{w}" if !h.present? and w.present?
+        command << "pnmscalefixed -ysize #{h}" if h.present? and !w.present?
+      end
+
+      # ignore quality
+      command << "pnmtojpeg -quality 95"
+      command = command.join(' | ')
+      execute(command)
+    end
+
+    def extract_imagemagick(options)
+      command = 'convert'
+      command << " -crop #{options[:crop]}" if options[:crop]
+      command << " -resize #{options[:size]}" if options[:size]
+      if options[:rotation]
+        command << " -virtual-pixel white +distort srt #{options[:rotation]}"
+      end
+
+      case options[:quality]
+      when 'grey'
+        command << ' -colorspace Gray'
+      when 'bitonal'
+        command << ' -colorspace Gray'
+        command << ' -type Bilevel'
+      end
+      command << " #{path} #{options[:format]}:-"
+      execute(command)
+    end
+
+    def info
+      return @info if @info
+      height, width = execute("identify -format %hx%w #{path}").split('x')
+      @info = { height: Integer(height), width: Integer(width) }
+    end
+
+    private
+
+      def execute(command)
+        out = nil
+        benchmark("Riiif executed #{command}") do
+          stdin, stdout, stderr, wait_thr = popen3(command)
+          stdin.close
+          stdout.binmode
+          out = stdout.read
+          stdout.close
+          err = stderr.read
+          stderr.close
+          raise "Unable to execute command \"#{command}\"\n#{err}" unless wait_thr.value.success?
+        end
+        out
+      end
+  end
+end

--- a/config/initializers/riiif_initializer.rb
+++ b/config/initializers/riiif_initializer.rb
@@ -3,6 +3,7 @@ Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
 
 # This tells RIIIF how to resolve the identifier to a URI in Fedora
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+  # This is slow. TODO: find an alternative if possible
   FileSet.find(id).files.first.uri.to_s || ''
 end
 
@@ -10,7 +11,7 @@ end
 # each image. If you are using hydra-file_characterization, you have the height & width
 # cached in Solr. The following block directs the info_service to return those values:
 Riiif::Image.info_service = lambda do |id, _file|
-  doc = FileSet.find(id).to_solr
+  doc = ActiveFedora::SolrService.query("{!terms f=id}#{id}").first
   { height: doc["height_is"], width: doc["width_is"] }
 end
 


### PR DESCRIPTION
Resolves #400 

This solves an immediate problem with very large (>200 MB) tiff files being processed by riiif and imagemagick. `convert` was loading the entire tiff in memory for each puma worker in order to generate IIIF tiles. This maxed out available ram in production and caused problems. The switch to netpbm's  `tifftopnm` specifically with the `-byrow` flag cuts down ram usage considerably.

This only works for tiffs, with the fallback to imagemagick for other file types (or if netpbm is not installed such as development environments). We can use other netpbm programs in the future for other large file types (jp2?) if needed.
