### PR TITLE
bundle update rubocop 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,17 @@ AllCops:
     - 'vendor/**/*'
     - 'tmp/**/*'
 
+Layout/BlockEndNewline:
+  Exclude:
+    - 'spec/**/*'
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Layout/MultilineBlockLayout:
+  Exclude:
+    - 'spec/**/*'
+
 Lint/ImplicitStringConcatenation:
   Exclude:
     - 'lib/generators/sufia/**/*'
@@ -45,21 +56,10 @@ Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'
 
-Style/BlockEndNewline:
-  Exclude:
-    - 'spec/**/*'
-
 Style/FileName:
   Exclude:
     - 'Gemfile'
     - 'Vagrantfile'
-
-Style/MultilineBlockLayout:
-  Exclude:
-    - 'spec/**/*'
-
-Style/IndentationConsistency:
-  EnforcedStyle: rails
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -4,6 +4,10 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/controllers/hyrax/monographs_controller_spec.rb'
     - 'spec/controllers/roles_controller_spec.rb'
 
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - 'config/initializers/mailboxer.rb'
+
 Metrics/BlockLength:
   Enabled: true
   Max: 295 # default is 25
@@ -77,10 +81,6 @@ RSpec/SubjectStub:
 
 RSpec/VerifiedDoubles:
   Enabled: false
-
-Style/EmptyLinesAroundBlockBody:
-  Exclude:
-    - 'config/initializers/mailboxer.rb'
 
 Style/FrozenStringLiteralComment:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ group :development, :test do
   gem 'rspec-context-private'
   gem 'rspec-html-matchers'
   gem 'rspec-rails'
-  gem 'rubocop', '~> 0.48.1'
+  gem 'rubocop', '~> 0.49.1'
   gem 'rubocop-rspec', '~> 1.15.1'
   gem 'solr_wrapper', '0.21.0'
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,7 @@ GEM
       rails (> 3.2.0)
     orm_adapter (0.5.0)
     os (0.9.6)
+    parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     posix-spawn (0.3.13)
@@ -639,7 +640,8 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.48.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -750,7 +752,7 @@ GEM
     uber (0.1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.2.1)
+    unicode-display_width (1.3.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.7)
@@ -809,7 +811,7 @@ DEPENDENCIES
   rspec-context-private
   rspec-html-matchers
   rspec-rails
-  rubocop (~> 0.48.1)
+  rubocop (~> 0.49.1)
   rubocop-rspec (~> 1.15.1)
   rubyzip
   sass-rails (~> 5.0)
@@ -824,4 +826,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CharacterizeJob < ActiveJob::Base
+class CharacterizeJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   # @param [FileSet] file_set

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublishJob < ActiveJob::Base
+class PublishJob < ApplicationJob
   queue_as :publish
 
   def perform(curation_concern)

--- a/app/models/press.rb
+++ b/app/models/press.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Press < ActiveRecord::Base
+class Press < ApplicationRecord
   mount_uploader :logo_path, LogoPathUploader
   validates :name, presence: true, uniqueness: true
   validates :subdomain, presence: true, uniqueness: true

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   ROLES = %w[admin editor].freeze
   belongs_to :resource, polymorphic: true
   belongs_to :user

--- a/app/models/sub_brand.rb
+++ b/app/models/sub_brand.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubBrand < ActiveRecord::Base
+class SubBrand < ApplicationRecord
   belongs_to :press
 
   validates :press, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
   # Connects this user object to Curation Concerns behaviors.

--- a/spec/lib/import/importer_spec.rb
+++ b/spec/lib/import/importer_spec.rb
@@ -57,8 +57,10 @@ describe Import::Importer do
       # It saves a nice chunk of time (> 10 secs) to test the "reimport" here as well. Ugly though.
       it 'imports the new monograph and files, or "reimports" them to a pre-existing monograph' do
         expect { importer.run }
-          .to change { Monograph.count }.by(1)
-          .and(change { FileSet.count }.by(9))
+          .to change { Monograph.count }
+          .by(1)
+          .and(change { FileSet.count }
+          .by(9))
 
         monograph = Monograph.first
 
@@ -103,8 +105,10 @@ describe Import::Importer do
 
         reimporter = described_class.new(root_dir: root_dir, user_email: user.email, monograph_id: monograph.id)
         expect { reimporter.run }
-          .to change { Monograph.count }.by(0)
-          .and(change { FileSet.count }.by(9))
+          .to change { Monograph.count }
+          .by(0)
+          .and(change { FileSet.count }
+          .by(9))
 
         # check it's indeed the same monograph
         expect(Monograph.first.id).to eq monograph.id


### PR DESCRIPTION
rubocop 0.49.1 has needed fix to rubocop 0.48.1 false positive for FileUtils.touch...

app/services/e_pub_service.rb:10:15: C: Rails/SkipsModelValidations: Avoid using touch because it skips validations.
    FileUtils.touch(EPubService.epub_path(epub_id))