### PR TITLE
move login link from header to footer 

### DIFF
--- a/app/views/shared/_brand_bar.html.erb
+++ b/app/views/shared/_brand_bar.html.erb
@@ -12,7 +12,10 @@
 
     <div class="collapse navbar-collapse" id="brand-bar-nav">
       <div class="navbar-right">
-        <%= render 'shared/site_actions' if show_site_actions? %>
+        <% if current_user && show_site_actions? %>
+          <%= render 'shared/add_content' %>
+          <%= render 'shared/my_actions' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_brand_press_bar.html.erb
+++ b/app/views/shared/_brand_press_bar.html.erb
@@ -28,7 +28,10 @@
 
     <div class="collapse navbar-collapse" id="brand-bar-nav">
       <div class="navbar-right">
-        <%= render 'shared/site_actions' if show_site_actions? %>
+        <% if current_user && show_site_actions? %>
+          <%= render 'shared/add_content' %>
+          <%= render 'shared/my_actions' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_brand_press_footer.html.erb
+++ b/app/views/shared/_brand_press_footer.html.erb
@@ -44,6 +44,7 @@
           <li><a href="http://fulcrum.org/blog/">Blog</a></li>
           <li><a href="mailto:fulcrum-info@umich.edu">Contact</a></li>
           <li><a href="https://github.com/mlibrary/heliotrope">Contribute</a></li>
+          <li><% if current_user %> <%= link_to 'Log Out', main_app.destroy_user_session_path, class: 'log-out', role: 'menuitem' %> <% else %> <%= link_to 'Log In', main_app.new_user_session_path, class: 'login', role: 'menuitem' %> <% end %></li>
         </ul>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="row">
     <div class="footer-text col-md-12">
       <p>
-        Powered by <a href="https://github.com/projecthydra-labs/curation_concerns">CurationConcerns</a>.<br />
-        Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
+        Powered by <a href="https://github.com/projecthydra-labs/curation_concerns">CurationConcerns</a> | Made possible by the <a href="http://projecthydra.org">Hydra</a> project | <% if current_user %> <%= link_to 'Log Out', main_app.destroy_user_session_path, class: 'log-out', role: 'menuitem' %> <% else %> <%= link_to 'Log In', main_app.new_user_session_path, class: 'login', role: 'menuitem' %>
+        <% end %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Closes #405 

if not logged in, a login link is in footer
if logged in, site actions (create monograph, etc.) are in the header and for consistency, a logout link is in the footer.