### PR TITLE
update cozy sun bear

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'redcarpet', '~> 3.3.4'
 gem 'jekyll', '~> 3.1.3'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '39507d37dead8fdfb49f9883b06e783c13ffa0d0'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'eaaedae10f3f0152d3b225ca357c881284ba31af'
 
 # Talking to Google Analytics
 gem 'legato', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 39507d37dead8fdfb49f9883b06e783c13ffa0d0
-  ref: 39507d37dead8fdfb49f9883b06e783c13ffa0d0
+  revision: eaaedae10f3f0152d3b225ca357c881284ba31af
+  ref: eaaedae10f3f0152d3b225ca357c881284ba31af
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Resolves #1065 pointing to the current `HEAD` of cozy-sun-bear. To see changes immediately in staging or preview, redeployment would be necessary.

NOTE: there will still need to be work to pass data from heliotrope to CSB to allow for download of files and bibliographic information about the EPUB.