### PR TITLE
change beta date to end in spring 2018

### DIFF
--- a/fulcrum/beta.html
+++ b/fulcrum/beta.html
@@ -4,6 +4,6 @@ title: Fulcrum Beta
 permalink: /beta/
 ---
 
-<p>Fulcrum is currently in a beta launch of its publishing platform until Spring 2017. During this time we're working to create rich and durable experiences for five university press projects centered around the presentation of supplemental materials to published monographs. Along the way we will be releasing changes to the platform to add new features, improve the user experience, and squash bugs.</p>
+<p>Fulcrum is currently in a beta launch of its publishing platform until Spring 2018. During this time we're working to create rich and durable experiences for five university press projects centered around the presentation of supplemental materials to published monographs. Along the way we will be releasing changes to the platform to add new features, improve the user experience, and squash bugs.</p>
 <p>Since we're in "beta mode", we'd especially love your feedback on your experience with Fulcrum. Although any and all feedback is welcome, we'd especially appreciate hearing from you if you spot a bug or something isn't working as you'd expect it to. We'd also love to hear from you if you are a publisher interested in being an early adopter of Fulcrum.</p>
 <p>You can send feedback via e-mail to <a href="mailto:fulcrum-info@umich.edu" title="Send feedback to Fulcrum">fulcrum-info@umich.edu</a> or <a href="https://github.com/mlibrary/heliotrope/issues">file a new issue in our GitHub repository</a>.</p>


### PR DESCRIPTION
FWIW, this fixup doesn't need to be deployed until the end of this sprint cycle.