### PR TITLE
refactor width for video, images, audio elements

### DIFF
--- a/app/assets/stylesheets/heliotrope.scss
+++ b/app/assets/stylesheets/heliotrope.scss
@@ -278,7 +278,9 @@ footer.press {
 .asset {
 
   figure {
-    display: inline;
+    display: inline-block;
+    width: 97%;
+    height: auto;
     margin: initial;
   }
 
@@ -295,12 +297,18 @@ footer.press {
   // LEAFLET/IMAGES
   #image {
     height: 540px;
-    width: 97%;
+    width: 100% !important;
   }
 
   // VIDEO
   video {
-    width: 97%;
+    width: 100% !important;
+    height: auto !important;
+  }
+
+  // AUDIO
+  audio {
+    width: 100% !important;
   }
 
   // ASSET METADATA


### PR DESCRIPTION
When I looked at what I originally wrote I wasn't happy with it -- Ultimately this doesn't change much of anything with the display of a video or image, but follows "best practices" for responsive video by also setting the height on `video` elements and ensures that widths do not get overridden.  I've also applied this technique to audio players and adjusted how the surrounding `figure` container width and displays are set.