### PR TITLE
add fulcrum video and modify language before case studies

### DIFF
--- a/fulcrum/_sass/custom.scss
+++ b/fulcrum/_sass/custom.scss
@@ -28,7 +28,7 @@
   padding: .5em;
   background: $accent-color;
   color: $white;
-  border-bottom: 0;  
+  border-bottom: 0;
 }
 
 //// resize navigation menu
@@ -52,6 +52,33 @@
   color: #ffffff;
   background-position: 0;
 }
+
+// video
+.promo {
+  margin-top: 2em;
+}
+
+.video {
+  height: 0;
+  padding-top: 25px;
+  padding-bottom: 67.5%;
+  margin-bottom: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.video.widescreen {
+  padding-bottom: 56.34%;
+}
+
+.video embed, .video iframe, .video object, .video video {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+}
+
 
 // custom sizing and positioning for icons
 //// 3-things icons
@@ -184,6 +211,9 @@ footer.page-footer {
   }
   #index-banner .section, .parallax-container .section.sponsor {
     top: -5%;
+  }
+  #index-banner .section, .parallax-container .section.phases {
+    top: 0%;
   }
 
 }

--- a/fulcrum/css/custom.css
+++ b/fulcrum/css/custom.css
@@ -560,6 +560,27 @@ a > g, a > path {
   color: #ffffff;
   background-position: 0; }
 
+.promo {
+  margin-top: 2em; }
+
+.video {
+  height: 0;
+  padding-top: 25px;
+  padding-bottom: 67.5%;
+  margin-bottom: 10px;
+  position: relative;
+  overflow: hidden; }
+
+.video.widescreen {
+  padding-bottom: 56.34%; }
+
+.video embed, .video iframe, .video object, .video video {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute; }
+
 .icon {
   font-size: 2.4rem; }
 
@@ -645,7 +666,10 @@ footer.page-footer {
     top: 40%; }
 
   #index-banner .section, .parallax-container .section.sponsor {
-    top: -5%; } }
+    top: -5%; }
+
+  #index-banner .section, .parallax-container .section.phases {
+    top: 0%; } }
 @media only screen and (max-width: 600px) {
   .nav-container, .nav-container .container, .nav-container .column {
     height: 3.07rem; }

--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -23,6 +23,14 @@ layout: default
 
 <div class="container">
     <div class="section">
+      <!-- video -->
+      <div class="row center promo">
+        <div class="col s12 l8 offset-l2">
+          <div class="video widescreen">
+            <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/wsscKcoJN-8?rel=0" frameborder="0" allowfullscreen></iframe>
+          </div>
+        </div>
+      </div>
 
       <!--   Icon Section   -->
       <div class="row">
@@ -60,10 +68,10 @@ layout: default
   </div>
 
   <div class="parallax-container valign-wrapper">
-    <div class="section no-pad-bot">
+    <div class="section no-pad-bot phases">
       <div class="container">
         <div class="row center">
-          <h2 class="header col s12 white-text">A rich integration of digital objects with books</h2>
+          <h2 class="header col s12 white-text">In its first phase the Fulcrum team has focused on providing branded companion websites for books. Now, in its second phase, it will expand to host complete ebook collections, journals, and new forms of multimodal publications.</h2>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Resolves #966 

Embeds the YT hosted version of the fulcrum video onto the fulcrum homepage; creates a class for responsive video on static pages; modifies language on homepage to reflect phases of project per CW request.

Released to production in 1.4.2.1