### PR TITLE
add Edited By language to Chaudhuri title on Fulcrum homepage

### DIFF
--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -102,7 +102,7 @@ layout: default
         </div>
         <div class="col s12 m8 project-info">
           <h3><a href="https://www.fulcrum.org/concern/monographs/br86b359j">Animal Acts: Performing Species Today</a></h3>
-          <h4>Una Chaudhuri and Holly Hughes</h4>
+          <h4>Edited by Una Chaudhuri and Holly Hughes</h4>
           <h5>University of Michigan Press, 2014</h5>
           <p class="light"><em>Animal Acts</em> is a unique collection that explores the fields of animal studies and performance studies, highlighting the areas where these two fields overlap in surprising, provocative, and insightful ways. Eleven stories by solo performers are accompanied by commentary from scholars and artists. Fulcrum allowed the University of Michigan Press to publish video excerpts of several of the performances discussed in the book. </p>
           <a href="https://www.fulcrum.org/concern/monographs/br86b359j" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>


### PR DESCRIPTION
Related to #879 

Modified fulcrum.org homepage to say "Edited by Una Chaudhuri and Holly Hughes"