### PR TITLE
Resolves #256 google analytics pageviews for file_sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 /config/secrets.yml
 /config/database.yml
+/config/analytics.yml
 /config/curation_concerns.yml
 
 # Ignore Vagrant support files

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,12 @@ gem 'redcarpet', '~> 3.3.4'
 # Use Jekyll for blog and informational pages
 gem 'jekyll'
 
+# Talking to Google Analytics
+gem 'oauth'
+gem 'oauth2', '~> 1.2'
+gem 'signet'
+gem 'legato', '~> 0.3'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,8 @@ GEM
       rdf-turtle
       rdf-vocab (>= 0.8)
       slop
+    legato (0.7.0)
+      multi_json
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.7.1)
@@ -615,7 +617,10 @@ DEPENDENCIES
   jekyll
   jquery-rails
   jquery-turbolinks
+  legato (~> 0.3)
   mysql2
+  oauth
+  oauth2 (~> 1.2)
   pry-rails (~> 0.3.4)
   puma
   rails (= 4.2.7.1)
@@ -631,6 +636,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  signet
   solr_wrapper (= 0.14.2)
   spring
   sqlite3

--- a/app/models/pageview.rb
+++ b/app/models/pageview.rb
@@ -1,0 +1,7 @@
+class Pageview
+  extend Legato::Model
+
+  metrics :pageviews
+  dimensions :date
+  filter :for_path, &->(path) { contains(:pagePath, path) }
+end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,0 +1,92 @@
+require 'oauth2'
+require 'signet/oauth_2/client'
+require 'legato'
+
+# This is mostly the same as Sufia's /services/sufia/analytics.rb
+
+module AnalyticsService
+  # Loads configuration options from config/analytics.yml. Expected structure:
+  # `analytics:`
+  # `  app_name: GOOGLE_OAUTH_APP_NAME`
+  # `  app_version: GOOGLE_OAUTH_APP_VERSION`
+  # `  privkey_path: GOOGLE_OAUTH_PRIVATE_KEY_PATH`
+  # `  privkey_secret: GOOGLE_OAUTH_PRIVATE_KEY_SECRET`
+  # `  client_email: GOOGLE_OAUTH_CLIENT_EMAIL`
+  # @return [Config]
+  def self.config
+    @config ||= Config.load_from_yaml
+  end
+  private_class_method :config
+
+  class Config
+    def self.load_from_yaml
+      filename = File.join(Rails.root, 'config', 'analytics.yml')
+      yaml = YAML.load(File.read(filename)) if File.exist?(filename)
+      unless yaml
+        Rails.logger.error("Unable to fetch any keys from #{filename}.")
+        return new({})
+      end
+      new yaml.fetch('analytics')
+    end
+
+    REQUIRED_KEYS = %w(app_name app_version privkey_path privkey_secret client_email).freeze
+
+    def initialize(config)
+      @config = config
+    end
+
+    # @return [Boolean] are all the required values present?
+    def valid?
+      config_keys = @config.keys
+      REQUIRED_KEYS.all? { |required| config_keys.include?(required) }
+    end
+
+    REQUIRED_KEYS.each do |key|
+      class_eval %{ def #{key};  @config.fetch('#{key}'); end }
+    end
+  end
+
+  # Generate an OAuth2 token for Google Analytics
+  # @return [OAuth2::AccessToken] An OAuth2 access token for GA
+  def self.token(scope = 'https://www.googleapis.com/auth/analytics.readonly')
+    access_token = auth_client(scope).fetch_access_token!
+    OAuth2::AccessToken.new(oauth_client, access_token['access_token'], expires_in: access_token['expires_in'])
+  end
+
+  def self.oauth_client
+    OAuth2::Client.new('', '', authorize_url: 'https://accounts.google.com/o/oauth2/auth',
+                               token_url: 'https://accounts.google.com/o/oauth2/token')
+  end
+
+  def self.auth_client(scope)
+    unless File.exist?(config.privkey_path)
+      raise "Private key file for Google analytics was expected at '#{config.privkey_path}', but no file was found."
+    end
+    private_key = File.read(config.privkey_path)
+    Signet::OAuth2::Client.new token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
+                               audience: 'https://accounts.google.com/o/oauth2/token',
+                               scope: scope,
+                               issuer: config.client_email,
+                               signing_key: OpenSSL::PKCS12.new(private_key, config.privkey_secret).key,
+                               sub: config.client_email
+  end
+
+  private_class_method :token
+
+  # Return a user object linked to a Google Analytics account
+  # @return [Legato::User] A user account wit GA access
+  def self.user
+    Legato::User.new(token)
+  end
+  private_class_method :user
+
+  # Return a Google Analytics profile matching specified ID
+  # @ return [Legato::Management::Profile] A user profile associated with GA
+  # In Sufia the GA ID is read from config, but for Heliotrope we pass it in.
+  def self.profile(id)
+    Rails.logger.error("Missing/invalid analytics config or .p12 file") && return unless config.valid? && File.exist?(config.privkey_path)
+    user.profiles.detect do |profile|
+      profile.web_property_id == id
+    end
+  end
+end

--- a/app/views/curation_concerns/file_sets/_attribute_rows_stats.html.erb
+++ b/app/views/curation_concerns/file_sets/_attribute_rows_stats.html.erb
@@ -1,3 +1,1 @@
-<p>Altmetric data</p>
-<p>Pageviews</p>
-<p>Downloads</p>
+<%= presenter.attribute_to_html(:pageviews) %>

--- a/app/views/curation_concerns/file_sets/_attributes.html.erb
+++ b/app/views/curation_concerns/file_sets/_attributes.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" class="active"><a href="#info" aria-controls="info" role="tab" data-toggle="tab">Info</a></li>
   <li role="presentation"><a href="#permissions" aria-controls="permissions" role="tab" data-toggle="tab">Permissions</a></li>
-  <!-- <li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li> -->
+  <li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
   <% if external_resource?(presenter) == false %>
   <li role="presentation"><a href="#technical-info" aria-controls="technical-info" role="tab" data-toggle="tab">Technical Info</a></li>
   <% end %>
@@ -22,12 +22,15 @@
       </tbody>
     </table>
   </div> <!-- /.permissions panel -->
-  <!-- TODO: activate pageview and download count via Google Analytics API -->
-  <% if false %>
+
   <div role="tabpanel" class="tab-pane fade" id="stats">
-    <%= render 'attribute_rows_stats', presenter: presenter %>
+    <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+      <tbody>
+        <%= render 'attribute_rows_stats', presenter: presenter %>
+      </tbody>
+    </table>
   </div>  <!-- /.stats panel -->
-  <% end %>
+
 
   <div role="tabpanel" class="tab-pane fade" id="technical-info">
     <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,7 @@ Dir.chdir APP_ROOT do
   # Add necessary setup steps to this file:
 
   puts "\n== Copying sample files =="
-  files = ['secrets', 'database']
+  files = ['secrets', 'database', 'analytics']
   files.each do |f|
     yml_name = "config/#{f}.yml"
     cp "#{yml_name}.sample", yml_name unless File.exist?(yml_name)

--- a/config/analytics.yml.sample
+++ b/config/analytics.yml.sample
@@ -1,0 +1,7 @@
+# Loads configuration options from config/analytics.yml. Expected structure:
+analytics:
+  app_name: 'My App Name'
+  app_version: '0.0.1'
+  privkey_path: '/tmp/privkey.p12'
+  privkey_secret: 's00pers3kr1t'
+  client_email: 'oauth@example.org'

--- a/spec/models/pageview_spec.rb
+++ b/spec/models/pageview_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Pageview, type: :model do
+  it 'has a pageviews metric' do
+    expect(described_class.metrics).to be == Legato::ListParameter.new(:metrics, [:pageviews])
+  end
+
+  it 'has a date dimension' do
+    expect(described_class.dimensions).to be == Legato::ListParameter.new(:dimensions, [:date])
+  end
+
+  it 'responds to :for_path' do
+    expect(described_class).to respond_to(:for_path)
+  end
+end

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -5,6 +5,7 @@ describe CurationConcerns::FileSetPresenter do
   let(:presenter) { described_class.new(fileset_doc, ability) }
   let(:monograph) { create(:monograph, creator_given_name: "firstname", creator_family_name: "lastname") }
   let(:file_set) { create(:file_set) }
+  let(:press) { create(:press, subdomain: 'blue', google_analytics: 'UA-THINGS') }
   before do
     monograph.ordered_members << file_set
     monograph.save!
@@ -39,6 +40,52 @@ describe CurationConcerns::FileSetPresenter do
     let(:fileset_doc) { SolrDocument.new(id: 'fs', has_model_ssim: ['FileSet'], allow_download_ssim: 'yes') }
     it "can download" do
       expect(presenter.allow_download?).to be true
+    end
+  end
+
+  describe '#subdomain' do
+    let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
+    it "returns the press subdomain" do
+      expect(presenter.subdomain).to eq press.subdomain
+    end
+  end
+
+  describe "#google_analytics_id" do
+    context "when the press has a google analytics id" do
+      let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
+      it "returns the press google analytics id" do
+        expect(presenter.google_analytics_id).to eq press.google_analytics
+      end
+    end
+    context "when the press has no google analytics id, but there's a fulcrum id" do
+      let(:fileset_doc) { SolrDocument.new(id: 'fs') }
+      it "returns the fulcrum google analytics id" do
+        Rails.application.secrets.google_analytics_id = 'UA-YES'
+        expect(presenter.google_analytics_id).to eq 'UA-YES'
+      end
+    end
+    context "when the press has no google analytics id and no fulcrum id" do
+      let(:fileset_doc) { SolrDocument.new(id: 'fs') }
+      it "returns nil" do
+        Rails.application.secrets.delete :google_analytics_id
+        expect(presenter.google_analytics_id).to be nil
+      end
+    end
+  end
+
+  describe "#pageviews" do
+    let(:fileset_doc) { SolrDocument.new(id: 'fs') }
+    before do
+      allow(presenter).to receive(:pageviews_by_date).and_return(
+        [
+          { date: "20161003", pageviews: "5" },
+          { date: "20161004", pageviews: "1" },
+          { date: "20161005", pageviews: "2" }
+        ]
+      )
+    end
+    it "has the correct number of pageviews" do
+      expect(presenter.pageviews).to eq 8
     end
   end
 end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe AnalyticsService, :no_clean do
+  before do
+    described_class.send(:remove_instance_variable, :@config) if described_class.send(:instance_variable_defined?, :@config)
+  end
+
+  describe "configuration" do
+    let(:config) { described_class.send(:config) }
+
+    context "When the yaml file has values" do
+      it "is valid" do
+        expect(config).to be_valid
+      end
+
+      it 'reads its config from a yaml file' do
+        expect(config.app_name).to eql 'My App Name'
+        expect(config.app_version).to eql '0.0.1'
+        expect(config.privkey_path).to eql '/tmp/privkey.p12'
+        expect(config.privkey_secret).to eql 's00pers3kr1t'
+        expect(config.client_email).to eql 'oauth@example.org'
+      end
+    end
+
+    context "When the yaml file has no values" do
+      before do
+        allow(File).to receive(:read).and_return("# Just comments\n# and comments\n")
+      end
+
+      it "is not valid" do
+        expect(Rails.logger).to receive(:error)
+          .with(starting_with("Unable to fetch any keys from"))
+        expect(config).not_to be_valid
+      end
+    end
+  end
+
+  describe "#user" do
+    before do
+      token = OAuth2::AccessToken.new(nil, nil)
+      allow(subject).to receive(:token).and_return(token)
+    end
+    it 'instantiates a user' do
+      expect(subject.send(:user)).to be_a(Legato::User)
+    end
+  end
+
+  describe "#profile" do
+    subject { described_class.profile('required_ga_id') }
+
+    context "when the private key file is missing" do
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when the config is not valid" do
+      before do
+        allow(File).to receive(:read).and_return("# Just comments\n# and comments\n")
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Much of this work has been lifted from Sufia, especially services/analytics_service.rb,
model/pageview.rb and their respective specs. But not all of the Sufia functionality
is carried over, there's no statistics.rb model for instance. There's no model for stats,
the service is just called directly from the presenter.

It might be that as demands for more complicated analytics functionality come in
we'll want to refactor and look for ways to manage that complexity. When that happens
it probably makes sense to look to Sufia and try to emulate more of what they've done.

Unless we get a plugin archetecture before that happens and can just include a GA gem(!)

NOTE: current developers should `cp config/analytics.yml.sample config/analytics.yml` to get tests to pass. For new installs this happens with `bin/setup`.