### PR TITLE
Story #673 Refactored the test setup on some specs to speed up the specs

### DIFF
--- a/spec/features/monograph_catalog_facets_spec.rb
+++ b/spec/features/monograph_catalog_facets_spec.rb
@@ -5,13 +5,12 @@ feature "Monograph Catalog Facets" do
     stub_out_redis
   end
 
+  let(:cover) { create(:public_file_set) }
+
   context "keywords" do
-    let(:user) { create(:platform_admin) }
-    let(:monograph) { create(:monograph, user: user, title: ["Yellow"], representative_id: cover.id) }
-    let(:cover) { create(:file_set) }
-    let(:file_set1) { create(:file_set, keywords: ["cat", "dog", "elephant", "lizard", "monkey", "mouse", "tiger"]) }
+    let(:monograph) { create(:public_monograph, title: ["Yellow"], representative_id: cover.id) }
+    let(:file_set1) { create(:public_file_set, keywords: ["cat", "dog", "elephant", "lizard", "monkey", "mouse", "tiger"]) }
     before do
-      login_as user
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
@@ -23,64 +22,46 @@ feature "Monograph Catalog Facets" do
   end
 
   context "sections" do
-    let(:user) { create(:platform_admin) }
-    let(:monograph) { create(:monograph, user: user, title: ["Yellow"], representative_id: cover.id) }
-    let(:cover) { create(:file_set) }
+    let(:section1) { build(:public_section, title: ['C 1']) }
+    let(:section2) { build(:public_section, title: ['B 2']) }
+    let(:section3) { build(:public_section, title: ['A 3']) }
+
+    let(:monograph) do
+      m = build(:public_monograph, title: ["Yellow"], representative_id: cover.id)
+      m.ordered_members = [cover, section1, section2, section3]
+      m.save! # Now m will have an ID
+      [section1, section2, section3].each do |section|
+        section.monograph_id = m.id
+        section.save!
+      end
+      m
+    end
+
+    let(:fs1) { build(:public_file_set, title: ['Sec 1 File 1']) }
+    let(:fs2) { build(:public_file_set, title: ['Sec 2 File 1']) }
+    let(:fs3) { build(:public_file_set, title: ['Sec 2 File 2']) }
+    let(:fs4) { build(:public_file_set, title: ['Sec 3 File 1']) }
+    let(:fs5) { build(:public_file_set, title: ['Sec 3 File 2']) }
+    let(:fs6) { build(:public_file_set, title: ['Sec 3 File 3']) }
+
     before do
-      login_as user
-      monograph.ordered_members << cover
-      monograph.save!
+      # Section 1 has 1 file
+      section1.ordered_members = [fs1]
+      section1.save!
+      # Section 2 has 2 files
+      section2.ordered_members = [fs2, fs3]
+      section2.save!
+      # Section 3 has 3 files
+      section3.ordered_members = [fs4, fs5, fs6]
+      section3.save!
+
+      # Update the solr index for each file to add section info
+      [section1, section2, section3].each do |section|
+        section.ordered_members.to_a.each(&:update_index)
+      end
     end
 
     scenario "shows sections in intended order" do
-      # Section 1, 1 file
-      visit new_curation_concerns_section_path
-      fill_in 'Title', with: "C 1"
-      select monograph.title.first, from: "Monograph"
-      click_button 'Create Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 1 File 1'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
-      # Section 2, 2 files
-      visit new_curation_concerns_section_path
-      fill_in 'Title', with: "B 2"
-      select monograph.title.first, from: "Monograph"
-      click_button 'Create Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 2 File 1'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 2 File 2'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
-      # Section 3, 3 files
-      visit new_curation_concerns_section_path
-      fill_in 'Title', with: "A 3"
-      select monograph.title.first, from: "Monograph"
-      click_button 'Create Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 3 File 1'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 3 File 2'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'Section 3 File 3'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
       visit monograph_catalog_facet_path(id: 'section_title_sim', monograph_id: monograph.id)
 
       # facet section order should be:
@@ -92,18 +73,29 @@ feature "Monograph Catalog Facets" do
       expect(page).to have_selector '.facet-values li:first', text: "C 1"
       expect(page).to_not have_selector '.facet-values li:first', text: "A 3"
     end
+  end
+
+  context "with italics in the title" do
+    let(:section) { create(:public_section, title: ["A Section with _Italicized Title_ Stuff"]) }
+
+    let(:monograph) do
+      m = build(:public_monograph, title: ["Yellow"], representative_id: cover.id)
+      m.ordered_members = [cover, section]
+      m.save!
+      section.monograph_id = m.id
+      section.save!
+      m
+    end
+
+    let(:fs) { create(:public_file_set) }
+
+    before do
+      section.ordered_members = [fs]
+      section.save!
+      fs.update_index
+    end
 
     scenario "shows italics (emphasis) in section facet links" do
-      visit new_curation_concerns_section_path
-      fill_in 'Title', with: "A Section with _Italicized Title_ Stuff"
-      select monograph.title.first, from: "Monograph"
-      click_button 'Create Section'
-
-      click_link 'Attach a File'
-      fill_in 'Title', with: 'File Title'
-      attach_file 'file_set_files', File.join(fixture_path, 'csv', 'miranda.jpg')
-      click_button 'Attach to Section'
-
       visit monograph_catalog_path(id: monograph.id)
       # get text inside <em> tags
       italicized_text = page.first('#facet-section_title_sim li .facet_select em').text
@@ -119,7 +111,6 @@ feature "Monograph Catalog Facets" do
   context "all facets" do
     let(:user) { create(:platform_admin) }
     let(:monograph) { create(:monograph, user: user, title: ["Yellow"], representative_id: cover.id) }
-    let(:cover) { create(:file_set) }
     before do
       login_as user
       monograph.ordered_members << cover


### PR DESCRIPTION
* For test setup, create the Monograph, Section, and FileSet records in
let blocks instead of creating them by interacting with the UI in the
body of the spec.  (Avoid extra routing and rendering work to speed up
the spec.)

* For specs that don't need admin-level access, don't log in with any
user.  (This change isn't for performance, but just to remove
unnecessary code.  You shouldn't have to be an admin user to view the
facets.)

On my laptop (without spring running), the specs in this file took about 38 seconds to run.  After these changes, they took about 27 seconds.