### PR TITLE
Fixes #542. Changing a Section title should not break the Section facet.

### DIFF
--- a/app/controllers/curation_concerns/sections_controller.rb
+++ b/app/controllers/curation_concerns/sections_controller.rb
@@ -6,4 +6,16 @@ class CurationConcerns::SectionsController < ApplicationController
   def search_builder_class
     ::SectionSearchBuilder
   end
+
+  def update
+    # If a section's title is changed, we need to re-index all of it's file_sets
+    # in order for the section facet on the monograph_catalog page to work right
+    # see #542
+    if curation_concern.title != params[:section][:title]
+      curation_concern.members.each do |member|
+        ReindexFileSetJob.perform_later(member) if member.file_set?
+      end
+    end
+    super
+  end
 end

--- a/app/jobs/reindex_file_set_job.rb
+++ b/app/jobs/reindex_file_set_job.rb
@@ -1,0 +1,7 @@
+class ReindexFileSetJob < ActiveJob::Base
+  queue_as :reindex_fileset
+
+  def perform(file_set)
+    file_set.update_index
+  end
+end

--- a/spec/jobs/reindex_file_set_job_spec.rb
+++ b/spec/jobs/reindex_file_set_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ReindexFileSetJob, type: :job do
+  describe "perform" do
+    let(:monograph) { create(:monograph) }
+    let(:section) { create(:section) }
+    let(:file_set) { create(:file_set) }
+    before do
+      monograph.ordered_members << section
+      monograph.save!
+      section.ordered_members << file_set
+      section.save!
+    end
+
+    context "when a section has a new title" do
+      before do
+        section.title = ["new title"]
+        section.save!
+      end
+      it "reindexes the file_set with the new section title" do
+        described_class.perform_now(file_set)
+        doc = FileSetIndexer.new(file_set).generate_solr_document
+        expect(doc.to_h["section_title_tesim"]).to eq ["new title"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a Section title is edited, we need to reindex all of it's file_sets since
we use the file_sets indexes section_title_tesim to build the Section facet
on the monograph_catalog page. Added a reindex_file_set_job that gets called
from by section_controller#update when a section's title(s) has changed.