### PR TITLE
add X-Sendfile header for videos, #401

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,3 +10,4 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Exclude:
     - 'app/models/riiif/file.rb'
+    - 'app/controllers/downloads_controller.rb'

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -3,7 +3,17 @@ class DownloadsController < ApplicationController
 
   def show
     if thumbnail? || video? || sound? || allow_download?
-      super
+      # See #401
+      if file.is_a? String
+        # For derivatives stored on the local file system
+        response.headers['Accept-Ranges'] = 'bytes'
+        response.headers['Content-Length'] = File.size(file).to_s
+        file.sub!(/releases\/\d+/, "shared")
+        response.headers['X-Sendfile'] = file
+        send_file file, derivative_download_options
+      else
+        super
+      end
     else
       render 'curation_concerns/base/unauthorized', status: :unauthorized
     end


### PR DESCRIPTION
Resolves #401 

This needs mod_xsendfile installed on Apache as well as some Apache config to work. What this means is iOS and Safari will be able to view video in production, staging, and preview, anywhere that has Apache in front of the app. This will not work for dev and test. iOS and Safari will not be able to view HTML5 video in dev and test.


