### PR TITLE
We're hitting GA quota limits on monograph_catalog pages.

### DIFF
--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -29,9 +29,12 @@
       <div class="description">
         <%= render_markdown @monograph_presenter.description.first || '' %>
       </div>
+      <% pageviews = @monograph_presenter.pageviews %>
+      <% unless pageviews.nil? %>
       <div>
-        <p>This item has been viewed <b><%= @monograph_presenter.pageviews %></b> times.</p>
+        <p>This item has been viewed <b><%= pageviews %></b> times.</p>
       </div>
+      <% end %>
       <div><p></p></div>
       <div class="isbn">
         <% if defined?(@monograph_presenter.isbn) %>


### PR DESCRIPTION
Should have seen this coming. We need to come up with a way to cache GA pageview (and other) stats.

This PR checks if we've hit the GA quota (it just catches the exception actually) for monograph_catalog and file_set pageview and creates a log entry if we're over the limit:

`E, [2016-11-17T11:13:07.463486 #6259] ERROR -- : Quota Error: profileId ga:126363248 has exceeded the daily request limit.`

On the monograph_catalog page, no pageview info is shown. On the file_set stats tab pageview shows as 0, although we haven't seen any quota problems with file_sets yet so it might not happen

We need to make a new story or two to come up with a better more sustainable way to show GA stats.