### PR TITLE
config.user_key_field = Devise.authentication_keys.first

### DIFF
--- a/config/initializers/hydra_config.rb
+++ b/config/initializers/hydra_config.rb
@@ -21,4 +21,6 @@ Hydra.configure do |config|
   #
   # Specify the user model
   # config.user_model = 'User'
+
+  config.user_key_field = Devise.authentication_keys.first
 end


### PR DESCRIPTION
DEPRECATION WARNING: You must set 'config.user_key_field = Devise.authentication_keys.first' in your config/initializer/hydra_config.rb file. The default value will be removed in hydra-access-controls 12. (called from user_key_field at /usr/local/Cellar/rbenv/1.1.1/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/lib/hydra/config.rb:39)