### PR TITLE
Refactor this spec to be consistent with the app's solr index.

### DIFF
--- a/app/presenters/concerns/open_url_presenter.rb
+++ b/app/presenters/concerns/open_url_presenter.rb
@@ -12,7 +12,7 @@ module OpenUrlPresenter
     fields << "rft.genre=bookitem"
     fields << "rft.source=fulcrum.org"
     fields << "rft.identifier=#{CGI.escape(citable_link)}"
-    fields << "rft.au=#{CGI.escape(full_name)}" if creator_full_name.present?
+    fields << "rft.au=#{CGI.escape(creator_full_name.first)}" if creator_full_name.present?
 
     contributor.each do |contrib|
       fields << "rft.au=#{CGI.escape(contrib)}"
@@ -35,7 +35,7 @@ module OpenUrlPresenter
     fields << "rft_val_fmt=info:ofi/fmt:kev:mtx:book"
     fields << "rfr_id=info:sid/fulcrum.org"
     fields << "rft.source=fulcrum.org"
-    fields << "rft.au=#{CGI.escape(full_name)}" if creator_full_name.present?
+    fields << "rft.au=#{CGI.escape(creator_full_name.first)}" if creator_full_name.present?
 
     contributor.each do |contrib|
       fields << "rtf.au=#{CGI.escape(contrib)}"
@@ -57,17 +57,4 @@ module OpenUrlPresenter
 
     fields.join('&')
   end
-
-  private
-
-    def full_name
-      # There's something weird with creator_full_name, is it multi or singular?
-      # Sometimes it's one, sometimes the other.
-      # Once #685 is fixed, this can be removed
-      if creator_full_name.is_a?(Array)
-        creator_full_name.first
-      else
-        creator_full_name
-      end
-    end
 end

--- a/spec/presenters/concerns/open_url_presenter_spec.rb
+++ b/spec/presenters/concerns/open_url_presenter_spec.rb
@@ -1,30 +1,24 @@
 require 'rails_helper'
 
 describe OpenUrlPresenter do
-  let(:press) { build(:press, subdomain: 'merp', name: 'Michigan Education Regional Program') }
-  let(:monograph) { create(:monograph, title: ['Stuff'],
-                                       creator_family_name: 'Worm',
-                                       creator_given_name: 'Bird',
-                                       description: ['Things about Stuff'],
-                                       subject: ['Birds', 'Bionics', 'Hats'],
-                                       date_published: ['1776'],
-                                       isbn: ['123-456-7890'],
-                                       press: press.subdomain,
-                                       publisher: [press.name]) }
+  let(:mono_doc) { SolrDocument.new(id: '1',
+                                    title_tesim: ['Stuff'],
+                                    creator_full_name_tesim: ['Worm, Bird'],
+                                    description_tesim: ['Things about Stuff'],
+                                    subject_tesim: ['Birds', 'Bionics', 'Hats'],
+                                    date_published_tesim: ['1776'],
+                                    isbn_tesim: ['123-456-7890'],
+                                    publisher_tesim: ['MERP']) }
 
-  let(:file_set) { create(:file_set, title: ['Songs of Stuff'],
-                                     description: ['Description about things'],
-                                     creator_family_name: 'Ronald',
-                                     creator_given_name: 'Ron',
-                                     search_year: '2025') }
-  before do
-    monograph.ordered_members << file_set
-    monograph.save!
-  end
+  let(:file_set_doc) { SolrDocument.new(id: '2',
+                                        title_tesim: ['Songs of Stuff'],
+                                        description_tesim: ['Description about things'],
+                                        creator_full_name_tesim: ['Ronald, Ron'],
+                                        search_year_tesim: ['2025'],
+                                        monograph_id_ssim: ['1']) }
 
   describe "#monograph_coins_title" do
-    let(:solr_doc) { SolrDocument.new(monograph.to_solr) }
-    let(:presenter) { CurationConcerns::MonographPresenter.new(solr_doc, nil) }
+    let(:presenter) { CurationConcerns::MonographPresenter.new(mono_doc, nil) }
 
     it "has the correct metadata" do
       kevs = presenter.monograph_coins_title
@@ -37,15 +31,16 @@ describe OpenUrlPresenter do
       expect(kevs).to match("rft.subject=Hats")
       expect(kevs).to match("rft.date=1776")
       expect(kevs).to match("rft.isbn=123-456-7890")
-      expect(CGI.unescape(kevs)).to match("rft.publisher=Michigan Education Regional Program")
+      expect(CGI.unescape(kevs)).to match("rft.publisher=MERP")
     end
   end
 
   describe '#file_set_coins_title' do
-    let(:solr_doc) { SolrDocument.new(file_set.to_solr) }
-    let(:presenter) { CurationConcerns::FileSetPresenter.new(solr_doc, nil) }
+    let(:presenter) { CurationConcerns::FileSetPresenter.new(file_set_doc, nil) }
 
     it "has the correct metadata" do
+      allow(presenter).to receive(:monograph).and_return(CurationConcerns::MonographPresenter.new(mono_doc, nil))
+
       kevs = presenter.file_set_coins_title
 
       expect(CGI.unescape(kevs)).to match("rft.au=Ronald, Ron")


### PR DESCRIPTION
As per notes in #685, refactored this spec to use multi-valued fields instead of singular _or_ multi.

In the future we could change some of the `*_tesim` fields to `*_tesi` (so don't use `:stored_searchable`) to more faithfully match how the fields are stored in fedora, but it's not a big priority I don't think. I just didn't fully understand what was happening.

Resolves #685