### PR TITLE
Jekyll rake task for production deployments

### DIFF
--- a/fulcrum/_includes/head.html
+++ b/fulcrum/_includes/head.html
@@ -45,7 +45,7 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "http://{{ site.host }}/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 
-  {% if jekyll.environment == "production" %}
+  {% if site.environment == "production" %}
     {% include analytics.html %}
   {% endif %}
 </head>

--- a/lib/tasks/jekyll.rake
+++ b/lib/tasks/jekyll.rake
@@ -3,6 +3,7 @@ namespace :jekyll do
   dest = Rails.root.join('public')
   conf = Rails.root.join('config', 'jekyll.yml')
   source = Rails.root.join('fulcrum')
+  deploy_env = 'production'
 
   task build: :environment do
     options = {
@@ -22,6 +23,18 @@ namespace :jekyll do
       'config' => conf.to_s,
       'source' => source.to_s,
       'destination' => dest.to_s
+    }
+
+    Jekyll::Commands::Build.process(options)
+  end
+
+  task deploy_production: :environment do
+    options = {
+      'baseurl' => baseurl,
+      'config' => conf.to_s,
+      'source' => source.to_s,
+      'destination' => dest.to_s,
+      'environment' => deploy_env.to_s
     }
 
     Jekyll::Commands::Build.process(options)


### PR DESCRIPTION
adds special jekyll rake task for production deployment -- when deploying jekyll site to production, tell jekyll it is production using the deploy_production rake task;add google analytics tracking to jekyll pages if it environment is production