### PR TITLE
Resolves #599: Updating the file of an existing file_set should work …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,5 @@ group :development, :test do
   gem 'sqlite3'
   gem 'factory_girl_rails'
   gem 'capybara'
+  gem "fakefs", require: "fakefs/safe"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     factory_girl_rails (4.7.0)
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
+    fakefs (0.10.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.5.2)
@@ -613,6 +614,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   factory_girl_rails
+  fakefs
   fcrepo_wrapper (= 0.5.2)
   jbuilder (~> 2.0)
   jekyll

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,0 +1,28 @@
+class CharacterizeJob < ActiveJob::Base
+  queue_as CurationConcerns.config.ingest_queue_name
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the CurationConcerns.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+    raise LoadError, "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
+
+    # Override CC
+    # On file updates characterization seemingly adds new height/width to an existing original_file
+    # array in apparently random places... not in the beginning, not the end (usually!).
+    # I don't get it. Just reset them. We need accurate height/width for riiif and leaflet
+    file_set.original_file.height = []
+    file_set.original_file.width  = []
+    # Also in case of a file update, clear out the riiif cached base image if one exisits
+    cached_file = Rails.root.join('tmp', 'network_files', Digest::MD5.hexdigest(file_set.original_file.uri.to_s))
+    File.delete(cached_file) if File.exist?(cached_file)
+
+    Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
+    Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
+    file_set.characterization_proxy.save!
+    file_set.update_index
+    file_set.parent.in_collections.each(&:update_index) if file_set.parent
+    CreateDerivativesJob.perform_later(file_set, file_id, filename)
+  end
+end

--- a/config/initializers/riiif_initializer.rb
+++ b/config/initializers/riiif_initializer.rb
@@ -15,4 +15,14 @@ Riiif::Image.info_service = lambda do |id, _file|
   { height: doc["height_is"], width: doc["width_is"] }
 end
 
+module Riiif
+  def Image.cache_key(id, options)
+    # Add a timestamp to "expire" image tiles if a file_set is updated with a new image
+    options[:timestamp] = ActiveFedora::SolrService.query("{!terms f=id}#{id}").first["timestamp"]
+    str = options.merge(id: id).delete_if { |_, v| v.nil? }.to_s
+    # Use a MD5 digest to ensure the keys aren't too long.
+    Digest::MD5.hexdigest(str)
+  end
+end
+
 Riiif::Engine.config.cache_duration_in_days = 7

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  # The ::Collection model is defined in .internal_test_app/app/models by the
+  # curation_concerns:install generator.
+  factory :collection do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ['Test collection title']
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    trait :public do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
+# Since we lifted this out of CC 1.6.2, we'll need to run the tests too
+
+describe CharacterizeJob do
+  let(:file_set)    { FileSet.new(id: file_set_id) }
+  let(:file_set_id) { 'abc12345678' }
+  let(:file_path)   { Rails.root + 'tmp' + 'uploads' + 'ab' + 'c1' + '23' + '45' + 'picture.png' }
+  let(:filename)    { file_path.to_s }
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'picture.png'
+      f.height = '111'
+      f.width = '222'
+      f.save!
+    end
+  end
+
+  before do
+    allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
+    allow(file_set).to receive(:original_file).and_return(file)
+  end
+
+  context 'when the characterization proxy content is present' do
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(file).to receive(:save!)
+      expect(file_set).to receive(:update_index)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      described_class.perform_now(file_set, file.id)
+    end
+  end
+
+  context 'when the characterization proxy content is absent' do
+    before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
+    it 'raises an error' do
+      expect { described_class.perform_now(file_set, file.id) }.to raise_error(LoadError, 'original_file was not found')
+    end
+  end
+
+  context "when the file set's work is in a collection" do
+    let(:work)       { build(:monograph) }
+    let(:collection) { build(:collection) }
+    before do
+      allow(file_set).to receive(:parent).and_return(work)
+      allow(work).to receive(:in_collections).and_return([collection])
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(file).to receive(:save!)
+      allow(file_set).to receive(:update_index)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    end
+    it "reindexes the collection" do
+      expect(collection).to receive(:update_index)
+      described_class.perform_now(file_set, file.id)
+    end
+  end
+
+  context "when there's a file with preexisting height and width" do
+    it "resets the height and width" do
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(file).to receive(:save!)
+      allow(file_set).to receive(:update_index)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      described_class.perform_now(file_set, file.id)
+
+      expect(file_set.original_file.height).to eq []
+      expect(file_set.original_file.width).to eq []
+    end
+  end
+
+  context "when there's a preexisting IIIF cached file" do
+    include FakeFS::SpecHelpers
+    let(:cached_file) { Rails.root.join('tmp', 'network_files', Digest::MD5.hexdigest(file_set.original_file.uri.to_s)) }
+    it "deletes the cached file" do
+      FileUtils.mkdir_p Rails.root.join('tmp', 'network_files')
+      FileUtils.touch cached_file
+      expect(cached_file.exist?).to be true
+
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(file).to receive(:save!)
+      allow(file_set).to receive(:update_index)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      described_class.perform_now(file_set, file.id)
+
+      expect(cached_file.exist?).to be false
+    end
+  end
+end


### PR DESCRIPTION
…in riiif and leaflet

1) Override Riif::Image.cache_key to include the file_set's timestamp when caching image tiles.
If the file/image changes, then the old cache_keys will no longer work and new ones will be
generated. The cache is cleaned periodically via a rake task and cron to clean up these old
cache tiles.

2) When a file is characterized we need to delete riiif's cache of it in tmp/network_files. If it's a new file it won't have one and won't matter.