### PR TITLE
Resolves #489: Ability to navigate next and previous from asset page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development, :test do
   #gem 'fcrepo_wrapper', '0.6'
   #gem 'solr_wrapper', '~> 0.16'
   gem 'rspec-rails'
+  gem 'rspec-context-private'
   gem 'rspec-html-matchers'
   gem 'rubocop', '~> 0.37.2'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
+    rspec-context-private (0.0.1)
     rspec-core (3.5.0)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -630,6 +631,7 @@ DEPENDENCIES
   resque-web (~> 0.0.7)
   riiif (= 0.4.0)
   rsolr (~> 1.1.2)
+  rspec-context-private
   rspec-html-matchers
   rspec-rails
   rubocop (~> 0.37.2)

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -72,6 +72,22 @@ module CurationConcerns
       monograph.subject
     end
 
+    def previous_id?
+      monograph.previous_file_sets_id? id
+    end
+
+    def previous_id
+      monograph.previous_file_sets_id id
+    end
+
+    def next_id?
+      monograph.next_file_sets_id? id
+    end
+
+    def next_id
+      monograph.next_file_sets_id id
+    end
+
     def link_name
       current_ability.can?(:read, id) ? Array(solr_document['label_tesim']).first : 'File'
     end

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -43,7 +43,39 @@ module CurationConcerns
       Press.find_by(subdomain: subdomain).press_url
     end
 
+    def previous_file_sets_id?(file_sets_id)
+      return false unless ordered_file_sets_ids.include? file_sets_id
+      ordered_file_sets_ids.first != file_sets_id
+    end
+
+    def previous_file_sets_id(file_sets_id)
+      return nil unless previous_file_sets_id? file_sets_id
+      ordered_file_sets_ids[(ordered_file_sets_ids.find_index(file_sets_id) - 1)]
+    end
+
+    def next_file_sets_id?(file_sets_id)
+      return false unless ordered_file_sets_ids.include? file_sets_id
+      ordered_file_sets_ids.last != file_sets_id
+    end
+
+    def next_file_sets_id(file_sets_id)
+      return nil unless next_file_sets_id? file_sets_id
+      ordered_file_sets_ids[(ordered_file_sets_ids.find_index(file_sets_id) + 1)]
+    end
+
     private
+
+      def ordered_file_sets_ids
+        return @ordered_file_sets_ids if @ordered_file_sets_ids
+        file_sets_ids = []
+        section_docs.each do |section_doc|
+          # Danger, Will Robinson! the ordered list is stored in reverse order.
+          section_doc['ordered_member_ids_ssim'].reverse_each do |file_sets_id|
+            file_sets_ids.append file_sets_id
+          end unless section_doc['ordered_member_ids_ssim'].nil?
+        end
+        @ordered_file_sets_ids = file_sets_ids
+      end
 
       def ordered_member_docs
         return @ordered_member_docs if @ordered_member_docs

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -1,6 +1,5 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
-  <!-- breadcrumbs -->
   <div class="row">
     <nav class="breadcrumbs col-sm-12">
       <ol class="breadcrumb">
@@ -10,6 +9,14 @@
       </ol>
     </nav>
   </div>
+  <ul class="pager">
+      <li class="previous">
+        <%= link_to "Previous", main_app.curation_concerns_file_set_path(@presenter.previous_id) if @presenter.previous_id? %>
+      </li>
+      <li class="next">
+        <%= link_to "Next", main_app.curation_concerns_file_set_path(@presenter.next_id) if @presenter.next_id? %>
+      </li>
+  </ul>
 <% end %>
 
   <div class="row asset">

--- a/spec/presenters/curation_concerns/monograph_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/monograph_presenter_spec.rb
@@ -63,20 +63,64 @@ describe CurationConcerns::MonographPresenter do
         expect(subject).to eq []
       end
     end
+
+    describe '#ordered_file_sets_ids', :private do
+      subject { presenter.ordered_file_sets_ids }
+      it 'returns an empty array' do
+        expect(subject.count).to eq 0
+      end
+    end
+
+    describe '#previous_file_sets_id?' do
+      subject { presenter.previous_file_sets_id? 0 }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+
+    describe '#previous_file_sets_id' do
+      subject { presenter.previous_file_sets_id 0 }
+      it 'returns nil' do
+        expect(subject).to eq nil
+      end
+    end
+
+    describe '#next_file_sets_id?' do
+      subject { presenter.next_file_sets_id? 0 }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+
+    describe '#next_file_sets_id' do
+      subject { presenter.next_file_sets_id 0 }
+      it 'returns nil' do
+        expect(subject).to eq nil
+      end
+    end
   end
 
   context 'a monograph with sections and filesets' do
     let(:fileset_doc) { SolrDocument.new(id: 'fileset', has_model_ssim: ['FileSet']) }
-    let(:chapter_1_doc) { SolrDocument.new(id: 'chapter1', has_model_ssim: ['Section']) }
-    let(:chapter_2_doc) { SolrDocument.new(id: 'chapter2', has_model_ssim: ['Section']) }
-    let(:chapter_3_doc) { SolrDocument.new(id: 'chapter3', has_model_ssim: ['Section']) }
-    let(:chapter_4_doc) { SolrDocument.new(id: 'chapter4', has_model_ssim: ['Section']) }
-    let(:chapter_5_doc) { SolrDocument.new(id: 'chapter5', has_model_ssim: ['Section']) }
-    let(:chapter_6_doc) { SolrDocument.new(id: 'chapter6', has_model_ssim: ['Section']) }
-    let(:chapter_7_doc) { SolrDocument.new(id: 'chapter7', has_model_ssim: ['Section']) }
-    let(:chapter_8_doc) { SolrDocument.new(id: 'chapter8', has_model_ssim: ['Section']) }
-    let(:chapter_9_doc) { SolrDocument.new(id: 'chapter9', has_model_ssim: ['Section']) }
-    let(:chapter_10_doc) { SolrDocument.new(id: 'chapter10', has_model_ssim: ['Section']) }
+    let(:expected_id_count) { 20 }
+    let(:expected_first_id) { 'expected_first_id' }
+    let(:expected_first_next_id) { 'expected_first_next_id' }
+    let(:expected_middle_previous_id) { 'expected_middle_previous_id' }
+    let(:expected_middle_id) { 'expected_middle_id' }
+    let(:expected_middle_next_id) { 'expected_middle_next_id' }
+    let(:expected_last_previous_id) { 'expected_last_previous_id' }
+    let(:expected_last_id) { 'expected_last_id' }
+    # Danger, Will Robinson! the ordered_member_ids_ssim list are stored in reverse order.
+    let(:chapter_1_doc) { SolrDocument.new(id: 'chapter1', has_model_ssim: ['Section'], ordered_member_ids_ssim: ['last_1', expected_first_next_id, expected_first_id]) }
+    let(:chapter_2_doc) { SolrDocument.new(id: 'chapter2', has_model_ssim: ['Section'], ordered_member_ids_ssim: ['first_2']) }
+    let(:chapter_3_doc) { SolrDocument.new(id: 'chapter3', has_model_ssim: ['Section'], ordered_member_ids_ssim: ['last_3', 'first_3']) }
+    let(:chapter_4_doc) { SolrDocument.new(id: 'chapter4', has_model_ssim: ['Section'], ordered_member_ids_ssim: ['last_4', 'middle_4', 'first_4']) }
+    let(:chapter_5_doc) { SolrDocument.new(id: 'chapter5', has_model_ssim: ['Section'], ordered_member_ids_ssim: []) }
+    let(:chapter_6_doc) { SolrDocument.new(id: 'chapter6', has_model_ssim: ['Section'], ordered_member_ids_ssim: [expected_middle_previous_id, 'first_6']) }
+    let(:chapter_7_doc) { SolrDocument.new(id: 'chapter7', has_model_ssim: ['Section'], ordered_member_ids_ssim: []) }
+    let(:chapter_8_doc) { SolrDocument.new(id: 'chapter8', has_model_ssim: ['Section'], ordered_member_ids_ssim: [expected_middle_id]) }
+    let(:chapter_9_doc) { SolrDocument.new(id: 'chapter9', has_model_ssim: ['Section'], ordered_member_ids_ssim: ['last_9', expected_middle_next_id]) }
+    let(:chapter_10_doc) { SolrDocument.new(id: 'chapter10', has_model_ssim: ['Section'], ordered_member_ids_ssim: [expected_last_id, expected_last_previous_id, 'first_10']) }
     # I added chapter 1 twice to make sure that duplicate
     # entries will work correctly.
     let(:mono_doc) { SolrDocument.new(id: 'mono',
@@ -101,6 +145,112 @@ describe CurationConcerns::MonographPresenter do
         expect(subject.count).to eq 11
         expect(subject.map(&:class).uniq).to eq [SolrDocument]
         expect(subject.map(&:id)).to eq [chapter_1_doc.id, chapter_2_doc.id, chapter_3_doc.id, chapter_1_doc.id, chapter_4_doc.id, chapter_5_doc.id, chapter_6_doc.id, chapter_7_doc.id, chapter_8_doc.id, chapter_9_doc.id, chapter_10_doc.id]
+      end
+    end
+
+    describe '#ordered_file_sets_ids', :private do
+      subject { presenter.ordered_file_sets_ids }
+
+      it 'returns an array of expected size' do
+        expect(subject.count).to eq expected_id_count
+      end
+
+      it 'the first element of the array is as expected' do
+        expect(subject.first).to eq expected_first_id
+      end
+
+      it 'the last element of the array is as expected' do
+        expect(subject.last).to eq expected_last_id
+      end
+    end
+
+    context 'expected first id' do
+      describe '#previous_file_sets_id?' do
+        subject { presenter.previous_file_sets_id? expected_first_id }
+        it 'returns false' do
+          expect(subject).to eq false
+        end
+      end
+
+      describe '#previous_file_sets_id' do
+        subject { presenter.previous_file_sets_id expected_first_id }
+        it 'returns nil' do
+          expect(subject).to eq nil
+        end
+      end
+
+      describe '#next_file_sets_id?' do
+        subject { presenter.next_file_sets_id? expected_first_id }
+        it 'returns true' do
+          expect(subject).to eq true
+        end
+      end
+
+      describe '#next_file_sets_id' do
+        subject { presenter.next_file_sets_id expected_first_id }
+        it 'returns expected' do
+          expect(subject).to eq expected_first_next_id
+        end
+      end
+    end
+
+    context 'expected_middle_id' do
+      describe '#previous_file_sets_id?' do
+        subject { presenter.previous_file_sets_id? expected_middle_id }
+        it 'returns true' do
+          expect(subject).to eq true
+        end
+      end
+
+      describe '#previous_file_sets_id' do
+        subject { presenter.previous_file_sets_id expected_middle_id }
+        it 'returns expected' do
+          expect(subject).to eq expected_middle_previous_id
+        end
+      end
+
+      describe '#next_file_sets_id?' do
+        subject { presenter.next_file_sets_id? expected_middle_id }
+        it 'returns true' do
+          expect(subject).to eq true
+        end
+      end
+
+      describe '#next_file_sets_id' do
+        subject { presenter.next_file_sets_id expected_middle_id }
+        it 'returns expected' do
+          expect(subject).to eq expected_middle_next_id
+        end
+      end
+    end
+
+    context 'expected last id' do
+      describe '#previous_file_sets_id?' do
+        subject { presenter.previous_file_sets_id? expected_last_id }
+        it 'returns true' do
+          expect(subject).to eq true
+        end
+      end
+
+      describe '#previous_file_sets_id' do
+        subject { presenter.previous_file_sets_id expected_last_id }
+        it 'returns expected' do
+          expect(subject).to eq expected_last_previous_id
+        end
+      end
+
+      describe '#next_file_sets_id?' do
+        subject { presenter.next_file_sets_id? expected_last_id }
+        it 'returns false' do
+          expect(subject).to eq false
+        end
+      end
+
+      describe '#next_file_sets_id' do
+        subject { presenter.next_file_sets_id expected_last_id }
+        it 'returns nil' do
+          expect(subject).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
You can now navigate the monograph's assets (file_sets) from the asset page using previous and next navigation buttons in the order they appear in the monograph.