### PR TITLE
refactor typekit 

### DIFF
--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -14,4 +14,9 @@ module PressHelper
     press = Press.where(subdomain: subdomain).first
     press.google_analytics if press.present?
   end
+
+  def typekit(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.typekit if press.present?
+  end
 end

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -29,29 +29,18 @@
     <meta name="msapplication-TileImage" content="/assets/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 
+  <% unless press_subdomain.nil? %>
+    <!-- Typekit -->
+    <%= render 'shared/typekit' %>
+  <% end %>
+  
     <!-- CSS -->
     <%= stylesheet_link_tag 'application' %>
 
     <!-- Javascript -->
     <%= javascript_include_tag 'application' %>
 
-    <!-- Typekit - Northwestern -->
-    <% if defined?(@press.subdomain ) %>
-      <% if @press.subdomain == 'northwestern' %>
-        <script src="//use.typekit.net/wyq1mfc.js"></script>
-        <script>try{Typekit.load({ async: true });}catch(e){}</script>
-      <% end %>
-    <% elsif defined?(@monograph_presenter.subdomain) %>
-      <% if @monograph_presenter.subdomain == 'northwestern' %>
-        <script src="//use.typekit.net/wyq1mfc.js"></script>
-        <script>try{Typekit.load({ async: true });}catch(e){}</script>
-      <% end %>
-    <% elsif defined?(@presenter.monograph.subdomain) %>
-      <% if @presenter.monograph.subdomain == 'northwestern' %>
-        <script src="//use.typekit.net/wyq1mfc.js"></script>
-        <script>try{Typekit.load({ async: true });}catch(e){}</script>
-      <% end %>
-    <% end %>
+
   </head>
 <% unless press_subdomain.nil? %>
   <body class="<%= press_subdomain %>">

--- a/app/views/shared/_typekit.html.erb
+++ b/app/views/shared/_typekit.html.erb
@@ -1,0 +1,6 @@
+<% typekit_id = typekit(press_subdomain) %>
+
+<% unless typekit_id.nil? %>
+  <script src="https://use.typekit.net/<%= typekit_id %>.js"></script>
+  <script>try{Typekit.load({ async: true });}catch(e){}</script>
+<% end %>

--- a/db/migrate/20160830143512_add_typekit_id_to_presses.rb
+++ b/db/migrate/20160830143512_add_typekit_id_to_presses.rb
@@ -1,0 +1,6 @@
+#Add typekit id to presses db
+class AddTypekitIdToPresses < ActiveRecord::Migration
+  def change
+    add_column(:presses, :typekit, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160822171245) do
+ActiveRecord::Schema.define(version: 20160830143512) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20160822171245) do
     t.datetime "updated_at",       null: false
     t.string   "press_url"
     t.string   "google_analytics"
+    t.string   "typekit"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,6 +41,7 @@ def northwestern
     press.description = "Northwestern University Press is dedicated to publishing works of enduring scholarly and cultural value, extending the University’s mission to a community of readers throughout the world. The Press publishes books and journals in the humanities, especially philosophy, literature, and contemporary European writers in translation and continues to explore new media as it strives to promote the finest works of scholarship in the humanities and social sciences.<br/><br/>[northwestern.fulcrumscholar.org](http://northwestern.fulcrumscholar.org) is the home of supplemental content for select books. You can find the full catalog of Northwestern University Press titles at the [publisher's website](http://www.nupress.northwestern.edu/)."
     press.subdomain = 'northwestern'
     press.press_url = 'http://nupress.northwestern.edu/'
+    press.typekit = 'wyq1mfc'
     press.save
   end
   puts "updated/created northwestern"


### PR DESCRIPTION
Resolves #434 

1) typekit loading now comes before other CSS and JS - dramatically reducing the FOUT (flash of unstyled font) time and ensuring the font is loaded completely; 

2) reuses press helpers to remove logic from views; 

3) mirror the pattern Seth created for storing Google Analytics IDs and store Typekit ID for a press in presses database

`bundle exec rake db:migrate` and `bundle exec rake db:seed` will need to be run for this to work.