### PR TITLE
use @presenter.page_title in all share links that include a title

### DIFF
--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -14,11 +14,11 @@
     <button type="button" class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share <span class="caret"></span></button>
       <ul class="dropdown-menu">
         <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter.page_title %>&amp;url=<%= @presenter.citable_link %>">Twitter</a></li>
-        <li><a href="http://www.facebook.com/sharer.php?u=<%= @presenter.citable_link %>&amp;t=<%= @presenter %>">Facebook</a></li>
+        <li><a href="http://www.facebook.com/sharer.php?u=<%= @presenter.citable_link %>&amp;t=<%= @presenter.page_title %>">Facebook</a></li>
         <li><a href="https://plus.google.com/share?url=<%= @presenter.citable_link %>">Google+</a></li>
         <li><a href="http://www.reddit.com/submit?url=<%= @presenter.citable_link %>">Reddit</a></li>
         <li><a href="http://www.mendeley.com/import/?url=<%= @presenter.citable_link %>">Mendeley</a></li>
-        <li><a href="http://www.citeulike.org/posturl?url=<%= @presenter.citable_link %>&amp;title=<%= @presenter %>">Cite U Like</a></li>
+        <li><a href="http://www.citeulike.org/posturl?url=<%= @presenter.citable_link %>&amp;title=<%= @presenter.page_title %>">Cite U Like</a></li>
       </ul>
   </div>
 </div><!-- form-actions -->


### PR DESCRIPTION
Very quick fix to ensure that markdown is removed from all share links that include a title.