### PR TITLE
Add penn state to fulcrum homepage and production db

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,6 +88,6 @@ unless Rails.env.test?
   michigan
   minnesota
   northwestern
-  pennstate unless bulleit?
+  pennstate
 end
 

--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -120,6 +120,18 @@ layout: default
           <a href="https://www.fulcrum.org/concern/monographs/4q77fr33m" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
         </div>
       </div>
+      <div class="row">
+        <div class="col s12 m4 project-cover">
+          <a href="https://www.fulcrum.org/concern/monographs/#"><img class="responsive-img" src="//fulcrum.org/image-service/#/full/300,/0/default.jpg" alt="Cover for Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City" /></a>
+        </div>
+        <div class="col s12 m8 project-info">
+          <h3><a href="https://www.fulcrum.org/concern/monographs/#">Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City</a></h3>
+          <h4>Robert Darden</h4>
+          <h5>Penn State University Press, 2016</h5>
+          <p class="light">Volume 2 of <em>Nothing but Love in God’s Water</em> by Robert Darden, continues the journey started in Volume 1 of chronicling the role music played in energizing and sustaining those most heavily involved in the civil rights movement. On Fulcrum, Penn State University Press was able to present an impressive array of images and interview transcripts collected by the author to support his scholarship. While the interview transcripts are not hosted on Fulcrum, the platform provides a durable landing page for each transcript, which then links to the externally hosted file. This gives the reader the ability to explore all of the materials in a much more cohesive manner.</p>
+          <a href="https://www.fulcrum.org/concern/monographs/#" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -122,14 +122,14 @@ layout: default
       </div>
       <div class="row">
         <div class="col s12 m4 project-cover">
-          <a href="https://www.fulcrum.org/concern/monographs/#"><img class="responsive-img" src="//fulcrum.org/image-service/#/full/300,/0/default.jpg" alt="Cover for Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City" /></a>
+          <a href="https://www.fulcrum.org/concern/monographs/rr171x24p"><img class="responsive-img" src="//fulcrum.org/image-service/1z40ks82j/full/300,/0/default.jpg" alt="Cover for Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City" /></a>
         </div>
         <div class="col s12 m8 project-info">
-          <h3><a href="https://www.fulcrum.org/concern/monographs/#">Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City</a></h3>
+          <h3><a href="https://www.fulcrum.org/concern/monographs/rr171x24p">Nothing but Love in God’s Water: Volume 2: Black Sacred Music from Sit-Ins to Resurrection City</a></h3>
           <h4>Robert Darden</h4>
           <h5>Penn State University Press, 2016</h5>
           <p class="light">Volume 2 of <em>Nothing but Love in God’s Water</em> by Robert Darden, continues the journey started in Volume 1 of chronicling the role music played in energizing and sustaining those most heavily involved in the civil rights movement. On Fulcrum, Penn State University Press was able to present an impressive array of images and interview transcripts collected by the author to support his scholarship. While the interview transcripts are not hosted on Fulcrum, the platform provides a durable landing page for each transcript, which then links to the externally hosted file. This gives the reader the ability to explore all of the materials in a much more cohesive manner.</p>
-          <a href="https://www.fulcrum.org/concern/monographs/#" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
+          <a href="https://www.fulcrum.org/concern/monographs/rr171x24p" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Resolves #958 

Adds penn state to homepage and adjusts `db/seeds.db` so penn state is created in production. 