### PR TITLE
Press catalog

### DIFF
--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -55,6 +55,7 @@ $fulcrum-light-2: #bec4cc;
     @include freight-sans-semi-bold;
   }
 
+  // links
   a {
     color: $nw-brand-color;
   }
@@ -103,6 +104,8 @@ $fulcrum-light-2: #bec4cc;
 
   }
 
+  // press catalog
+
   // jumbotron
   .jumbotron {
     background-color: $nw-purple-10;
@@ -117,6 +120,18 @@ $fulcrum-light-2: #bec4cc;
 
     }
 
+  }
+
+  .press {
+
+    h2:nth-child(2) {
+      margin-bottom: 1.5em;
+    }
+
+    .document,
+    .documentHeader {
+      margin-bottom: 2em;
+    }
   }
 
   // assets

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -3,6 +3,8 @@ class PressCatalogController < ::CatalogController
 
   configure_blacklight do |config|
     config.search_builder_class = PressSearchBuilder
+
+    config.index.partials = [:thumbnail, :index_header]
   end
 
   def show_site_search?

--- a/app/views/catalog/_press_results.html.erb
+++ b/app/views/catalog/_press_results.html.erb
@@ -1,0 +1,22 @@
+<h2 class="sr-only top-content-title">Books from Northwestern University Press</h2>
+<h2>Books</h2>
+
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+<% end %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/press_catalog/_document_list.html.erb
+++ b/app/views/press_catalog/_document_list.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index list view -%>
+<div id="documents" class="documents-<%= document_index_view_type %>">
+  <%= render documents, :as => :document %>
+</div>

--- a/app/views/press_catalog/_index_header_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_list_monograph.html.erb
@@ -6,8 +6,8 @@
         <% counter = document_counter_with_offset(document_counter) %>
         <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
       </h2>
-      <h3><%= render_markdown document.creator_given_name.first %> <%= render_markdown document.creator_family_name.first %></h3>
-      <p><%= render_markdown document.description.first %></p>
+      <h3><%= render_markdown document.creator_given_name.first || '' %> <%= render_markdown document.creator_family_name.first || '' %></h3>
+      <p><%= render_markdown document.description.first || '' %></p>
     </div>
   </div>
   <div class="row featured-assets">

--- a/app/views/press_catalog/_index_header_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_list_monograph.html.erb
@@ -1,0 +1,28 @@
+<% # header bar for doc items in index view -%>
+<div class="col-sm-9">
+  <div class="row documentHeader">
+    <div class="col-sm-12">
+      <h2 class="index_title">
+        <% counter = document_counter_with_offset(document_counter) %>
+        <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+      </h2>
+      <h3><%= render_markdown document.creator_given_name.first %> <%= render_markdown document.creator_family_name.first %></h3>
+      <p><%= render_markdown document.description.first %></p>
+    </div>
+  </div>
+  <div class="row featured-assets">
+    <div class="col-sm-3">
+    </div>
+    <div class="col-sm-3">
+    </div>
+    <div class="col-sm-3">
+    </div>
+    <div class="col-sm-3">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <a class="btn btn-default" href="<%= url_for_document document %>">View book materials</a>
+    </div>
+  </div>
+</div>

--- a/app/views/press_catalog/_thumbnail_monograph.html.erb
+++ b/app/views/press_catalog/_thumbnail_monograph.html.erb
@@ -1,0 +1,5 @@
+<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+<div class="col-sm-3">
+  <a href="<%= url_for_document document %>" ><img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/225,/0/default.jpg" alt="<%= document.title.first %>"></a>
+</div>
+<%- end %>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -2,5 +2,5 @@
 <% provide :page_class, 'press' %>
 
 <div id="content">
-  <%= render 'catalog/search_results' %>
+  <%= render 'catalog/press_results' %>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,32 +1,43 @@
-# This file should contain all the record creation needed to seed the database with its default values.
+# This file should contain all the record creation needed to seed the database with its default values, or update those values when necessary.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
-Press.create!(name: 'University of Michigan Press',
-              logo_path: 'http://www.press.umich.edu/images/umpre/logo.png',
-              description: '[The University of Michigan Press](http://www.press.umich.edu/) publishes academic and general books about contemporary political, social, and cultural issues.',
-              subdomain: 'michigan',
-              press_url: 'http://www.press.umich.edu')
 
-Press.create!(name: 'Penn State University Press',
-              logo_path: 'http://www.psupress.org/site_images/logo_psupress.gif',
-              description: '[The Penn State University Press](http://www.psupress.org/) publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.',
-              subdomain: 'pennstate',
-              press_url: 'http://www.psupress.org')
+Press.where(name: 'University of Michigan Press').first_or_initialize.tap do |press|
+  press.logo_path = 'http://www.press.umich.edu/images/umpre/logo.png'
+  press.description = '[The University of Michigan Press](http://www.press.umich.edu/) publishes academic and general books about contemporary political, social, and cultural issues.'
+  press.subdomain = 'michigan'
+  press.press_url = 'http://www.press.umich.edu'
+  press.save
+end
 
-Press.create!(name: 'Indiana University Press',
-              logo_path: 'https://assets.iu.edu/brand/2.x/trident-large.png',
-              description: "Indiana University Press's mission is to inform and inspire scholars, students, and thoughtful general readers by disseminating ideas and knowledge of global significance, regional importance, and lasting value.",
-              subdomain: 'indiana',
-              press_url: 'http://www.iupress.indiana.edu')
+Press.where(name: 'Penn State University Press').first_or_initialize.tap do |press|
+  press.logo_path = 'http://www.psupress.org/site_images/logo_psupress.gif'
+  press.description = 'The Penn State University Press](http://www.psupress.org/) publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.'
+  press.subdomain = 'pennstate'
+  press.press_url = 'http://www.psupress.org'
+  press.save
+end
 
-Press.create!(name: 'Northwestern University Press',
-              logo_path: 'northwestern.png',
-              description: "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the University’s mission to a community of readers throughout the world. The Press publishes books and journals in the humanities, especially philosophy, literature, and contemporary European writers in translation and continues to explore new media as it strives to promote the finest works of scholarship in the humanities and social sciences.",
-              subdomain: 'northwestern',
-              press_url: 'http://nupress.northwestern.edu/')
+Press.where(name: 'Indiana University Press').first_or_initialize.tap do |press|
+  press.logo_path = 'https://assets.iu.edu/brand/2.x/trident-large.png'
+  press.description = "Indiana University Press's mission is to inform and inspire scholars, students, and thoughtful general readers by disseminating ideas and knowledge of global significance, regional importance, and lasting value."
+  press.subdomain = 'indiana'
+  press.press_url = 'http://www.iupress.indiana.edu'
+  press.save
+end
 
-Press.create!(name: 'University of Minnesota Press',
-              logo_path: 'http://www.upress.umn.edu/++theme++ump.theme/_images/logo.gif',
-              description: "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest.",
-              subdomain: 'minnesota',
-              press_url: 'http://www.upress.umn.edu/')
+Press.where(name: 'Northwestern University Press').first_or_initialize.tap do |press|
+  press.logo_path = 'northwestern.png'
+  press.description = "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the University’s mission to a community of readers throughout the world. The Press publishes books and journals in the humanities, especially philosophy, literature, and contemporary European writers in translation and continues to explore new media as it strives to promote the finest works of scholarship in the humanities and social sciences."
+  press.subdomain = 'northwestern'
+  press.press_url = 'http://nupress.northwestern.edu/'
+  press.save
+end
+
+Press.where(name: 'University of Minnesota Press').first_or_initialize.tap do |press|
+  press.logo_path = 'http://www.upress.umn.edu/++theme++ump.theme/_images/logo.gif'
+  press.description = "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest."
+  press.subdomain = 'minnesota'
+  press.press_url = 'http://www.upress.umn.edu/'
+  press.save
+end


### PR DESCRIPTION
Closes #384 

Creates a press results set to work with the press catalog page. Modifies the display of the list of monographs on a press catalog page to only include book cover, title, author, a description of the book, and a link to the monograph page. Stubs out a place to later include 4 "featured" assets.

This PR also rewrites db/seeds, enabling it to either create OR update entries in the presses database when running `bundle exec rake db:seed`