### PR TITLE
Fixup/fulcrum/indiana

### DIFF
--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -110,7 +110,7 @@ layout: default
       </div>
       <div class="row">
         <div class="col s12 m4 project-cover">
-          <a href="https://www.fulcrum.org/concern/monographs/4q77fr33m"><img class="responsive-img" src="//fulcrum.org/image-service/qb98mf474/full/300,/0/default.jpg" alt="Cover for A Song to Save the Sailish Sea: Musical Performance as Environmental Activism" /></a>
+          <a href="https://www.fulcrum.org/concern/monographs/4q77fr33m"><img class="responsive-img" src="//fulcrum.org/image-service/qb98mf474/full/300,/0/default.jpg" alt="Cover for A Song to Save the Salish Sea: Musical Performance as Environmental Activism" /></a>
         </div>
         <div class="col s12 m8 project-info">
           <h3><a href="https://www.fulcrum.org/concern/monographs/4q77fr33m">A Song to Save the Salish Sea: Musical Performance as Environmental Activism</a></h3>

--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -110,10 +110,10 @@ layout: default
       </div>
       <div class="row">
         <div class="col s12 m4 project-cover">
-          <a href="https://www.fulcrum.org/concern/monographs/4q77fr33m"><img class="responsive-img" src="//fulcrum.org/image-service/qb98mf474/full/300,/0/default.jpg" alt="Cover for A Song to Save the Sailish Sea" /></a>
+          <a href="https://www.fulcrum.org/concern/monographs/4q77fr33m"><img class="responsive-img" src="//fulcrum.org/image-service/qb98mf474/full/300,/0/default.jpg" alt="Cover for A Song to Save the Sailish Sea: Musical Performance as Environmental Activism" /></a>
         </div>
         <div class="col s12 m8 project-info">
-          <h3><a href="https://www.fulcrum.org/concern/monographs/4q77fr33m">A Song to Save the Sailish Sea</a></h3>
+          <h3><a href="https://www.fulcrum.org/concern/monographs/4q77fr33m">A Song to Save the Salish Sea: Musical Performance as Environmental Activism</a></h3>
           <h4>Mark Pedelty</h4>
           <h5>Indiana University Press, 2016</h5>
           <p class="light">In this book, Mark Pedelty explores Cascadia's vibrant eco-musical community in order to understand how environmentalist music imagines, and perhaps even creates, a more sustainable conception of place. Fulcrum enabled Indiana University Press to make available several music videos and songs by well-known musician and environmental activist Dana Lyons.</p>


### PR DESCRIPTION
fixes typo in book title on homepage and adds subtitle to be consistent with other book titles.