### PR TITLE
running db:seed in production should be different than in dev/test #414

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,42 +2,68 @@
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
 
-Press.where(name: 'University of Michigan Press').first_or_initialize.tap do |press|
-  press.logo_path = 'http://www.press.umich.edu/images/umpre/logo.png'
-  press.description = '[The University of Michigan Press](http://www.press.umich.edu/) publishes academic and general books about contemporary political, social, and cultural issues.'
-  press.subdomain = 'michigan'
-  press.press_url = 'http://www.press.umich.edu'
-  press.save
+def michigan
+  Press.where(name: 'University of Michigan Press').first_or_initialize.tap do |press|
+    press.logo_path = 'http://www.press.umich.edu/images/umpre/logo.png'
+    press.description = '[The University of Michigan Press](http://www.press.umich.edu/) publishes academic and general books about contemporary political, social, and cultural issues.'
+    press.subdomain = 'michigan'
+    press.press_url = 'http://www.press.umich.edu'
+    press.save
+  end
+  puts "updated/created michigan"
 end
 
-Press.where(name: 'Penn State University Press').first_or_initialize.tap do |press|
-  press.logo_path = 'http://www.psupress.org/site_images/logo_psupress.gif'
-  press.description = 'The Penn State University Press](http://www.psupress.org/) publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.'
-  press.subdomain = 'pennstate'
-  press.press_url = 'http://www.psupress.org'
-  press.save
+def pennstate
+  Press.where(name: 'Penn State University Press').first_or_initialize.tap do |press|
+    press.logo_path = 'http://www.psupress.org/site_images/logo_psupress.gif'
+    press.description = 'The Penn State University Press](http://www.psupress.org/) publishes academic books and journals, especially art history, philosophy, literature, religion, and political science.'
+    press.subdomain = 'pennstate'
+    press.press_url = 'http://www.psupress.org'
+    press.save
+  end
+  puts "updated/created pennstate"
 end
 
-Press.where(name: 'Indiana University Press').first_or_initialize.tap do |press|
-  press.logo_path = 'https://assets.iu.edu/brand/2.x/trident-large.png'
-  press.description = "Indiana University Press's mission is to inform and inspire scholars, students, and thoughtful general readers by disseminating ideas and knowledge of global significance, regional importance, and lasting value."
-  press.subdomain = 'indiana'
-  press.press_url = 'http://www.iupress.indiana.edu'
-  press.save
+def indiana
+  Press.where(name: 'Indiana University Press').first_or_initialize.tap do |press|
+    press.logo_path = 'https://assets.iu.edu/brand/2.x/trident-large.png'
+    press.description = "Indiana University Press's mission is to inform and inspire scholars, students, and thoughtful general readers by disseminating ideas and knowledge of global significance, regional importance, and lasting value."
+    press.subdomain = 'indiana'
+    press.press_url = 'http://www.iupress.indiana.edu'
+    press.save
+  end
+  puts "updated/created indiana"
 end
 
-Press.where(name: 'Northwestern University Press').first_or_initialize.tap do |press|
-  press.logo_path = 'northwestern.png'
-  press.description = "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the University’s mission to a community of readers throughout the world. The Press publishes books and journals in the humanities, especially philosophy, literature, and contemporary European writers in translation and continues to explore new media as it strives to promote the finest works of scholarship in the humanities and social sciences."
-  press.subdomain = 'northwestern'
-  press.press_url = 'http://nupress.northwestern.edu/'
-  press.save
+def northwestern
+  Press.where(name: 'Northwestern University Press').first_or_initialize.tap do |press|
+    press.logo_path = 'northwestern.png'
+    press.description = "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the University’s mission to a community of readers throughout the world. The Press publishes books and journals in the humanities, especially philosophy, literature, and contemporary European writers in translation and continues to explore new media as it strives to promote the finest works of scholarship in the humanities and social sciences."
+    press.subdomain = 'northwestern'
+    press.press_url = 'http://nupress.northwestern.edu/'
+    press.save
+  end
+  puts "updated/created northwestern"
 end
 
-Press.where(name: 'University of Minnesota Press').first_or_initialize.tap do |press|
-  press.logo_path = 'http://www.upress.umn.edu/++theme++ump.theme/_images/logo.gif'
-  press.description = "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest."
-  press.subdomain = 'minnesota'
-  press.press_url = 'http://www.upress.umn.edu/'
-  press.save
+def minnesota
+  Press.where(name: 'University of Minnesota Press').first_or_initialize.tap do |press|
+    press.logo_path = 'http://www.upress.umn.edu/++theme++ump.theme/_images/logo.gif'
+    press.description = "The University of Minnesota Press holds a strong commitment to publishing books on the people, history, and natural environment of Minnesota and the Upper Midwest."
+    press.subdomain = 'minnesota'
+    press.press_url = 'http://www.upress.umn.edu/'
+    press.save
+  end
+  puts "updated/created minnesota"
+end
+
+if Rails.env.eql?('production')
+  # add presses as they become ready for production
+  northwestern
+else
+  northwestern
+  pennstate
+  indiana
+  minnesota
+  michigan
 end


### PR DESCRIPTION
Resolves #414 

We want the default presses to be different in production and development/test. We'll use seeds.db for this for now, with the possibility of moving to some other process in the future.