### PR TITLE
Resolves #634

### DIFF
--- a/app/presenters/concerns/analytics_presenter.rb
+++ b/app/presenters/concerns/analytics_presenter.rb
@@ -3,51 +3,27 @@ module AnalyticsPresenter
 
   def pageviews_by_path(path)
     count = 0
-    begin
-      profile = google_analytics_profile
-      if profile.present?
-        Pageview.results(profile).each do |entry|
-          count += entry[:pageviews].to_i if entry[:pagePath] == path
-        end
+    pageviews = Rails.cache.read('ga_pageviews')
+    return '?' if pageviews.nil?
+    if pageviews.is_a?(Array)
+      pageviews.each do |entry|
+        count += entry[:pageviews].to_i if entry[:pagePath] == path
       end
-    rescue OAuth2::Error => e
-      Rails.logger.error(e.code["message"])
     end
     return count
   end
 
   def pageviews_by_ids(ids)
     count = 0
-    begin
-      profile = google_analytics_profile
-      if profile.present?
-        Pageview.results(profile).each do |entry|
-          ids.each do |id|
-            count += entry[:pageviews].to_i if entry[:pagePath].include? id
-          end
+    pageviews = Rails.cache.read('ga_pageviews')
+    return '?' if pageviews.nil?
+    if pageviews.is_a?(Array)
+      pageviews.each do |entry|
+        ids.each do |id|
+          count += entry[:pageviews].to_i if entry[:pagePath].include? id
         end
       end
-    rescue OAuth2::Error => e
-      # TODO: we're hitting GA quotas for monograph_catalog pages in production.
-      # Need to figure out a better way to do this...
-      Rails.logger.error(e.code["message"])
-      return nil
     end
     return count
-  end
-
-  def google_analytics_id
-    press = Press.find_by(subdomain: subdomain)
-    return press.google_analytics unless press.nil? || press.google_analytics.nil?
-    Rails.application.secrets.google_analytics_id
-  end
-
-  def google_analytics_profile
-    profile = AnalyticsService.profile(google_analytics_id)
-    unless profile
-      Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
-      return []
-    end
-    return profile
   end
 end

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -29,7 +29,7 @@
       <div class="description">
         <%= render_markdown @monograph_presenter.description.first || '' %>
       </div>
-      <% pageviews = nil #@monograph_presenter.pageviews %>
+      <% pageviews = @monograph_presenter.pageviews %>
       <% unless pageviews.nil? %>
       <div>
         <p>This item has been viewed <b><%= pageviews %></b> times.</p>

--- a/lib/tasks/ga_cache.rake
+++ b/lib/tasks/ga_cache.rake
@@ -1,0 +1,23 @@
+desc "cache google analytics data"
+namespace :heliotrope do
+  task ga_cache: :environment do
+    cached = []
+    ga_id = Rails.application.secrets.google_analytics_id
+    if ga_id.present?
+      begin
+        profile = AnalyticsService.profile(ga_id)
+        if profile.present?
+          Pageview.results(profile).each do |entry|
+            cached << entry
+          end
+          Rails.cache.write('ga_pageviews', cached)
+          Rails.logger.debug("Wrote ga_pageviews to cache")
+        else
+          Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+        end
+      rescue OAuth2::Error => e
+        Rails.logger.error(e.code["message"])
+      end
+    end
+  end
+end

--- a/spec/presenters/concerns/analytics_presenter_spec.rb
+++ b/spec/presenters/concerns/analytics_presenter_spec.rb
@@ -3,72 +3,51 @@ require 'rails_helper'
 describe AnalyticsPresenter do
   let(:ability) { double('ability') }
   let(:presenter) { CurationConcerns::FileSetPresenter.new(fileset_doc, ability) }
-  let(:press) { create(:press, subdomain: 'blue', google_analytics: 'UA-THINGS') }
   let(:fileset_doc) { SolrDocument.new(id: 'fs') }
 
-  describe "#google_analytics_id" do
-    context "when the press has a google analytics id" do
-      let(:fileset_doc) { SolrDocument.new(id: 'fs', press_tesim: press.subdomain) }
-      it "returns the press google analytics id" do
-        expect(presenter.google_analytics_id).to eq press.google_analytics
-      end
-    end
-    context "when the press has no google analytics id, but there's a fulcrum id" do
-      it "returns the fulcrum google analytics id" do
-        Rails.application.secrets.google_analytics_id = 'UA-YES'
-        expect(presenter.google_analytics_id).to eq 'UA-YES'
-      end
-    end
-    context "when the press has no google analytics id and no fulcrum id" do
-      it "returns nil" do
-        Rails.application.secrets.delete :google_analytics_id
-        expect(presenter.google_analytics_id).to be nil
-      end
-    end
-  end
-
-  describe "#google_analytics_profile" do
-    context "when there is a valid profile" do
-      it "returns the profile" do
-        allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
-        expect(presenter.google_analytics_profile).to be_a Legato::Management::Profile
-      end
-    end
-    context "when there is not a valid profile" do
-      it "returns []" do
-        allow(AnalyticsService).to receive(:profile).and_return(nil)
-        expect(presenter.google_analytics_profile).to eq []
-      end
-    end
-  end
-
-  describe "#pageviews_by_path" do
-    it "returns the correct number of pageviews" do
-      allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
-      allow(Pageview).to receive(:results).and_return(
-        [
-          OpenStruct.new(date: "20161022", pagePath: "/concern/thing", pageviews: "2"),
-          OpenStruct.new(date: "20161111", pagePath: "/concern/stuff", pageviews: "9"),
-          OpenStruct.new(date: "20160909", pagePath: "/concern/other", pageviews: "3"),
-          OpenStruct.new(date: "20160910", pagePath: "/concern/thing", pageviews: "5")
-        ]
-      )
+  describe "#page_views_by_path" do
+    let(:pageviews) {
+      [
+        OpenStruct.new(date: "20161022", pagePath: "/concern/thing", pageviews: "2"),
+        OpenStruct.new(date: "20161111", pagePath: "/concern/stuff", pageviews: "9"),
+        OpenStruct.new(date: "20160909", pagePath: "/concern/other", pageviews: "3"),
+        OpenStruct.new(date: "20160910", pagePath: "/concern/thing", pageviews: "5")
+      ]
+    }
+    it "when there are pageviews, it returns the pageviews" do
+      allow(Rails.cache).to receive(:read).and_return(pageviews)
       expect(presenter.pageviews_by_path("/concern/thing")).to eq 7
     end
+    it "when there are no pageviews, it returns 0" do
+      allow(Rails.cache).to receive(:read).and_return(pageviews)
+      expect(presenter.pageviews_by_path("/concern/newthing")).to eq 0
+    end
+    it "when there is no cache, it returns '?'" do
+      allow(Rails.cache).to receive(:read).and_return(nil)
+      expect(presenter.pageviews_by_path("/concern/thing")).to eq '?'
+    end
   end
 
-  describe "#pageviews_by_ids" do
-    it "returns the correct number of pageviews" do
-      allow(AnalyticsService).to receive(:profile).and_return(Legato::Management::Profile.new('', ''))
-      allow(Pageview).to receive(:results).and_return(
-        [
-          OpenStruct.new(date: "20161022", pagePath: "/concern/A", pageviews: "2"),
-          OpenStruct.new(date: "20161111", pagePath: "/concern/B", pageviews: "9"),
-          OpenStruct.new(date: "20160909", pagePath: "/concern/C", pageviews: "3"),
-          OpenStruct.new(date: "20160910", pagePath: "/concern/D", pageviews: "5")
-        ]
-      )
-      expect(presenter.pageviews_by_ids(['A', 'C', 'D'])).to eq 10
+  describe "#page_views_by_ids" do
+    let(:pageviews) {
+      [
+        OpenStruct.new(date: "20161022", pagePath: "/concern/123", pageviews: "2"),
+        OpenStruct.new(date: "20161111", pagePath: "/concern/123?search=dogs", pageviews: "9"),
+        OpenStruct.new(date: "20160909", pagePath: "/concern/456", pageviews: "3"),
+        OpenStruct.new(date: "20160910", pagePath: "/concern/789", pageviews: "5")
+      ]
+    }
+    it "when there are pageviews, it returns the pageviews" do
+      allow(Rails.cache).to receive(:read).and_return(pageviews)
+      expect(presenter.pageviews_by_ids(['123', '456'])).to eq 14
+    end
+    it "when there are no pageviews, it returns 0" do
+      allow(Rails.cache).to receive(:read).and_return(pageviews)
+      expect(presenter.pageviews_by_ids(['12X', '89Y'])).to eq 0
+    end
+    it "when there is no cache, it returns '?'" do
+      allow(Rails.cache).to receive(:read).and_return(nil)
+      expect(presenter.pageviews_by_ids(['123', '456'])).to eq '?'
     end
   end
 end


### PR DESCRIPTION
We're having problems with the google bot crawling the site so frequently
that it uses up our 50,000/day google analytics API quota. So we need to
cache it.

1. A rake task to cache google analytics data to the Rails.cache
2. Refactored the analytics_presenter to use the Rails.cache

When this is merged, add a cron in staging, preview and production to call the rake task to build the ga_cache. Something like:

`0 3 * * * cd /hydra-dev/heliotrope-staging/current; RBENV_ROOT=/l/local/rbenv RBENV_VERSION=2.3.0 RAILS_ENV=production /l/local/rbenv/bin/rbenv exec bundle exec rake heliotrope:ga_cache`