### PR TITLE
modify permalink structure for jekyll blog posts 

### DIFF
--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -25,4 +25,4 @@ markdown: kramdown
 baseurl: "" # the subpath of your site, e.g. /blog
 
 # Outputting
-permalink: /blog/:year/:month/:day/:title
+permalink: /blog/:year/:month/:day/:title/


### PR DESCRIPTION
bug fix!

do not use extensionless permalinks for blog posts so that

https://www.fulcrum.org/blog/2016/06/30/year-one-report

becomes

https://www.fulcrum.org/blog/2016/06/30/year-one-report/

when generating the jekyll site