### PR TITLE
comment out monograph pageview

### DIFF
--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -29,7 +29,7 @@
       <div class="description">
         <%= render_markdown @monograph_presenter.description.first || '' %>
       </div>
-      <% pageviews = @monograph_presenter.pageviews %>
+      <% pageviews = nil #@monograph_presenter.pageviews %>
       <% unless pageviews.nil? %>
       <div>
         <p>This item has been viewed <b><%= pageviews %></b> times.</p>


### PR DESCRIPTION
Until we figure out what is causing the monograph pageview stat to make so many requests that we're consistently over the GA quota, comment it out. Obviously something is wrong.