### PR TITLE
Solr's default results row limit is only 10

### DIFF
--- a/app/models/monograph_search_builder.rb
+++ b/app/models/monograph_search_builder.rb
@@ -25,7 +25,7 @@ class MonographSearchBuilder < ::SearchBuilder
         ids = monograph.first['ordered_member_ids_ssim']
         if ids.present?
           ids.delete(monograph.first['representative_id_ssim'].first)
-          docs = ActiveFedora::SolrService.query("{!terms f=id}#{ids.join(',')}")
+          docs = ActiveFedora::SolrService.query("{!terms f=id}#{ids.join(',')}", rows: 9999)
 
           section_docs = docs.select { |doc| doc['has_model_ssim'] == ['Section'].freeze }
           asset_docs   = docs.select { |doc| doc['has_model_ssim'] == ['FileSet'].freeze }


### PR DESCRIPTION
Only 10 sections' worth of assets can get through with the default limit, less if some ordered_members are non-representative filesets attached directly to the monograph.
