### PR TITLE
Imported monographs are editable by press/platform admins

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,7 +11,7 @@ class Ability
     can :manage, Role, resource_id: @user.admin_roles.pluck(:resource_id), resource_type: 'Press'
 
     # monograph.press is a String (the subdomain of a Press)
-    can :create, Monograph do |m|
+    can [:create, :update], Monograph do |m|
       @user.admin_presses.map(&:subdomain).include?(m.press)
     end
 
@@ -21,6 +21,19 @@ class Ability
 
     can :update, Press do |p|
       admin_for?(p)
+    end
+
+    # For the different view presenters
+    can :update, CurationConcerns::MonographPresenter do |p|
+      @user.admin_presses.map(&:subdomain).include?(p.subdomain)
+    end
+
+    can :update, CurationConcerns::FileSetPresenter do |p|
+      @user.admin_presses.map(&:subdomain).include?(p.monograph.subdomain)
+    end
+
+    can :update, CurationConcerns::SectionPresenter do |p|
+      @user.admin_presses.map(&:subdomain).include?(p.monograph.subdomain)
     end
 
     grant_platform_admin_abilities

--- a/app/presenters/curation_concerns/section_presenter.rb
+++ b/app/presenters/curation_concerns/section_presenter.rb
@@ -2,6 +2,16 @@ module CurationConcerns
   class SectionPresenter < WorkShowPresenter
     include TitlePresenter
 
+    attr_accessor :monograph_presenter
+
+    def monograph_id
+      Array(solr_document['monograph_id_ssim']).first
+    end
+
+    def monograph
+      @monograph_presenter ||= PresenterFactory.build_presenters([monograph_id], MonographPresenter, current_ability).first
+    end
+
     def monograph_label
       member_of.first.fetch('title_tesim', []).first
     end

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -1,10 +1,10 @@
 <div class="form-actions">
-  <% if can? :edit, presenter.id %>
+  <% if can? :edit, presenter %>
     <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default btn-lg'  %>
     <!-- TODO: remove the following button, it will be replaced by breadcrumbs -->
     <%= link_to "Back to #{parent.human_readable_type}", parent_path(parent), class: 'btn btn-default btn-lg' %>
   <% end %>
-  <% if  can? :edit, presenter.id || presenter.allow_download?  %>
+  <% if  can? :edit, presenter || presenter.allow_download?  %>
     <%= link_to "Download", main_app.download_path(presenter), class: 'btn btn-default btn-lg' %>
   <% end %>
   <!-- TODO: add citation generator -->

--- a/app/views/curation_concerns/monographs/show.html.erb
+++ b/app/views/curation_concerns/monographs/show.html.erb
@@ -3,8 +3,8 @@
   <h1><%= @presenter.title %> <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span></h1>
 <% end %>
 
-<% collector = can?(:collect, @presenter.id) %>
-<% editor    = can?(:edit,    @presenter.id) %>
+<% collector = can?(:collect, @presenter) %>
+<% editor    = can?(:edit,    @presenter) %>
 
 <%= render 'representative_media', presenter: @presenter %>
 <%= render 'sub_brands', presenter: @presenter %>

--- a/app/views/curation_concerns/sections/show.html.erb
+++ b/app/views/curation_concerns/sections/show.html.erb
@@ -11,8 +11,8 @@
   <% end %>
 <% end %>
 
-<% collector = can?(:collect, @presenter.id) %>
-<% editor    = can?(:edit,    @presenter.id) %>
+<% collector = can?(:collect, @presenter) %>
+<% editor    = can?(:edit,    @presenter) %>
 
 <%= render 'representative_media', presenter: @presenter %>
 <%= render "attributes", presenter: @presenter %>

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -21,7 +21,7 @@
 
     <div class="monograph-metadata">
       <h2><%= @monograph_presenter.title || '' %></h2>
-      <% if can?(:edit, @monograph_presenter.id) %>
+      <% if can? :edit, @monograph_presenter %>
         <%= link_to "Manage Monograph and Files", main_app.monograph_show_path(@monograph_presenter.id), class: 'btn btn-primary', id: 'manage-monograph-button' %>
       <% end %>
       <h3><%= @monograph_presenter.creator_given_name.first %> <%= @monograph_presenter.creator_family_name.first %><%= contributors_string(@monograph_presenter.contributor) %></h3>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,5 +1,3 @@
-  <%= render 'shared/press_branding' %>
-
   <h2>Manage user permissions</h2>
   <%= form_for @press, url: update_all_press_roles_path(@press) do |f| %>
     <table class="table table-striped users">

--- a/spec/features/show_section_spec.rb
+++ b/spec/features/show_section_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 feature 'Display a section' do
   let(:user) { create(:user) }
   let!(:monograph) { create(:monograph, user: user) }
-  let!(:ch2) { create(:section, title: ['Chapter 2'], user: user) }
-  let!(:ch1) { create(:section, title: ['Chapter 1'], user: user) }
+  let!(:ch2) { create(:section, title: ['Chapter 2'], user: user, monograph_id: monograph.id) }
+  let!(:ch1) { create(:section, title: ['Chapter 1'], user: user, monograph_id: monograph.id) }
 
   let(:admin_user) { create(:platform_admin) }
   let!(:unauthorized_section) { create(:section, user: admin_user) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,12 +11,25 @@ describe Ability do
   let(:section) { create(:section, user: creating_user) }
   let(:file_set) { create(:file_set, user: creating_user) }
 
+  let(:monograph_presenter) do
+    CurationConcerns::MonographPresenter.new(SolrDocument.new(id: monograph.id, press_tesim: press.subdomain), described_class.new(creating_user))
+  end
+  let(:section_presenter) do
+    CurationConcerns::SectionPresenter.new(SolrDocument.new(id: section.id, monograph_id_ssim: monograph.id), described_class.new(creating_user))
+  end
+  let(:file_set_presenter) do
+    CurationConcerns::FileSetPresenter.new(SolrDocument.new(id: file_set.id, monograph_id_ssim: monograph.id), described_class.new(creating_user))
+  end
+
   describe 'a platform-wide admin user' do
     let(:creating_user) { current_user }
     let(:current_user) { create(:platform_admin) }
     let(:role) { create(:role) }
     let(:another_user) { create(:user) }
     let(:another_user_monograph) { create(:monograph, user: another_user, press: press.subdomain) }
+    let(:another_user_monograph_presenter) do
+      CurationConcerns::MonographPresenter.new(SolrDocument.new(id: another_user_monograph.id, press_tesim: press.subdomain), described_class.new(another_user))
+    end
 
     it do
       should be_able_to(:create, Monograph.new)
@@ -24,16 +37,19 @@ describe Ability do
       should be_able_to(:read, monograph)
       should be_able_to(:update, monograph)
       should be_able_to(:destroy, monograph)
+      should be_able_to(:update, monograph_presenter)
 
       should be_able_to(:create, Section.new)
       should be_able_to(:read, section)
       should be_able_to(:update, section)
       should be_able_to(:destroy, section)
+      should be_able_to(:update, section_presenter)
 
       should be_able_to(:create, FileSet.new)
       should be_able_to(:read, file_set)
       should be_able_to(:update, file_set)
       should be_able_to(:destroy, file_set)
+      should be_able_to(:update, file_set_presenter)
 
       should be_able_to(:read, role)
       should be_able_to(:update, role)
@@ -48,6 +64,7 @@ describe Ability do
       should be_able_to(:update, another_user_monograph)
       should be_able_to(:publish, another_user_monograph)
       should be_able_to(:destroy, another_user_monograph)
+      should be_able_to(:update, another_user_monograph_presenter)
     end
   end
 
@@ -86,8 +103,17 @@ describe Ability do
 
       it do
         should be_able_to(:create, monograph_for_my_press)
-
         should_not be_able_to(:create, monograph_for_other_press)
+      end
+    end
+
+    context "updating" do
+      let(:my_presenter) { CurationConcerns::MonographPresenter.new(SolrDocument.new(id: 'my_id', press_tesim: my_press.subdomain), subject) }
+      let(:other_presenter) { CurationConcerns::MonographPresenter.new(SolrDocument.new(id: 'other_id', press_tesim: other_press.subdomain), subject) }
+
+      it do
+        should be_able_to(:update, my_presenter)
+        should_not be_able_to(:update, other_presenter)
       end
     end
   end

--- a/spec/presenters/curation_concerns/section_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/section_presenter_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe CurationConcerns::SectionPresenter do
   let(:ability) { nil }
+  let(:press) { create(:press) }
+  let(:monograph) { create(:monograph, press: press.subdomain) }
 
   it 'includes TitlePresenter' do
     expect(described_class.new(nil, nil)).to be_a TitlePresenter
@@ -14,7 +16,7 @@ describe CurationConcerns::SectionPresenter do
         "title_tesim" => ["foo bar"],
         "human_readable_type_tesim" => ["Section"],
         "has_model_ssim" => ["Section"],
-        "monograph_id_ssim" => "dr26xx448"
+        "monograph_id_ssim" => monograph.id
       }
     end
     let(:presenter) { described_class.new(solr_document, ability) }
@@ -36,6 +38,13 @@ describe CurationConcerns::SectionPresenter do
 
     it "returns a FileSetPresenter" do
       expect(presenter.representative_presenter.class).to eq CurationConcerns::FileSetPresenter
+    end
+  end
+
+  describe "#monograph" do
+    let(:presenter) { described_class.new(SolrDocument.new(id: 'section_id', monograph_id_ssim: monograph.id), ability) }
+    it "returns a MonographPresenters" do
+      expect(presenter.monograph.class).to eq CurationConcerns::MonographPresenter
     end
   end
 end


### PR DESCRIPTION
Resolves #322

Monograph edit buttons are available to press/platform admin

Resolves #181

Also made sure edit buttons are available for sections and file_sets.
Right now only press/platform admins can see/use them.

Press Admins can only create or update Monographs (not sections, file_sets).
We'll need to add some more stories about specific Press Admin permissions
for sections and file_sets.