### PR TITLE
Resolves #955: Tombstone

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -11,5 +11,7 @@ class EmbedController < ApplicationController
     else
       render layout: false
     end
+  rescue Ldp::Gone # tombstone
+    raise CanCan::AccessDenied
   end
 end

--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -70,5 +70,7 @@ class MonographCatalogController < ::CatalogController
       monograph_id = params[:monograph_id] || params[:id]
       @curation_concern = Monograph.find(monograph_id)
       @monograph_presenter = CurationConcerns::PresenterFactory.build_presenters([monograph_id], CurationConcerns::MonographPresenter, current_ability).first
+    rescue Ldp::Gone # tombstone
+      raise CanCan::AccessDenied
     end
 end

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -3,90 +3,130 @@
 require 'rails_helper'
 
 describe CurationConcerns::FileSetsController do
-  let(:controller) { described_class.new }
-  let(:params) { { file_set: { visibility_during_embargo: "restricted",
-                               embargo_release_date: "2020-01-01",
-                               visibility_after_embargo: "open",
-                               visibility_during_lease: "open",
-                               lease_expiration_date: "2020-01-01",
-                               visibility_after_lease: "restricted" } } }
+  context "visibility" do
+    let(:controller) { described_class.new }
+    let(:params) { { file_set: { visibility_during_embargo: "restricted",
+                                 embargo_release_date: "2020-01-01",
+                                 visibility_after_embargo: "open",
+                                 visibility_during_lease: "open",
+                                 lease_expiration_date: "2020-01-01",
+                                 visibility_after_lease: "restricted" } } }
 
-  describe "when visibility is embargo" do
-    before do
-      params[:file_set][:visibility] = 'embargo'
-      controller.params = params
-      controller.fix_visibility
+    describe "when visibility is embargo" do
+      before do
+        params[:file_set][:visibility] = 'embargo'
+        controller.params = params
+        controller.fix_visibility
+      end
+      it "has no visibility_during_lease" do
+        expect(controller.params[:file_set][:visibility_during_lease]).to be nil
+      end
+      it "has a visibiltiy of restricted" do
+        expect(controller.params[:file_set][:visibility]).to eq('restricted')
+      end
     end
-    it "has no visibility_during_lease" do
-      expect(controller.params[:file_set][:visibility_during_lease]).to be nil
+
+    describe "when visibiltiy is lease" do
+      before do
+        params[:file_set][:visibility] = 'lease'
+        controller.params = params
+        controller.fix_visibility
+      end
+      it "has no visibility_during_embargo" do
+        expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
+      end
+      it "has a visibility of public" do
+        expect(controller.params[:file_set][:visibility]).to eq('open')
+      end
     end
-    it "has a visibiltiy of restricted" do
-      expect(controller.params[:file_set][:visibility]).to eq('restricted')
+
+    describe "when visibility is open" do
+      before do
+        params[:file_set][:visibility] = 'open'
+        controller.params = params
+        controller.fix_visibility
+      end
+      it "has no visibility_during_embargo" do
+        expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
+      end
+      it "has no visibility_during_lease" do
+        expect(controller.params[:file_set][:visibility_during_lease]).to be nil
+      end
+      it "has a visibility of public" do
+        expect(controller.params[:file_set][:visibility]).to eq('open')
+      end
+    end
+
+    describe "when visibility is private" do
+      before do
+        params[:file_set][:visibility] = 'restricted'
+        controller.params = params
+        controller.fix_visibility
+      end
+      it "has no visibility_during_embargo" do
+        expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
+      end
+      it "has no visibility_during_lease" do
+        expect(controller.params[:file_set][:visibility_during_lease]).to be nil
+      end
+      it "has a visibility of restricted" do
+        expect(controller.params[:file_set][:visibility]).to eq('restricted')
+      end
+    end
+
+    describe "when visibility is authenticated" do
+      before do
+        params[:file_set][:visibility] = 'authenticated'
+        controller.params = params
+        controller.fix_visibility
+      end
+      it "has no visibility_during_embargo" do
+        expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
+      end
+      it "has no visibility_during_lease" do
+        expect(controller.params[:file_set][:visibility_during_lease]).to be nil
+      end
+      it "has a visibility of authenticated" do
+        expect(controller.params[:file_set][:visibility]).to eq('authenticated')
+      end
     end
   end
 
-  describe "when visibiltiy is lease" do
-    before do
-      params[:file_set][:visibility] = 'lease'
-      controller.params = params
-      controller.fix_visibility
-    end
-    it "has no visibility_during_embargo" do
-      expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
-    end
-    it "has a visibility of public" do
-      expect(controller.params[:file_set][:visibility]).to eq('open')
-    end
-  end
+  context 'tombstone' do
+    let(:user) { create(:platform_admin) }
+    let(:press) { create(:press) }
+    let(:monograph) { create(:monograph, user: user, press: press.subdomain) }
+    let(:file_set) { create(:file_set) }
 
-  describe "when visibility is open" do
     before do
-      params[:file_set][:visibility] = 'open'
-      controller.params = params
-      controller.fix_visibility
+      monograph.ordered_members << file_set
+      monograph.save!
+      file_set.save!
+      sign_in user
     end
-    it "has no visibility_during_embargo" do
-      expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
-    end
-    it "has no visibility_during_lease" do
-      expect(controller.params[:file_set][:visibility_during_lease]).to be nil
-    end
-    it "has a visibility of public" do
-      expect(controller.params[:file_set][:visibility]).to eq('open')
-    end
-  end
 
-  describe "when visibility is private" do
-    before do
-      params[:file_set][:visibility] = 'restricted'
-      controller.params = params
-      controller.fix_visibility
+    context 'file set created' do
+      before do
+        get :show, params: { parent_id: monograph.id, id: file_set.id }
+      end
+      it do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+        expect(response).to render_template("curation_concerns/file_sets/show")
+      end
     end
-    it "has no visibility_during_embargo" do
-      expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
-    end
-    it "has no visibility_during_lease" do
-      expect(controller.params[:file_set][:visibility_during_lease]).to be nil
-    end
-    it "has a visibility of restricted" do
-      expect(controller.params[:file_set][:visibility]).to eq('restricted')
-    end
-  end
 
-  describe "when visibility is authenticated" do
-    before do
-      params[:file_set][:visibility] = 'authenticated'
-      controller.params = params
-      controller.fix_visibility
-    end
-    it "has no visibility_during_embargo" do
-      expect(controller.params[:file_set][:visibility_during_embargo]).to be nil
-    end
-    it "has no visibility_during_lease" do
-      expect(controller.params[:file_set][:visibility_during_lease]).to be nil
-    end
-    it "has a visibility of authenticated" do
-      expect(controller.params[:file_set][:visibility]).to eq('authenticated')
+    context 'file set deleted' do
+      before do
+        file_set.destroy!
+        get :show, params: { parent_id: monograph.id, id: file_set.id }
+      end
+      it do
+        # The HTTP response status code 302 Found is a common way of performing URL redirection.
+        expect(response).to have_http_status(:found)
+        # raise CanCan::AccessDenied currently redirects to root_url
+        expect(response.header["Location"]).to match "http://test.host/"
+      end
     end
   end
 end

--- a/spec/controllers/curation_concerns/monographs_controller_spec.rb
+++ b/spec/controllers/curation_concerns/monographs_controller_spec.rb
@@ -3,94 +3,139 @@
 require 'rails_helper'
 
 describe CurationConcerns::MonographsController do
-  let(:monograph) { create(:monograph, user: user, press: press.subdomain) }
-  let(:press) { build(:press) }
-  let!(:sipity_entity) do
-    create(:sipity_entity, proxy_for_global_id: monograph.to_global_id.to_s)
-  end
+  context 'actions' do
+    let(:monograph) { create(:monograph, user: user, press: press.subdomain) }
+    let(:press) { build(:press) }
+    let!(:sipity_entity) do
+      create(:sipity_entity, proxy_for_global_id: monograph.to_global_id.to_s)
+    end
 
-  before do
-    sign_in user
-  end
+    before do
+      sign_in user
+    end
 
-  context 'a platform superadmin' do
-    let(:user) { create(:platform_admin) }
+    context 'a platform superadmin' do
+      let(:user) { create(:platform_admin) }
 
-    describe "#new" do
-      context 'press parameter' do
-        let(:subdomain) { "subdomain" }
-        let(:form) { assigns(:form) }
-        it 'handles missing press param' do
-          get :new
-          expect(form["press"]).to match(//)
+      describe "#new" do
+        context 'press parameter' do
+          let(:subdomain) { "subdomain" }
+          let(:form) { assigns(:form) }
+          it 'handles missing press param' do
+            get :new
+            expect(form["press"]).to match(//)
+          end
+          it 'handles press param' do
+            get :new, params: { press: subdomain }
+            expect(form["press"]).to match(/#{subdomain}/)
+          end
         end
-        it 'handles press param' do
-          get :new, params: { press: subdomain }
-          expect(form["press"]).to match(/#{subdomain}/)
-        end
       end
-    end
 
-    describe "#show" do
-      it 'is successful' do
-        get :show, params: { id: monograph }
-        expect(response).to be_success
-      end
-    end
-
-    describe "#create" do
-      it 'is successful' do
-        post :create, params: { monograph: { title: ['Title one'],
-                                             press: press.subdomain,
-                                             date_published: ['Oct 20th'] } }
-
-        expect(assigns[:curation_concern].title).to eq ['Title one']
-        expect(assigns[:curation_concern].date_published).to eq ['Oct 20th']
-        expect(assigns[:curation_concern].press).to eq press.subdomain
-        expect(response).to redirect_to Rails.application.routes.url_helpers.curation_concerns_monograph_path(assigns[:curation_concern])
-      end
-    end
-
-    describe "#publish" do
-      it 'is successful' do
-        expect(PublishJob).to receive(:perform_later).with(monograph)
-        post :publish, params: { id: monograph }
-        expect(response).to redirect_to Rails.application.routes.url_helpers.curation_concerns_monograph_path(monograph)
-        expect(flash[:notice]).to eq "Monograph is publishing."
-      end
-    end
-  end # platform superadmin
-
-  context 'a press-level admin' do
-    let(:user) { create(:press_admin) }
-
-    describe "#create" do
-      context 'within my own press' do
-        let(:press) { user.presses.first }
-
+      describe "#show" do
         it 'is successful' do
-          expect {
-            post :create, params: { monograph: { title: ['Title one'],
-                                                 press: press.subdomain } }
-          }.to change { Monograph.count }.by(1)
+          get :show, params: { id: monograph }
+          expect(response).to be_success
+        end
+      end
+
+      describe "#create" do
+        it 'is successful' do
+          post :create, params: { monograph: { title: ['Title one'],
+                                               press: press.subdomain,
+                                               date_published: ['Oct 20th'] } }
 
           expect(assigns[:curation_concern].title).to eq ['Title one']
+          expect(assigns[:curation_concern].date_published).to eq ['Oct 20th']
           expect(assigns[:curation_concern].press).to eq press.subdomain
           expect(response).to redirect_to Rails.application.routes.url_helpers.curation_concerns_monograph_path(assigns[:curation_concern])
         end
       end
 
-      context "within a press that I don't have permission for" do
-        it 'denies access' do
-          expect {
-            post :create, params: { monograph: { title: ['Title one'],
-                                                 press: press.subdomain } }
-          }.not_to change { Monograph.count }
-
-          expect(response.status).to eq 401
-          expect(response).to render_template :unauthorized
+      describe "#publish" do
+        it 'is successful' do
+          expect(PublishJob).to receive(:perform_later).with(monograph)
+          post :publish, params: { id: monograph }
+          expect(response).to redirect_to Rails.application.routes.url_helpers.curation_concerns_monograph_path(monograph)
+          expect(flash[:notice]).to eq "Monograph is publishing."
         end
       end
+    end # platform superadmin
+
+    context 'a press-level admin' do
+      let(:user) { create(:press_admin) }
+
+      describe "#create" do
+        context 'within my own press' do
+          let(:press) { user.presses.first }
+
+          it 'is successful' do
+            expect {
+              post :create, params: { monograph: { title: ['Title one'],
+                                                   press: press.subdomain } }
+            }.to change { Monograph.count }.by(1)
+
+            expect(assigns[:curation_concern].title).to eq ['Title one']
+            expect(assigns[:curation_concern].press).to eq press.subdomain
+            expect(response).to redirect_to Rails.application.routes.url_helpers.curation_concerns_monograph_path(assigns[:curation_concern])
+          end
+        end
+
+        context "within a press that I don't have permission for" do
+          it 'denies access' do
+            expect {
+              post :create, params: { monograph: { title: ['Title one'],
+                                                   press: press.subdomain } }
+            }.not_to change { Monograph.count }
+
+            expect(response.status).to eq 401
+            expect(response).to render_template :unauthorized
+          end
+        end
+      end
+    end # press-level admin
+  end # actions
+
+  context 'tombstone' do
+    let(:user) { create(:platform_admin) }
+    let(:press) { create(:press) }
+    let(:monograph) { create(:monograph, user: user, press: press.subdomain) }
+
+    before do
+      sign_in user
     end
-  end # press-level admin
+
+    context 'monograph created' do
+      before do
+        get :show, params: { id: monograph.id }
+      end
+      it do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+        expect(response).to render_template("curation_concerns/monographs/show")
+      end
+    end
+
+    #
+    # Currently returns 404 (:not_found)
+    # ActionView::MissingTemplate: Missing template ./public/404.html
+    # Since are using jekyll we don't have a 404.html under public
+    # But we do have ./public/404/index.html
+    # Regardless we are not currently using this controller for Monographs
+    # Monographs are shown with the monograph_catalog_controller
+    # Hence this test is commented out as a record of history
+    #
+    # context 'monograph deleted' do
+    #   before do
+    #     monograph.destroy!
+    #     get :show, params: { id: monograph.id }
+    #   end
+    #   it do
+    #     # The HTTP response status code 302 Found is a common way of performing URL redirection.
+    #     expect(response).to have_http_status(:found)
+    #     # raise CanCan::AccessDenied currently redirects to root_url
+    #     expect(response.header["Location"]).to match "http://test.host/"
+    #   end
+    # end
+  end
 end

--- a/spec/controllers/e_pub_controller_spec.rb
+++ b/spec/controllers/e_pub_controller_spec.rb
@@ -34,12 +34,33 @@ RSpec.describe EPubController, type: :controller do
         expect(response).to have_http_status(:success)
       end
     end
+    context 'tombstone' do
+      let(:monograph) { create(:monograph) }
+      let(:file_set) { create(:file_set, content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
+      before do
+        monograph.ordered_members << file_set
+        monograph.save!
+        file_set.save!
+        file_set.destroy!
+        get :show, params: { id: file_set.id }
+      end
+      it do
+        # The HTTP response status code 302 Found is a common way of performing URL redirection.
+        expect(response).to have_http_status(:found)
+        # raise CanCan::AccessDenied currently redirects to root_url
+        expect(response.header["Location"]).to match "http://test.host/"
+      end
+    end
   end
 
   describe "GET #file" do
     context 'not found' do
       before { get :file, params: { id: :id, file: 'META-INF/container', format: 'xml' } }
-      it { expect(response).to have_http_status(:unauthorized) }
+      it do
+        expect(response).to_not have_http_status(:unauthorized)
+        expect(response).to have_http_status(:success)
+        expect(response.body.empty?).to be true
+      end
     end
     context 'file nil' do
       let(:file_set) { create(:file_set) }
@@ -78,6 +99,17 @@ RSpec.describe EPubController, type: :controller do
           expect(response).to_not have_http_status(:unauthorized)
           expect(response).to have_http_status(:success)
           expect(response.body.empty?).to be false
+        end
+      end
+      context 'tombstone' do
+        before do
+          file_set.destroy!
+          get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'xml' }
+        end
+        it do
+          expect(response).to_not have_http_status(:unauthorized)
+          expect(response).to have_http_status(:success)
+          expect(response.body.empty?).to be true
         end
       end
     end

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -44,8 +44,25 @@ RSpec.describe EmbedController, type: :controller do
         allow(CurationConcerns::PresenterFactory).to receive(:build_presenters).with([obj.id], CurationConcerns::FileSetPresenter, anything).and_return([presenter])
         get :show, params: { hdl: hdl }
       end
-      it { expect(response).to_not have_http_status(:unauthorized) }
-      it { expect(response).to be_success }
+      it do
+        expect(response).to_not have_http_status(:unauthorized)
+        expect(response).to be_success
+      end
+    end
+
+    context 'tombstone' do
+      let(:hdl) { 'hdl' }
+
+      before do
+        allow(HandleService).to receive(:object).with(hdl).and_raise(Ldp::Gone)
+        get :show, params: { hdl: hdl }
+      end
+      it do
+        # The HTTP response status code 302 Found is a common way of performing URL redirection.
+        expect(response).to have_http_status(:found)
+        # raise CanCan::AccessDenied currently redirects to root_url
+        expect(response.header["Location"]).to match "http://test.host/"
+      end
     end
   end
 end

--- a/spec/controllers/monograph_catalog_controller_spec.rb
+++ b/spec/controllers/monograph_catalog_controller_spec.rb
@@ -87,5 +87,20 @@ describe MonographCatalogController do
         end
       end
     end
+    context 'when a monograph tombstone id' do
+      let(:press) { build(:press) }
+      let(:user) { create(:platform_admin) }
+      let(:monograph) { create(:monograph, user: user, press: press.subdomain) }
+      before do
+        monograph.destroy!
+        get :index, params: { id: monograph.id }
+      end
+      it do
+        # The HTTP response status code 302 Found is a common way of performing URL redirection.
+        expect(response).to have_http_status(:found)
+        # raise CanCan::AccessDenied currently redirects to root_url
+        expect(response.header["Location"]).to match "http://test.host/"
+      end
+    end
   end # #index
 end


### PR DESCRIPTION
Ensures encountering a tombstone behavior is consistent with default CC behavior a.k.a. rescue from Ldp::Gone and raise CanCan::AccessDenied.
