### PR TITLE
Modify Holding Contact label on show and form

### DIFF
--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -140,7 +140,7 @@ footer.press {
   figcaption {
     font-style: italic;
     margin-top: 1em;
-    
+
     em {
       font-style: normal;
     }
@@ -181,9 +181,4 @@ footer.press {
   .translation, .transcript {
     margin-top: 2em;
   }
-
-  .holding_contact {
-    margin-left: -6em;
-  }
-
 }

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -148,6 +148,15 @@ $fulcrum-light-2: #bec4cc;
     ul.nav-tabs li {
       @include freight-sans-book;
     }
+
+    #permissions {
+      table tbody tr:last-of-type {
+          th {
+            display: none;
+          }
+      }
+      
+    }
   }
 
   //footer

--- a/app/views/curation_concerns/file_sets/_attribute_rows_permissions.html.erb
+++ b/app/views/curation_concerns/file_sets/_attribute_rows_permissions.html.erb
@@ -6,4 +6,4 @@
 <%= presenter.attribute_to_html(:rights_granted, label: 'Rights Granted') %>
 <%= presenter.attribute_to_html(:rights_granted_creative_commons, label: 'Rights Granted - Creative Commons') %>
 <%= presenter.attribute_to_html(:credit_line, render_as: :markdown, label: 'Credit Line') %>
-<%= presenter.attribute_to_html(:holding_contact, render_as: :markdown, label: '') %>
+<%= presenter.attribute_to_html(:holding_contact, render_as: :markdown, label: 'Holding Contact') %>

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -156,7 +156,7 @@
           <span class="control-label">
             <%= label_tag 'file_set[holding_contact]', 'Holding Contact',  class: "string required" %>
           </span>
-          <%= text_field_tag 'file_set[holding_contact]', curation_concern.holding_contact, class: 'form-control' %>
+          <%= text_area_tag 'file_set[holding_contact]', curation_concern.holding_contact, class: 'form-control' %>
 
           <span class="control-label">
             <%= label_tag 'file_set[ext_url_doi_or_handle]', 'External URL/DOI',  class: "string required" %>


### PR DESCRIPTION
Closes #488 

By default, display the Holding Contact label on the asset show page

For the NW theme, do not show the Holding Contact label

Change the Holding Contact field in the asset edit form to a text area to allow for complex formatting of the Holding Contact text

