### PR TITLE
Resolves #481: add ga event tracking

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,5 +30,6 @@
 //= require 'disable_video_download'
 //= require 'disable_audio_download'
 //= require 'disable_image_download'
+//= require 'ga_event_tracking'
 // Required by Hydra/Rails?
 //= require_tree .

--- a/app/assets/javascripts/ga_event_tracking.js
+++ b/app/assets/javascripts/ga_event_tracking.js
@@ -1,0 +1,146 @@
+$(document).on('turbolinks:load', function() {
+  // Register user events with google analytics
+
+  //
+  // Press page
+  //
+  // header link
+  $('a.navbar-brand').click(function() {
+    ga('pressTracker.send', 'event', which_category(), 'click', $(this).attr('href'))
+  });
+
+  // press catalog listing of monographs, titles and title buttons
+  $('#documents .document').each(function(index, value) {
+
+    var title = $(value).find('h2.index_title a').text();
+
+    $(value).find('h2.index_title a').click(function() {
+      ga('pressTracker.send', 'event', 'press_page', 'click', title)
+    });
+
+    $(value).find('a.btn.btn-default').click(function() {
+      ga('pressTracker.send', 'event', 'press_page', 'click_button', title)
+    })
+  });
+
+  // footer links
+  $('footer.press a').click(function() {
+    ga('pressTracker.send', 'event', which_category(), 'click', $(this).attr('href'))
+  });
+
+  //
+  // Search
+  //
+  // The search form on each "page type" is the same, so we try to guess where
+  // the search came from for the event category.
+  //
+  $('#keyword-search-submit').click(function() {
+    // console.log(which_category());
+    ga('pressTracker.send', 'event', which_category(), 'search', $('#catalog_search').val());
+  });
+
+  //
+  // Monograph page
+  //
+  // monograph catalog listing of file_sets/assets
+  // This is *very* close the press_page catalog listing, it's just h4 instead of h2!
+  $('#documents .document h4.index_title a').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'click', $(this).text());
+  });
+
+  // buy button
+  $('#monograph-buy-btn').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'click_buy', $(this).attr('href'))
+  });
+
+  // sort
+  $('#sort-dropdown ul.dropdown-menu li a').click(function() {
+    //console.log($(this).attr('href').split("?")[1]);
+    ga('pressTracker.send', 'event', 'monograph_page', 'sort', $(this).attr('href').split("?")[1]);
+  });
+
+  // facets
+  //$('#facets a.facet_select').mouseover(function() {
+  //  console.log($(this).text());
+  //});
+  // Repeating/hard coding this to get a little more detail in the 'action', but
+  // probably could DRY it out with a little work...
+  // Also, this doesn't work in the facet modal yet, just the top 5...
+  $('#facet-section_title_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_section', $(this).text());
+  });
+  $('#facet-keywords_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_keywords', $(this).text());
+  });
+  $('#facet-creator_full_name_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_creator', $(this).text());
+  });
+  $('#facet-resource_type_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_format', $(this).text());
+  });
+  $('#facet-search_year_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_year', $(this).text());
+  });
+  $('#facet-exclusive_to_platform_sim a.facet_select').click(function() {
+    ga('pressTracker.send', 'event', 'monograph_page', 'facet_exclusivity', $(this).text());
+  });
+
+  //
+  // File Set/Asset page
+  //
+  // leaflet image zoom buttons
+  $('a.leaflet-control-zoom-in').click(function() {
+    ga('pressTracker.send', 'event', 'file_set_page', 'zoom_in', $('#asset-title').text());
+  });
+  $('a.leaflet-control-zoom-out').click(function() {
+    ga('pressTracker.send', 'event', 'file_set_page', 'zoom_out', $('#asset-title').text());
+  });
+  // capture the scrollwheel zoom too...
+  var image = $('#image');
+  if (image) {
+    image.on('DOMMouseScroll mousewheel', function (event) {
+      if ( event.originalEvent.detail > 0 || event.originalEvent.wheelDelta < 0 ) {
+        ga('pressTracker.send', 'event', 'file_set_page', 'zoom_out', $('#asset-title').text());
+      } else {
+        ga('pressTracker.send', 'event', 'file_set_page', 'zoom_in', $('#asset-title').text());
+      }
+    });
+  }
+
+  // video and audio
+  var video = $('#video').get(0)
+  if (video) {
+    video.addEventListener("play", function() {
+      ga('pressTracker.send', 'event', 'file_set_page', 'play_video', $('#asset-title').text());
+    });
+    video.addEventListener("pause", function() {
+      ga('pressTracker.send', 'event', 'file_set_page', 'stop_video', $('#asset-title').text());
+    });
+  }
+  var audio = $('#audio').get(0)
+  if (audio) {
+    audio.addEventListener("play", function() {
+      ga('pressTracker.send', 'event', 'file_set_page', 'start_audio', $('#asset-title').text());
+    });
+    audio.addEventListener("pause", function() {
+      ga('pressTracker.send', 'event', 'file_set_page', 'stop_audio', $('#asset-title').text());
+    });
+  }
+
+  // tabs
+  $('ul.nav.nav-tabs li a').click(function() {
+    var tab = $(this).attr('href').split('#')[1];
+    ga('pressTracker.send', 'event', 'file_set_page', 'tab_' + tab, $('#asset-title').text());
+  });
+
+
+  function which_category() {
+    // Some events can be in multiple "pages", press, monograph or file_set
+    // This tries to figure out where the user initiated the event
+    var url = window.location.href.split("?")[0];
+    var category = 'press_page';
+    if (url.match(/monograph/g)) { category = 'monograph_page' }
+    if (url.match(/file_set/g))  { category = 'file_set_page'  }
+    return category
+  }
+});

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -39,7 +39,7 @@
     <div class="col-sm-6">
       <div class="row asset-attributes">
         <div class="col-sm-12">
-          <h2><%= @presenter.title %></h2>
+          <h2 id="asset-title"><%= @presenter.title %></h2>
           <h3>From <em><%= link_to @presenter.monograph.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
             by <%= @presenter.monograph.creator_given_name.first %> <%= @presenter.monograph.creator_family_name.first %><%= contributors_string(@presenter.monograph.contributor) %></h3>
           <br />

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -63,7 +63,7 @@
       <% if defined?(@monograph_presenter.buy_url) %>
       <div class="btn-toolbar" role="toolbar" aria-label="">
         <div class="btn-group" role="group" aria-label="">
-            <a href="<%= @monograph_presenter.buy_url.first %>" target="_blank" title="Buy <%= @monograph_presenter.title %>" role="button" class="btn btn-default btn-small">Buy Book</a>
+            <a id="monograph-buy-btn" href="<%= @monograph_presenter.buy_url.first %>" target="_blank" title="Buy <%= @monograph_presenter.title %>" role="button" class="btn btn-default btn-small">Buy Book</a>
         </div>
       </div>
       <% end %>

--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -123,6 +123,11 @@ feature 'Create a file set' do
       # check external autolink are opening in a new tab and internal are not
       expect(find_link('external link')[:target]).to eq '_blank'
       expect(find_link('internal link')[:target]).to be nil
+
+      # Selectors needed for assets/javascripts/ga_event_tracking.js
+      # If these change, fix here then update ga_event_tracking.js
+      expect(page).to have_selector('#image')
+      expect(page).to have_selector('ul.nav.nav-tabs li a', count: 4)
     end
   end
 end

--- a/spec/features/file_set_search_spec.rb
+++ b/spec/features/file_set_search_spec.rb
@@ -31,5 +31,10 @@ feature 'FileSet Search' do
     click_button 'keyword-search-submit'
 
     expect(page).to have_content 'Mr. Worf'
+
+    # Selectors needed for assets/javascripts/ga_event_tracking.js
+    # If these change, fix here then update ga_event_tracking.js
+    expect(page).to have_selector('#keyword-search-submit')
+    expect(page).to have_selector('#catalog_search')
   end
 end

--- a/spec/features/monograph_catalog_search_spec.rb
+++ b/spec/features/monograph_catalog_search_spec.rb
@@ -43,6 +43,13 @@ feature 'Monograph Catalog Search' do
     attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
     click_button 'Attach to Monograph'
 
+    # Selectors needed for assets/javascripts/ga_event_tracking.js
+    # If these change, fix here then update ga_event_tracking.js
+    expect(page).to have_selector('#documents .document h4.index_title a')
+    expect(page).to have_selector('#monograph-buy-btn')
+    expect(page).to have_selector('#keyword-search-submit')
+    expect(page).to have_selector('#catalog_search')
+
     fill_in 'catalog_search', with: 'Unruly'
     click_button 'keyword-search-submit'
     expect(page).to have_content 'Unruly Puddles'

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -52,6 +52,15 @@ feature 'Press Catalog' do
         expect(page).to     have_link red.title.first
         expect(page).to_not have_link blue.title.first
         expect(page).to_not have_link colors.title.first
+
+        # Selectors needed for assets/javascripts/ga_event_tracking.js
+        # If these change, fix here then update ga_event_tracking.js
+        expect(page).to have_selector('a.navbar-brand')
+        expect(page).to have_selector('#documents .document h2.index_title a')
+        expect(page).to have_selector('#documents .document a.btn.btn-default')
+        expect(page).to have_selector('footer.press a')
+        expect(page).to have_selector('#keyword-search-submit')
+        expect(page).to have_selector('#catalog_search')
       end
     end
     context 'with with a monograph with multiple authors' do


### PR DESCRIPTION
This is all done in javascript, similar to the old blacklight_google_analytics gem:

https://github.com/uohull/blacklight_google_analytics/blob/master/app/assets/javascripts/blacklight_google_analytics.js.erb