### PR TITLE
Revert "Revert "clean repo between each spec""

### DIFF
--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 describe CurationConcerns::Actors::SectionActor do
-  before do
-    Section.destroy_all
-    Monograph.destroy_all
-  end
-
   let(:user) { create(:user) }
   let(:list_of_actors) { [described_class] }
   let(:actor) { CurationConcerns::Actors::ActorStack.new(curation_concern, user, list_of_actors) }

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 feature 'Catalog search' do
-  before do
-    Monograph.destroy_all
-  end
-
   context 'a user who is not logged in' do
     let!(:private_monograph) { create(:private_monograph) }
     let!(:public_monograph) { create(:public_monograph) }

--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 feature 'Create a file set' do
-  before do
-    FileSet.destroy_all
-    Section.destroy_all
-    Monograph.destroy_all
-  end
-
   context 'as a logged in user' do
     let(:user) { create(:platform_admin) }
     let!(:press) { create(:press) }

--- a/spec/features/create_section_spec.rb
+++ b/spec/features/create_section_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 feature 'Create a section' do
   context 'a logged in user' do
-    before do
-      Section.destroy_all
-      Monograph.destroy_all
-    end
     let(:user) { create(:platform_admin) }
     let!(:monograph) { create(:monograph, user: user) }
     before do

--- a/spec/features/edit_section_spec.rb
+++ b/spec/features/edit_section_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 feature 'Edit a section' do
   context 'a logged in user' do
-    before do
-      Section.destroy_all
-      Monograph.destroy_all
-    end
     let(:user) { create(:platform_admin) }
     let!(:monograph1) { create(:monograph, user: user) }
     let!(:monograph2) { create(:monograph, user: user) }

--- a/spec/features/monograph_catalog_facets_spec.rb
+++ b/spec/features/monograph_catalog_facets_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 feature "Monograph Catalog Facets" do
-  before do
-    FileSet.destroy_all
-    Section.destroy_all
-    Monograph.destroy_all
-  end
-
   context "keywords" do
     let(:user) { create(:platform_admin) }
     let(:monograph) { create(:monograph, user: user, title: ["Yellow"], representative_id: cover.id) }

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -8,8 +8,6 @@ feature 'Press Catalog' do
 
   context 'a user who is not logged in' do
     context 'with monographs for different presses' do
-      before { Monograph.destroy_all }
-
       let!(:red) { create(:public_monograph, title: ['The Red Book'], press: umich.subdomain) }
       let!(:blue) { create(:public_monograph, title: ['The Blue Book'], press: umich.subdomain) }
       let!(:colors) { create(:public_monograph, title: ['Red and Blue are Colors'], press: psu.subdomain) }
@@ -57,7 +55,6 @@ feature 'Press Catalog' do
       end
     end
     context 'with with a monograph with multiple authors' do
-      before { Monograph.destroy_all }
       let!(:monograph) { create(:public_monograph, title: ['The Two Authors\' Book'], creator_family_name: 'Johns', creator_given_name: 'Jimmy', contributor: ['Sub Way'], press: umich.subdomain) }
 
       scenario 'Sees multiple author names on the press catalog page' do

--- a/spec/lib/import/importer_spec.rb
+++ b/spec/lib/import/importer_spec.rb
@@ -40,9 +40,6 @@ describe Import::Importer do
   describe '#run' do
     before do
       stub_out_redis
-      Monograph.destroy_all
-      Section.destroy_all
-      FileSet.destroy_all
     end
 
     context 'when the importer runs successfully' do

--- a/spec/lib/import/monograph_builder_spec.rb
+++ b/spec/lib/import/monograph_builder_spec.rb
@@ -31,7 +31,6 @@ describe Import::MonographBuilder do
 
   describe '#run' do
     before do
-      Monograph.destroy_all
       stub_out_redis
     end
 

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -7,10 +7,6 @@ describe FileSet do
   let(:search_year) { '2014' }
   let(:bad_search_year) { 'YEAR' }
 
-  before do
-    described_class.destroy_all
-  end
-
   it 'has a valid sort_date' do
     file_set.sort_date = sort_date
     file_set.apply_depositor_metadata('admin@example.com')

--- a/spec/models/monograph_spec.rb
+++ b/spec/models/monograph_spec.rb
@@ -8,11 +8,6 @@ describe Monograph do
   let(:imprint) { create(:sub_brand, title: 'UM Press Literary Classics') }
   let(:series) { create(:sub_brand, title: "W. Shakespeare Collector's Series") }
 
-  before do
-    Section.destroy_all
-    described_class.destroy_all
-  end
-
   it "has date_published" do
     monograph.date_published = [date]
     expect(monograph.date_published).to eq [date]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,12 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'active_fedora/cleaner'
+
 RSpec.configure do |config|
+  config.before :each do
+    ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count > 0
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Reverts mlibrary/heliotrope#632

I merged the original PR, then realized it broke my dev environment, reverted, then realized it was really all my fault. Sigh. So, here's an "unrevert" to fix the fix that was never broken...
