### PR TITLE
Resolves #590: Handle/DOI/Permalink should be (easily) copyable

### DIFF
--- a/app/views/curation_concerns/file_sets/_attribute_rows_info.html.erb
+++ b/app/views/curation_concerns/file_sets/_attribute_rows_info.html.erb
@@ -8,4 +8,3 @@
 <%= presenter.attribute_to_html(:keywords, render_as: :monograph_facet, monograph_id: presenter.monograph.id) %>
 <%= presenter.attribute_to_html(:content_type, label: t('content_type'), render_as: :monograph_search, monograph_id: presenter.monograph.id) %>
 <%= presenter.attribute_to_html(:language, render_as: :monograph_facet, monograph_id: presenter.monograph.id) %>
-<%= presenter.attribute_to_html(:citable_link, label: t('citable_link'), render_as: :external_link) %>

--- a/app/views/curation_concerns/file_sets/_attributes.html.erb
+++ b/app/views/curation_concerns/file_sets/_attributes.html.erb
@@ -12,6 +12,15 @@
     <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
       <tbody>
         <%= render 'attribute_rows_info', presenter: presenter %>
+        <tr>
+          <th><%= t('citable_link') %></th>
+          <td>
+            <form>
+              <label for="permalink" style="display: none;"><%= t('citable_link') %></label>
+              <input type="text" class="form-control" id="permalink" value="<%= presenter.citable_link %>" readonly="readonly" onclick="this.select(); document.execCommand('copy');" />
+            </form>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div> <!-- /.info panel -->

--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -94,7 +94,7 @@ feature 'Create a file set' do
       expect(page).to have_content 'Here is what that means'
       expect(page).to have_content 'A Nice Museum'
       expect(page).to have_content 'Unauthorized use prohibited. A Nice Museum.'
-      expect(page).to have_content 'http://hdl.handle.net/2027/fulcrum.this-is-a-handle'
+      expect(page.has_field?('Citable Link', with: 'http://hdl.handle.net/2027/fulcrum.this-is-a-handle')).to be true
       # expect(page).to have_content 'yes1'
       # expect(page).to have_content 'yes2'
       # expect(page).to have_content 'yes3'


### PR DESCRIPTION
Right now this is not an attribute renderer, that seems like overkill. We can change that if we need to in the future. There's javascript on the input field so that when you click it it's copied to your clipboard.


![citable-link](https://cloud.githubusercontent.com/assets/3924142/20728817/741ced90-b64d-11e6-9e74-67c652c5e390.png)


