### PR TITLE
435 Removed file name from view of asset tech info

### DIFF
--- a/app/views/curation_concerns/file_sets/_attribute_rows_technical.html.erb
+++ b/app/views/curation_concerns/file_sets/_attribute_rows_technical.html.erb
@@ -1,4 +1,3 @@
-<%= presenter.attribute_to_html(:original_name) %>
 <%= presenter.attribute_to_html(:file_format) %>
 <%= presenter.attribute_to_html(:file_size) %>
 <%= presenter.attribute_to_html(:width) %>


### PR DESCRIPTION
Resolves #435 