### PR TITLE
Don't run unnecessary background jobs during specs.  Goal is to speed up specs, story #673

### DIFF
--- a/spec/features/create_file_set_spec.rb
+++ b/spec/features/create_file_set_spec.rb
@@ -7,7 +7,12 @@ feature 'Create a file set' do
 
     before do
       login_as user
-      stub_out_redis
+
+      # stub out redis file-locking:
+      allow_any_instance_of(CurationConcerns::Actors::FileSetActor).to receive(:acquire_lock_for).and_yield
+
+      # Don't run characterize job during specs
+      allow(CharacterizeJob).to receive_messages(perform_later: nil, perform_now: nil)
     end
 
     scenario do

--- a/spec/features/monograph_catalog_facets_spec.rb
+++ b/spec/features/monograph_catalog_facets_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 feature "Monograph Catalog Facets" do
+  before do
+    stub_out_redis
+  end
+
   context "keywords" do
     let(:user) { create(:platform_admin) }
     let(:monograph) { create(:monograph, user: user, title: ["Yellow"], representative_id: cover.id) }
@@ -24,7 +28,6 @@ feature "Monograph Catalog Facets" do
     let(:cover) { create(:file_set) }
     before do
       login_as user
-      stub_out_redis
       monograph.ordered_members << cover
       monograph.save!
     end
@@ -119,7 +122,6 @@ feature "Monograph Catalog Facets" do
     let(:cover) { create(:file_set) }
     before do
       login_as user
-      stub_out_redis
       monograph.ordered_members << cover
       monograph.save!
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ end
 # Stub out anything that requires a redis connection,
 # such as background jobs and lock management.
 def stub_out_redis
+  allow(IngestFileJob).to receive_messages(perform_later: nil, perform_now: nil)
   allow(CharacterizeJob).to receive_messages(perform_later: nil, perform_now: nil)
   allow_any_instance_of(CurationConcerns::Actors::FileSetActor).to receive(:acquire_lock_for).and_yield
 end


### PR DESCRIPTION
Don't run background jobs during specs if the specs aren't testing the outcome of the job. Part of story #673