### PR TITLE
UI cleanup

### DIFF
--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -132,6 +132,21 @@ footer.press {
 .asset {
   margin-top: 5em;
 
+  figure {
+    display: inline;
+    margin: initial;
+  }
+
+  figcaption {
+    font-style: italic;
+    margin-top: 1em;
+    
+    em {
+      font-style: normal;
+    }
+
+  }
+
   // leaflet-images
   #image {
     height: 540px;
@@ -143,12 +158,18 @@ footer.press {
     width: 97%;
   }
 
+  // metadata info
   .table > thead > tr > th, .table > thead > tr > td, .table > tbody > tr > th, .table > tbody > tr > td, .table > tfoot > tr > th, .table > tfoot > tr > td {
     border-top: 0 solid #fff;
   }
 
-  .description, .permission_badge {
-    margin-top: 1em;
+  .tab-content {
+    table.table {
+      margin-top: 1.5em;
+    }
+  }
+
+  .description {
     margin-left: -6em;
   }
 

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -134,6 +134,15 @@ $fulcrum-light-2: #bec4cc;
     }
   }
 
+  // monograph
+  .monograph {
+    .documentHeader {
+      p {
+        @include freight-sans-book;
+      }
+    }
+  }
+
   // assets
   .asset {
     ul.nav-tabs li {

--- a/app/views/curation_concerns/file_sets/_media.html.erb
+++ b/app/views/curation_concerns/file_sets/_media.html.erb
@@ -1,4 +1,4 @@
-<div class="image" title="<%= @presenter.alt_text.first %>">
+  <figure class="image" title="<%= @presenter.alt_text.first %>">
     <% if @presenter.image? %>
       <div id="image"></div>
       <script>
@@ -6,9 +6,6 @@
 
         //window.F = window.F || {};
         var $map = $("#image");
-        //$map.height($(window).height() - 100);
-        //$map.height(540);
-        //$map.width(540);
 
         var map = L.map('image', {
           center: [0, 0],
@@ -20,8 +17,9 @@
       <% else %>
         <%= media_display @presenter %>
     <% end %>
-  </div> <!-- /.image/media -->
-  <p><em><%= presenter.attribute_to_html(:caption, render_as: :markdown, label: '') %></em></p>
+    <figcaption><%= presenter.attribute_to_html(:caption, render_as: :markdown, label: '') %></figcaption>
+  </figure> <!-- /.image/media -->
+
   <% if @presenter.translation.present? %>
   <div class="panel panel-default translation">
     <div class="panel-heading">


### PR DESCRIPTION
monograph page: change font for section titles; 

asset page: add white space to metadata tabs, place media in figures with figcaption for more semantic markup, no italics for caption text that is styled italic