### PR TITLE
Fixes #526 - Remove markdown in Twitter share link.

### DIFF
--- a/app/presenters/concerns/title_presenter.rb
+++ b/app/presenters/concerns/title_presenter.rb
@@ -1,0 +1,11 @@
+module TitlePresenter
+  extend ActiveSupport::Concern
+
+  def page_title
+    MarkdownService.markdown_as_text(solr_document.title.first)
+  end
+
+  def title
+    MarkdownService.markdown(solr_document.title.first)
+  end
+end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -1,7 +1,9 @@
 module CurationConcerns
   class FileSetPresenter
+    include TitlePresenter
     include ModelProxy
     include PresentsAttributes
+
     attr_accessor :solr_document, :current_ability, :request, :monograph_presenter
 
     # @param [SolrDocument] solr_document
@@ -21,7 +23,7 @@ module CurationConcerns
     delegate :has?, :first, :fetch, to: :solr_document
 
     # Metadata Methods
-    delegate :title, :resource_type, :caption, :alt_text, :description, :copyright_holder,
+    delegate :resource_type, :caption, :alt_text, :description, :copyright_holder,
              :content_type, :creator, :creator_full_name, :contributor, :date_created,
              :keywords, :relation, :publisher, :identifier, :language, :date_uploaded,
              :rights, :embargo_release_date, :lease_expiration_date, :depositor, :tags,
@@ -47,10 +49,6 @@ module CurationConcerns
 
     def press_url
       Press.find_by(subdomain: subdomain).press_url
-    end
-
-    def page_title
-      Array(solr_document['title_tesim']).first
     end
 
     def section_title

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -1,8 +1,9 @@
 module CurationConcerns
   class MonographPresenter < WorkShowPresenter
+    include TitlePresenter
     include ActionView::Helpers::UrlHelper
 
-    delegate :title, :date_created, :date_modified, :date_uploaded,
+    delegate :date_created, :date_modified, :date_uploaded,
              :description, :creator, :editor, :contributor, :subject,
              :publisher, :date_published, :language, :isbn, :isbn_paper,
              :isbn_ebook, :copyright_holder, :buy_url, :embargo_release_date,

--- a/app/presenters/curation_concerns/section_presenter.rb
+++ b/app/presenters/curation_concerns/section_presenter.rb
@@ -1,5 +1,7 @@
 module CurationConcerns
   class SectionPresenter < WorkShowPresenter
+    include TitlePresenter
+
     def monograph_label
       member_of.first.fetch('title_tesim', []).first
     end

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -12,7 +12,7 @@ class MarkdownService
     rendered_html = outer_p_tags_removed.nil? ? rendered_html : outer_p_tags_removed[1]
     # redcarpet's hard_wrap causes unwanted line breaks, the first gsub seems to be the most targeted way to remove them
     # with the second gsub allowing us to unescape non-breaking spaces to format certain fields per authors' requests
-    rendered_html.gsub(/<\/th><br>/, '</th>').gsub(/&amp;nbsp;/, '&nbsp;')
+    rendered_html.gsub(/<\/th><br>/, '</th>').gsub(/&amp;nbsp;/, '&nbsp;').html_safe
   end
 
   mattr_accessor :sd

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -13,7 +13,7 @@
   <div class="btn-group share">
     <button type="button" class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share <span class="caret"></span></button>
       <ul class="dropdown-menu">
-        <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter %>&amp;url=http://hdl.handle.net/2027/fulcrum.<%= @presenter.id %>">Twitter</a></li>
+        <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter.page_title %>&amp;url=http://hdl.handle.net/2027/fulcrum.<%= @presenter.id %>">Twitter</a></li>
         <li><a href="http://www.facebook.com/sharer.php?u=http://hdl.handle.net/2027/fulcrum.<%= @presenter.id %>&amp;t=<%= @presenter %>">Facebook</a></li>
         <li><a href="https://plus.google.com/share?url=http://hdl.handle.net/2027/fulcrum.<%= @presenter.id %>">Google+</a></li>
         <li><a href="http://www.reddit.com/submit?url=http://hdl.handle.net/2027/fulcrum.<%= @presenter.id %>">Reddit</a></li>

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -12,8 +12,8 @@
     <div class="col-sm-6">
       <div class="row asset-attributes">
         <div class="col-sm-12">
-          <h2><%= render_markdown @presenter.page_title %></h2>
-          <h3>From <em><%= render_markdown link_to @presenter.monograph.title.first, "/concern/monographs/#{@presenter.monograph.id}" %></em>
+          <h2><%= @presenter.title %></h2>
+          <h3>From <em><%= link_to @presenter.monograph.title, "/concern/monographs/#{@presenter.monograph.id}" %></em>
             by <%= @presenter.monograph.creator_given_name.first %> <%= @presenter.monograph.creator_family_name.first %><%= contributors_string(@presenter.monograph.contributor) %></h3></h3>
           <br />
           <%= render "attributes", presenter: @presenter %>

--- a/app/views/curation_concerns/monographs/show.html.erb
+++ b/app/views/curation_concerns/monographs/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
-  <h1><%= render_markdown @presenter.to_s %> <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span></h1>
+  <h1><%= @presenter.title %> <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span></h1>
 <% end %>
 
 <% collector = can?(:collect, @presenter.id) %>

--- a/app/views/curation_concerns/sections/show.html.erb
+++ b/app/views/curation_concerns/sections/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
-  <h1><%= render_markdown @presenter.to_s %> </h1>
+  <h1><%= @presenter.title %> </h1>
   <% if @parent_presenter %>
     <ul class="breadcrumb">
       <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title><%= render_markdown_as_text(content_for?(:page_title) ? yield(:page_title) : default_page_title) %></title>
+    <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
     <meta name="viewport" content="width=device-width">
     <%= csrf_meta_tag %>
 

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :page_title, @monograph_presenter.title.first || "Title" %>
+<% provide :page_title, @monograph_presenter.title || "Title" %>
 <% provide :page_class, 'search monograph' %>
 
 <% provide :page_header do %>
@@ -11,7 +11,7 @@
       <%= render 'curation_concerns/base/representative_media', presenter: @monograph_presenter %>
     </div><!-- /.monograph-cover -->
     <div class="monograph-metadata">
-      <h2><%= render_markdown @monograph_presenter.title.first || '' %></h2>
+      <h2><%= @monograph_presenter.title || '' %></h2>
       <% if can?(:edit, @monograph_presenter.id) %>
         <%= link_to "Manage Monograph and Files", main_app.monograph_show_path(@monograph_presenter.id), class: 'btn btn-primary', id: 'manage-monograph-button' %>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Heliotrope
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
     config.active_job.queue_adapter = :resque
+
+    # Add concerns to autoload paths
+    config.autoload_paths += %W( #{config.root}/app/presenters/concerns )
   end
 end

--- a/spec/controllers/monograph_catalog_controller_spec.rb
+++ b/spec/controllers/monograph_catalog_controller_spec.rb
@@ -25,7 +25,7 @@ describe MonographCatalogController do
           expect(controller.instance_variable_get(:@monograph_presenter).class).to eq CurationConcerns::MonographPresenter
         end
         it 'mongraph presenter has the monograph' do
-          expect(controller.instance_variable_get(:@monograph_presenter).title.first).to eq monograph.title.first
+          expect(controller.instance_variable_get(:@monograph_presenter).solr_document.id).to eq monograph.id
         end
       end
     end

--- a/spec/presenters/concerns/title_presenter_spec.rb
+++ b/spec/presenters/concerns/title_presenter_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+class Presenter
+  include TitlePresenter
+  attr_reader :solr_document
+
+  def initialize(solr_document)
+    @solr_document = solr_document
+  end
+end
+
+describe TitlePresenter do
+  let(:markdown_title) { '__Markdown Title__' }
+  let(:expected_markdown_title_as_text) { 'Markdown Title' }
+  let(:expected_markdown_title_as_html_safe) { '<strong>Markdown Title</strong>'.html_safe }
+  let(:solr_document) { SolrDocument.new(title_tesim: [markdown_title]) }
+  let(:presenter) { Presenter.new(solr_document) }
+
+  describe 'Presenter' do
+    it 'includes TitlePresenter' do
+      expect(presenter).to be_a described_class
+    end
+  end
+
+  describe '#page_title' do
+    it 'translates markdown to text' do
+      expect(presenter.page_title).to eq expected_markdown_title_as_text
+    end
+  end
+
+  describe '#title' do
+    it 'translates markdown to html' do
+      expect(presenter.title).to eq expected_markdown_title_as_html_safe
+    end
+    it 'returns safe html' do
+      expect(presenter.title).to be_a ActiveSupport::SafeBuffer
+    end
+  end
+end

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -10,11 +10,8 @@ describe CurationConcerns::FileSetPresenter do
     monograph.save!
   end
 
-  describe '#allow_download?' do
-    let(:fileset_doc) { SolrDocument.new(id: 'fs', has_model_ssim: ['FileSet'], allow_download_ssim: 'yes') }
-    it "can download" do
-      expect(presenter.allow_download?).to be true
-    end
+  it 'includes TitlePresenter' do
+    expect(described_class.new(nil, nil)).to be_a TitlePresenter
   end
 
   describe "#monograph" do
@@ -24,14 +21,10 @@ describe CurationConcerns::FileSetPresenter do
     end
   end
 
-  describe '#page_title' do
-    let(:expected_page_title) { 'Hello' }
-    let(:fileset_doc) { SolrDocument.new(id: 'fs', has_model_ssim: ['FileSet'], title_tesim: [expected_page_title]) }
-    context 'is file set first title' do
-      it { expect(presenter.page_title).to eq fileset_doc[:title_tesim].first }
-    end
-    context 'is expected page title' do
-      it { expect(presenter.page_title).to eq expected_page_title }
+  describe '#allow_download?' do
+    let(:fileset_doc) { SolrDocument.new(id: 'fs', has_model_ssim: ['FileSet'], allow_download_ssim: 'yes') }
+    it "can download" do
+      expect(presenter.allow_download?).to be true
     end
   end
 end

--- a/spec/presenters/curation_concerns/monograph_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/monograph_presenter_spec.rb
@@ -11,6 +11,10 @@ describe CurationConcerns::MonographPresenter do
   let(:ability) { double('ability') }
   let(:presenter) { described_class.new(mono_doc, ability) }
 
+  it 'includes TitlePresenter' do
+    expect(described_class.new(nil, nil)).to be_a TitlePresenter
+  end
+
   describe '#sub_brand_links' do
     context 'a monograph without sub-brands' do
       let(:mono_doc) { SolrDocument.new(id: 'mono', has_model_ssim: ['Monograph'], press_tesim: [press.subdomain]) }

--- a/spec/presenters/curation_concerns/section_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/section_presenter_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 describe CurationConcerns::SectionPresenter do
   let(:ability) { nil }
 
+  it 'includes TitlePresenter' do
+    expect(described_class.new(nil, nil)).to be_a TitlePresenter
+  end
+
   describe "#monograph_label" do
     let(:solr_document) { SolrDocument.new(attributes) }
     let(:attributes) do

--- a/spec/services/markdown_service_spec.rb
+++ b/spec/services/markdown_service_spec.rb
@@ -1,10 +1,17 @@
 require 'rails_helper'
 
 describe MarkdownService do
-  let(:html) { "\n\nThis is _italics_ and this is\n\na paragraph\n\n__bold__ a line\nbreak and this is ~~strikethrough~~" }
+  describe '.markdown' do
+    let(:html) { "\n\nThis is _italics_ and this is\n\na paragraph\n\n__bold__ a line\nbreak and this is ~~strikethrough~~" }
+    let(:rvalue) { described_class.markdown(html) }
 
-  it "renders html from markdown" do
-    expect(described_class.markdown(html)).to eq("This is <em>italics</em> and this is</p>\n\n<p>a paragraph</p>\n\n<p><strong>bold</strong> a line<br>\nbreak and this is <del>strikethrough</del>")
+    it "renders html from markdown" do
+      expect(rvalue).to eq("This is <em>italics</em> and this is</p>\n\n<p>a paragraph</p>\n\n<p><strong>bold</strong> a line<br>\nbreak and this is <del>strikethrough</del>")
+    end
+
+    it 'returns safe html' do
+      expect(rvalue).to be_a ActiveSupport::SafeBuffer
+    end
   end
 
   describe '.markdown_as_text' do


### PR DESCRIPTION
Created TitlePresenter concern and added concern to File_Set, Section,
and Mongraph Presenters.