### PR TITLE
Resolves #560: Add google analytics pageviews to monographs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,10 @@
 /config/secrets.yml
 /config/database.yml
 /config/analytics.yml
+/config/analytics.yml.dev
 /config/curation_concerns.yml
+# Google Analytics access keys
+*.p12
 
 # Ignore Vagrant support files
 .vagrant
@@ -47,4 +50,3 @@
 
 # Ingnore import directory
 import/
-

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,3 +11,7 @@ Metrics/PerceivedComplexity:
   Exclude:
     - 'app/models/riiif/file.rb'
     - 'app/controllers/downloads_controller.rb'
+
+Style/RedundantReturn:
+  Exclude:
+    - 'app/presenters/concerns/analytics_presenter.rb'

--- a/app/models/pageview.rb
+++ b/app/models/pageview.rb
@@ -2,6 +2,5 @@ class Pageview
   extend Legato::Model
 
   metrics :pageviews
-  dimensions :date
-  filter :for_path, &->(path) { contains(:pagePath, path) }
+  dimensions :date, :pagePath
 end

--- a/app/presenters/concerns/analytics_presenter.rb
+++ b/app/presenters/concerns/analytics_presenter.rb
@@ -1,0 +1,42 @@
+module AnalyticsPresenter
+  extend ActiveSupport::Concern
+
+  def pageviews_by_path(path)
+    count = 0
+    profile = google_analytics_profile
+    if profile.present?
+      Pageview.results(profile).each do |entry|
+        count += entry[:pageviews].to_i if entry[:pagePath] == path
+      end
+    end
+    return count
+  end
+
+  def pageviews_by_ids(ids)
+    count = 0
+    profile = google_analytics_profile
+    if profile.present?
+      Pageview.results(profile).each do |entry|
+        ids.each do |id|
+          count += entry[:pageviews].to_i if entry[:pagePath].include? id
+        end
+      end
+    end
+    return count
+  end
+
+  def google_analytics_id
+    press = Press.find_by(subdomain: subdomain)
+    return press.google_analytics unless press.nil? || press.google_analytics.nil?
+    Rails.application.secrets.google_analytics_id
+  end
+
+  def google_analytics_profile
+    profile = AnalyticsService.profile(google_analytics_id)
+    unless profile
+      Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+      return []
+    end
+    return profile
+  end
+end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -1,6 +1,7 @@
 module CurationConcerns
   class FileSetPresenter
     include TitlePresenter
+    include AnalyticsPresenter
     include ModelProxy
     include PresentsAttributes
     include Rails.application.routes.url_helpers
@@ -126,25 +127,8 @@ module CurationConcerns
     end
 
     # Google Analytics
-    def google_analytics_id
-      press = Press.find_by(subdomain: subdomain)
-      return press.google_analytics unless press.nil? || press.google_analytics.nil?
-      Rails.application.secrets.google_analytics_id
-    end
-
-    def pageviews_by_date
-      profile = AnalyticsService.profile(google_analytics_id)
-      unless profile
-        Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
-        return []
-      end
-      Pageview.for_path(curation_concerns_file_set_path(id))
-              .results(profile)
-              .map(&:to_h)
-    end
-
     def pageviews
-      pageviews_by_date.map { |entry| entry[:pageviews].to_i }.inject(0) { |sum, x| sum + x }
+      pageviews_by_path(curation_concerns_file_set_path(id))
     end
 
     # Technical Metadata

--- a/app/presenters/curation_concerns/monograph_presenter.rb
+++ b/app/presenters/curation_concerns/monograph_presenter.rb
@@ -1,6 +1,7 @@
 module CurationConcerns
   class MonographPresenter < WorkShowPresenter
     include TitlePresenter
+    include AnalyticsPresenter
     include ActionView::Helpers::UrlHelper
 
     delegate :date_created, :date_modified, :date_uploaded,
@@ -61,6 +62,10 @@ module CurationConcerns
     def next_file_sets_id(file_sets_id)
       return nil unless next_file_sets_id? file_sets_id
       ordered_file_sets_ids[(ordered_file_sets_ids.find_index(file_sets_id) + 1)]
+    end
+
+    def pageviews
+      pageviews_by_ids(file_set_ids << id)
     end
 
     private

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -18,14 +18,19 @@
     <div class="monograph-cover">
       <%= render 'curation_concerns/base/representative_media', presenter: @monograph_presenter %>
     </div><!-- /.monograph-cover -->
+
     <div class="monograph-metadata">
       <h2><%= @monograph_presenter.title || '' %></h2>
       <% if can?(:edit, @monograph_presenter.id) %>
         <%= link_to "Manage Monograph and Files", main_app.monograph_show_path(@monograph_presenter.id), class: 'btn btn-primary', id: 'manage-monograph-button' %>
       <% end %>
       <h3><%= @monograph_presenter.creator_given_name.first %> <%= @monograph_presenter.creator_family_name.first %><%= contributors_string(@monograph_presenter.contributor) %></h3>
+
       <div class="description">
         <%= render_markdown @monograph_presenter.description.first || '' %>
+      </div>
+      <div>
+        <p>This item has been viewed <b><%= @monograph_presenter.pageviews %></b> times.</p>
       </div>
       <div><p></p></div>
       <div class="isbn">
@@ -59,6 +64,7 @@
         </div>
       </div>
       <% end %>
+
     </div><!-- /.monograph-metadata -->
   </div><!-- /.monograph-info -->
   <hr>

--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -121,8 +121,8 @@ feature 'Create a file set' do
       expect(page).to have_link("screenshot", href: "/concern/monographs/" + Monograph.first.id + "?f%5Bcontent_type_tesim%5D%5B%5D=screenshot")
 
       # check external autolink are opening in a new tab and internal are not
-      find_link('external link')[:target].should eq('_blank')
-      find_link('internal link')[:target].should eq(nil)
+      expect(find_link('external link')[:target]).to eq '_blank'
+      expect(find_link('internal link')[:target]).to be nil
     end
   end
 end

--- a/spec/models/pageview_spec.rb
+++ b/spec/models/pageview_spec.rb
@@ -5,11 +5,7 @@ describe Pageview, type: :model do
     expect(described_class.metrics).to be == Legato::ListParameter.new(:metrics, [:pageviews])
   end
 
-  it 'has a date dimension' do
-    expect(described_class.dimensions).to be == Legato::ListParameter.new(:dimensions, [:date])
-  end
-
-  it 'responds to :for_path' do
-    expect(described_class).to respond_to(:for_path)
+  it 'has a date and pagePath dimension' do
+    expect(described_class.dimensions).to be == Legato::ListParameter.new(:dimensions, [:date, :pagePath])
   end
 end

--- a/spec/presenters/concerns/analytics_presenter_spec.rb
+++ b/spec/presenters/concerns/analytics_presenter_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe AnalyticsPresenter do
+  let(:ability) { double('ability') }
+  let(:presenter) { CurationConcerns::FileSetPresenter.new(fileset_doc, ability) }
+  let(:press) { create(:press, subdomain: 'blue', google_analytics: 'UA-THINGS') }
+  let(:fileset_doc) { SolrDocument.new(id: 'fs') }
+
+  describe "#google_analytics_id" do
+    context "when the press has a google analytics id" do
+      let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
+      it "returns the press google analytics id" do
+        expect(presenter.google_analytics_id).to eq press.google_analytics
+      end
+    end
+    context "when the press has no google analytics id, but there's a fulcrum id" do
+      it "returns the fulcrum google analytics id" do
+        Rails.application.secrets.google_analytics_id = 'UA-YES'
+        expect(presenter.google_analytics_id).to eq 'UA-YES'
+      end
+    end
+    context "when the press has no google analytics id and no fulcrum id" do
+      it "returns nil" do
+        Rails.application.secrets.delete :google_analytics_id
+        expect(presenter.google_analytics_id).to be nil
+      end
+    end
+  end
+
+  describe "#google_analytics_profile" do
+    context "when there is a valid profile" do
+      it "returns the profile" do
+        allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
+        expect(presenter.google_analytics_profile).to be_a Legato::Management::Profile
+      end
+    end
+    context "when there is not a valid profile" do
+      it "returns []" do
+        allow(AnalyticsService).to receive(:profile).and_return(nil)
+        expect(presenter.google_analytics_profile).to eq []
+      end
+    end
+  end
+
+  describe "#pageviews_by_path" do
+    it "returns the correct number of pageviews" do
+      allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
+      allow(Pageview).to receive(:results).and_return(
+        [
+          OpenStruct.new(date: "20161022", pagePath: "/concern/thing", pageviews: "2"),
+          OpenStruct.new(date: "20161111", pagePath: "/concern/stuff", pageviews: "9"),
+          OpenStruct.new(date: "20160909", pagePath: "/concern/other", pageviews: "3"),
+          OpenStruct.new(date: "20160910", pagePath: "/concern/thing", pageviews: "5")
+        ]
+      )
+      expect(presenter.pageviews_by_path("/concern/thing")).to eq 7
+    end
+  end
+
+  describe "#pageviews_by_ids" do
+    it "returns the correct number of pageviews" do
+      allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
+      allow(Pageview).to receive(:results).and_return(
+        [
+          OpenStruct.new(date: "20161022", pagePath: "/concern/A", pageviews: "2"),
+          OpenStruct.new(date: "20161111", pagePath: "/concern/B", pageviews: "9"),
+          OpenStruct.new(date: "20160909", pagePath: "/concern/C", pageviews: "3"),
+          OpenStruct.new(date: "20160910", pagePath: "/concern/D", pageviews: "5")
+        ]
+      )
+      expect(presenter.pageviews_by_ids(['A', 'C', 'D'])).to eq 10
+    end
+  end
+end

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -5,7 +5,7 @@ describe CurationConcerns::FileSetPresenter do
   let(:presenter) { described_class.new(fileset_doc, ability) }
   let(:monograph) { create(:monograph, creator_given_name: "firstname", creator_family_name: "lastname") }
   let(:file_set) { create(:file_set) }
-  let(:press) { create(:press, subdomain: 'blue', google_analytics: 'UA-THINGS') }
+  let(:press) { create(:press, subdomain: 'blue') }
   before do
     monograph.ordered_members << file_set
     monograph.save!
@@ -47,45 +47,6 @@ describe CurationConcerns::FileSetPresenter do
     let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
     it "returns the press subdomain" do
       expect(presenter.subdomain).to eq press.subdomain
-    end
-  end
-
-  describe "#google_analytics_id" do
-    context "when the press has a google analytics id" do
-      let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
-      it "returns the press google analytics id" do
-        expect(presenter.google_analytics_id).to eq press.google_analytics
-      end
-    end
-    context "when the press has no google analytics id, but there's a fulcrum id" do
-      let(:fileset_doc) { SolrDocument.new(id: 'fs') }
-      it "returns the fulcrum google analytics id" do
-        Rails.application.secrets.google_analytics_id = 'UA-YES'
-        expect(presenter.google_analytics_id).to eq 'UA-YES'
-      end
-    end
-    context "when the press has no google analytics id and no fulcrum id" do
-      let(:fileset_doc) { SolrDocument.new(id: 'fs') }
-      it "returns nil" do
-        Rails.application.secrets.delete :google_analytics_id
-        expect(presenter.google_analytics_id).to be nil
-      end
-    end
-  end
-
-  describe "#pageviews" do
-    let(:fileset_doc) { SolrDocument.new(id: 'fs') }
-    before do
-      allow(presenter).to receive(:pageviews_by_date).and_return(
-        [
-          { date: "20161003", pageviews: "5" },
-          { date: "20161004", pageviews: "1" },
-          { date: "20161005", pageviews: "2" }
-        ]
-      )
-    end
-    it "has the correct number of pageviews" do
-      expect(presenter.pageviews).to eq 8
     end
   end
 end


### PR DESCRIPTION
Monograph pageviews include views of the monograph, any of the
monograph's file_sets and any searches of file_sets.

This has been tested in preview with live GA data and looks ok.