### PR TITLE
enable a press to have customized text displayed in the footer

### DIFF
--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -39,12 +39,12 @@ footer.press {
     padding-bottom: 99999px;
   }
 
-  .social {
+  .press-block-a {
     padding-left: 30px;
   }
 
-  .social,
-  .footer-nav {
+  .press-block-a,
+  .press-block-b {
     padding-top: 30px;
     background-color: #171717;
   }
@@ -54,7 +54,7 @@ footer.press {
     color: #BABABA;
   }
 
-  .copyright {
+  .press-block-c {
     background-color: #000;
     padding: 10px;
 
@@ -153,7 +153,7 @@ footer.press {
   .view-icon-gallery {
     &:before { content: "\e011"; }
   }
-  
+
   #documents.gallery {
     display: -webkit-box;
     display: -moz-box;

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -1,5 +1,5 @@
-// Press themes are collected here
-
+// Press Themes are collected here to override
+// base classes set in heliotrope.scss
 ///////////////////////////////////////////////
 //
 // University of Minnesota Press
@@ -180,8 +180,8 @@ $umn-white: #fff;
     a:active {
       color: $umn-white;
     }
-    .social,
-    .footer-nav {
+    .press-block-a,
+    .press-block-b {
       background-color:  $umn-grey;
 
       .crop {
@@ -207,7 +207,7 @@ $umn-white: #fff;
       }
 
     }
-    .copyright {
+    .press-block-c {
       background-color: $umn-brand-color;
     }
     .platform {
@@ -421,15 +421,15 @@ $fulcrum-light-2: #bec4cc;
     a:active {
       color: $nw-white;
     }
-    .social,
-    .footer-nav {
+    .press-block-a,
+    .press-block-b {
       background-color: $nw-purple-60;
       img {
         width: 50px;
       }
 
     }
-    .copyright {
+    .press-block-c {
       background-color: $nw-brand-color;
     }
     .platform {
@@ -665,8 +665,8 @@ $psu-jumbotron: #efefef;
 
 
 
-    .social,
-    .footer-nav {
+    .press-block-a,
+    .press-block-b {
       background-color: $psu-brand-color-alt;
 
       .crop {
@@ -698,7 +698,7 @@ $psu-jumbotron: #efefef;
       }
 
     }
-    .copyright {
+    .press-block-c {
       background-color: $psu-brand-color;
     }
     // .platform {

--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -10,6 +10,31 @@ module PressHelper
     end
   end
 
+  def name(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.name if press.present?
+  end
+
+  def logo(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.logo_path if press.present?
+  end
+
+  def footer_block_a(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.footer_block_a if press.present?
+  end
+
+  def footer_block_c(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.footer_block_c if press.present?
+  end
+
+  def url(subdomain)
+    press = Press.where(subdomain: subdomain).first
+    press.press_url if press.present?
+  end
+
   def google_analytics(subdomain)
     press = Press.where(subdomain: subdomain).first
     press.google_analytics if press.present?

--- a/app/views/shared/_brand_fulcrum_footer_block.html.erb
+++ b/app/views/shared/_brand_fulcrum_footer_block.html.erb
@@ -1,0 +1,11 @@
+<div class="col-sm-4 platform col">
+  <p>Powered by <a href="/" title="Fulcrum" data-turbolinks="false"><%= image_tag "fulcrum-white-50px.png", class: 'logo', alt: 'Fulcrum Beta logo' %></a> <a class="beta" href="/beta" title="Fulcrum Beta information" data-turbolinks="false">beta</a></p>
+  <ul class="list-unstyled">
+    <!-- <li><a href="#">Help</a></li> -->
+    <li><a href="/about/" data-turbolinks="false">About</a></li>
+    <li><a href="/blog/" data-turbolinks="false">Blog</a></li>
+    <li><a href="mailto:fulcrum-info@umich.edu">Contact</a></li>
+    <li><a href="https://github.com/mlibrary/heliotrope">Contribute</a></li>
+    <li><% if current_user %> <%= link_to 'Log Out', main_app.destroy_user_session_path, class: 'log-out', role: 'menuitem' %> <% else %> <%= link_to 'Log In', main_app.new_user_session_path, class: 'login', role: 'menuitem' %> <% end %></li>
+  </ul>
+</div>

--- a/app/views/shared/_brand_press_footer.html.erb
+++ b/app/views/shared/_brand_press_footer.html.erb
@@ -1,67 +1,16 @@
 <footer class="press">
   <div class="container-fluid">
     <div class="row col-wrap">
-      <div class="col-sm-4 social col">
-        <div class="crop">
-          <% if defined?(@press.logo_path) %>
-            <%= image_tag @press.logo_path, alt: @press.name, class: 'img-responsive' %><br /><br />
-          <% elsif defined?(@monograph_presenter.press_logo) %>
-            <%= image_tag @monograph_presenter.press_logo, alt: @monograph_presenter.press, class: 'img-responsive' %><br /><br />
-          <% elsif defined?(@presenter.monograph.press_logo) %>
-            <%= image_tag @presenter.monograph.press_logo, alt: @presenter.monograph.press, class: 'img-responsive' %><br /><br />
-          <% end %>
-        </div>
-        <p>
-          <% if defined?(@press.press_url) %>
-            <a class="brand" href="<%= @press.press_url %>"><%= @press.name %></a>
-          <% elsif defined?(@monograph_presenter.press_url) %>
-            <a class="brand" href="<%= @monograph_presenter.press_url %>"><%= @monograph_presenter.press %></a>
-          <% elsif defined?(@presenter.monograph.press_url) %>
-            <a class="brand" href="<%= @presenter.monograph.press_url %>"><%= @presenter.monograph.press %></a>
-          <% else %>
-            <a class="brand" href="#" >University Press</a>
-          <% end %>
-        </p>
-        <!-- <ul class="list-inline">
-          <li><a href="#">FB</a></li>
-          <li><a href="#">I</a></li>
-          <li><a href="#">T</a></li>
-          <li><a href="#">YT</a></li>
-        </ul> -->
-      </div>
-      <div class="col-sm-4 footer-nav col">
-        <!-- <ul class="list-unstyled">
-          <li><a href="#">Home</a></li>
-          <li><a href="#">Search</a></li>
-          <li><a href="#">Browse All Books</a></li>
-          <li><a href="#">Browse All Book Materials</a></li>
-          <li><a href="#">About</a></li>
-        </ul> -->
-      </div>
-      <div class="col-sm-4 platform col">
-        <p>Powered by <a href="/" title="Fulcrum" data-turbolinks="false"><%= image_tag "fulcrum-white-50px.png", class: 'logo', alt: 'Fulcrum Beta logo' %></a> <a class="beta" href="/beta" title="Fulcrum Beta information" data-turbolinks="false">beta</a></p>
-        <ul class="list-unstyled">
-          <!-- <li><a href="#">Help</a></li> -->
-          <li><a href="/about/" data-turbolinks="false">About</a></li>
-          <li><a href="/blog/" data-turbolinks="false">Blog</a></li>
-          <li><a href="mailto:fulcrum-info@umich.edu">Contact</a></li>
-          <li><a href="https://github.com/mlibrary/heliotrope">Contribute</a></li>
-          <li><% if current_user %> <%= link_to 'Log Out', main_app.destroy_user_session_path, class: 'log-out', role: 'menuitem' %> <% else %> <%= link_to 'Log In', main_app.new_user_session_path, class: 'login', role: 'menuitem' %> <% end %></li>
-        </ul>
-      </div>
+
+      <%= render 'shared/brand_press_footer_block_a' %>
+
+      <%= render 'shared/brand_press_footer_block_b' %>
+
+      <%= render 'shared/brand_fulcrum_footer_block' %>
+
     </div>
-    <div class="row copyright">
-      <div class="col-sm-12">
-        <% if defined?(@press.name) %>
-          <p>&copy; <%= @press.name %> 2016</p>
-        <% elsif defined?(@monograph_presenter.press) %>
-          <p>&copy; <%= @monograph_presenter.press %> 2016</p>
-        <% elsif defined?(@presenter.monograph.press) %>
-          <p>&copy; <%= @presenter.monograph.press %> 2016</p>
-        <% else %>
-          <p>&copy; University Press 2016</p>
-        <% end %>
-      </div>
+    <div class="row press-block-c">
+      <%= render 'shared/brand_press_footer_block_c' %>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_brand_press_footer_block_a.html.erb
+++ b/app/views/shared/_brand_press_footer_block_a.html.erb
@@ -1,0 +1,18 @@
+<div class="col-sm-4 press-block-a col">
+  <% if footer_block_a(press_subdomain) %>
+    <p><%= render_markdown footer_block_a(press_subdomain) %></p>
+  <% else %>
+    <div class="crop">
+      <%= image_tag logo(press_subdomain), alt: name(press_subdomain), class: 'img-responsive' %><br /><br />
+    </div>
+    <p>
+      <a class="brand" href="<%= url(press_subdomain) %>"><%= name(press_subdomain) %></a>
+    </p>
+  <% end %>
+  <!-- <ul class="list-inline">
+    <li><a href="#">FB</a></li>
+    <li><a href="#">I</a></li>
+    <li><a href="#">T</a></li>
+    <li><a href="#">YT</a></li>
+  </ul> -->
+</div>

--- a/app/views/shared/_brand_press_footer_block_b.html.erb
+++ b/app/views/shared/_brand_press_footer_block_b.html.erb
@@ -1,0 +1,9 @@
+<div class="col-sm-4 press-block-b col">
+  <!-- <ul class="list-unstyled">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Search</a></li>
+    <li><a href="#">Browse All Books</a></li>
+    <li><a href="#">Browse All Book Materials</a></li>
+    <li><a href="#">About</a></li>
+  </ul> -->
+</div>

--- a/app/views/shared/_brand_press_footer_block_c.html.erb
+++ b/app/views/shared/_brand_press_footer_block_c.html.erb
@@ -1,0 +1,7 @@
+<div class="col-sm-12">
+  <% if footer_block_c(press_subdomain) %>
+    <p><%= render_markdown footer_block_c(press_subdomain) %></p>
+  <% else %>
+    <p>&copy; <%= name(press_subdomain) %> 2016</p>
+  <% end %>
+</div>

--- a/db/migrate/20161111093512_add_footer_blocks_to_presses.rb
+++ b/db/migrate/20161111093512_add_footer_blocks_to_presses.rb
@@ -1,0 +1,7 @@
+#Add footer_block_a and footer_block_c to presses db
+class AddFooterBlocksToPresses < ActiveRecord::Migration
+  def change
+    add_column(:presses, :footer_block_a, :text)
+    add_column(:presses, :footer_block_c, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830143512) do
+ActiveRecord::Schema.define(version: 20161111093512) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -70,6 +70,8 @@ ActiveRecord::Schema.define(version: 20160830143512) do
     t.string   "press_url"
     t.string   "google_analytics"
     t.string   "typekit"
+    t.text     "footer_block_a"
+    t.text     "footer_block_c"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,8 @@ def pennstate
   Press.where(name: 'Penn State University Press').first_or_initialize.tap do |press|
     press.logo_path = 'http://www.psupress.org/site_images/logo_psupress.gif'
     press.description = 'The Penn State University Press publishes academic books and journals, especially art history, philosophy, literature, religion, and political science. This page is the home of supplemental content for select Penn State University Press books. You can find the full catalog of Penn State titles on the [publisher\'s website](http://www.psupress.org/).'
+    press.footer_block_a = '© Penn State University 2016'
+    press.footer_block_c = 'http://www.psupress.org'
     press.subdomain = 'pennstate'
     press.press_url = 'http://www.psupress.org'
     press.typekit = 'cbh1mev'


### PR DESCRIPTION
Resolves #594 

adds new fields to the presses database to input customized text (supports markdown) that is rendered in the footer if defined; abstracts out the footer into separate content blocks and renames css styles to reflect that renaming; adds presses database fields to press helper to make accessing these values easier in partials; 

will need to run `bundle exec rake db:migrate` and `bundle exec rake db:seed` to see changes in local and deployed instances.