### PR TITLE
add emphasis tags around the monograph title on an asset show page

### DIFF
--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -13,7 +13,7 @@
       <div class="row asset-attributes">
         <div class="col-sm-12">
           <h2><%= render_markdown @presenter.to_s %></h2>
-          <h3>From <%= render_markdown link_to @presenter.monograph.title.first, "/concern/monographs/#{@presenter.monograph.id}" %>
+          <h3>From <em><%= render_markdown link_to @presenter.monograph.title.first, "/concern/monographs/#{@presenter.monograph.id}" %></em>
             by <%= @presenter.monograph.creator_given_name.first %> <%= @presenter.monograph.creator_family_name.first %></h3>
           <br />
           <%= render "attributes", presenter: @presenter %>


### PR DESCRIPTION
Closes #397 

On asset pages, the parent monograph's title is italicized.