### PR TITLE
436 Remove markdown from asset page title

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+    <title><%= strip_tags(render_markdown (content_for?(:page_title) ? yield(:page_title) : default_page_title)) %></title>
     <meta name="viewport" content="width=device-width">
     <%= csrf_meta_tag %>
 


### PR DESCRIPTION
Resolves #436 Remove markdown from asset page title.