### PR TITLE
Fixes #1017 'Read' link for epubs on the press catalog page

### DIFF
--- a/app/controllers/e_pub_controller.rb
+++ b/app/controllers/e_pub_controller.rb
@@ -10,7 +10,7 @@ class EPubController < ApplicationController
       @citable_link = presenter.citable_link
       @creator_given_name = presenter.creator_given_name
       @creator_family_name = presenter.creator_family_name
-      @back_link = params[:subdomain].present? ? main_app.root_url + params[:subdomain] : main_app.monograph_catalog_url(presenter.monograph_id)
+      @back_link = params[:publisher].present? ? URI.join(main_app.root_url, params[:publisher]).to_s : main_app.monograph_catalog_url(presenter.monograph_id)
       @subdomain = presenter.monograph.subdomain
       render layout: false
     else

--- a/app/views/press_catalog/_index_header_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_list_monograph.html.erb
@@ -29,7 +29,7 @@
   <% if presenter.epub? %>
     <div class="row">
       <div class="col-sm-12">
-        <a class="btn btn-default" href="<%= epub_path(presenter.epub) + '?subdomain=' + presenter.subdomain %>" title="Read <%= presenter.title %>" role="button">Read</a>
+        <a class="btn btn-default" href="<%= epub_path(presenter.epub, publisher: presenter.subdomain) %>" title="Read <%= presenter.title %>" role="button">Read</a>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Hyrax is appending "locale=lang" to all urls by default, so building urls using raw strings isn't going to work anymore.
It also turns out that "subdomin" is a reserved term by the rails url helpers, http://api.rubyonrails.org/v5.1/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for
so we'll use "publisher" as the param name.

 