### PR TITLE
remove share buttons for soft launch

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -10,7 +10,8 @@
   <!-- TODO: add citation generator -->
   <!-- <button type="button" class="btn btn-default btn-lg cite">Cite</button> -->
   <!-- TODO: figure out what asset metadata field holds the permanent URL and replace below -->
-  <div class="btn-group share">
+  <!-- TODO: reactivate share buttons -->
+  <!-- <div class="btn-group share">
     <button type="button" class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share <span class="caret"></span></button>
       <ul class="dropdown-menu">
         <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter %>&amp;url=<%= request.original_url %>">Twitter</a></li>
@@ -20,5 +21,5 @@
         <li><a href="http://www.mendeley.com/import/?url=<%= request.original_url %>">Mendeley</a></li>
         <li><a href="http://www.citeulike.org/posturl?url=<%= request.original_url %>&amp;title=<%= @presenter %>">Cite U Like</a></li>
       </ul>
-  </div>
+  </div> -->
 </div><!-- form-actions -->


### PR DESCRIPTION
temporarily hide share button on asset page during the soft launch to prevent preview-heliotrope URLs from easily being shared.