### PR TITLE
style negated if enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@
 
 # Ignore coverall's files
 /coverage
+
+# Ignore Ruumba working directory
+/ruumba

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,11 +8,12 @@ AllCops:
     - '**/config.ru'
   Exclude:
     - 'db/**/*'
+    - 'ruumba/**/*'
     - 'script/**/*'
     - 'spec/internal/**/*'
     - 'spec/test_app_templates/**/*'
-    - 'vendor/**/*'
     - 'tmp/**/*'
+    - 'vendor/**/*'
 
 Layout/BlockEndNewline:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.49.1'
   gem 'rubocop-rspec', '~> 1.15.1'
+  gem 'ruumba'
   gem 'solr_wrapper', '0.21.0'
   gem 'sqlite3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,6 +656,8 @@ GEM
       oauth2
     ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
+    ruumba (0.1.0)
+      rubocop
     safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -814,6 +816,7 @@ DEPENDENCIES
   rubocop (~> 0.49.1)
   rubocop-rspec (~> 1.15.1)
   rubyzip
+  ruumba
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   signet
@@ -826,4 +829,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/app/views/hyrax/file_sets/_attributes.html.erb
+++ b/app/views/hyrax/file_sets/_attributes.html.erb
@@ -2,7 +2,7 @@
   <li role="presentation" class="active"><a href="#info" aria-controls="info" role="tab" data-toggle="tab">Info</a></li>
   <li role="presentation"><a href="#permissions" aria-controls="permissions" role="tab" data-toggle="tab">Permissions</a></li>
   <li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
-  <% if !presenter.external_resource? %>
+  <% unless presenter.external_resource? %>
   <li role="presentation"><a href="#technical-info" aria-controls="technical-info" role="tab" data-toggle="tab">Technical Info</a></li>
   <% end %>
 </ul>

--- a/app/views/monograph_catalog/_index_header_list_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_header_list_file_set.html.erb
@@ -5,7 +5,7 @@
       <% counter = document_counter_with_offset(document_counter) %>
       <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
     </h4>
-    <% if !document.section_title.blank? %>
+    <% if document.section_title.present? %>
       <p>From <%= render_markdown @monograph_presenter.display_section_titles document.section_title %></p>
     <% end %>
   </div>

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -8,8 +8,15 @@ unless Rails.env.production?
     task.fail_on_error = true
   end
 
+  require 'ruumba/rake_task'
+  desc "Run style checker's sidekick"
+  Ruumba::RakeTask.new(:ruumba) do |task|
+    task.dir = ["app/views"]
+    task.options = { tmp_folder: "ruumba", arguments: ["--display-cop-names", "--config .ruumba.yml"] }
+  end
+
   desc 'Run the ci build'
-  task ci: [:rubocop] do
+  task ci: %i[rubocop ruumba] do
     require 'active_fedora/rake_support'
     with_test_server do
       # run the tests

--- a/ruumba/.ruumba.yml
+++ b/ruumba/.ruumba.yml
@@ -60,8 +60,6 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false
-Style/NegatedIf:
-  Enabled: false
 Style/Next:
   Enabled: false
 Style/PreferredHashMethods:

--- a/ruumba/.ruumba.yml
+++ b/ruumba/.ruumba.yml
@@ -1,0 +1,78 @@
+Layout/AlignHash:
+  Enabled: false
+Layout/AlignParameters:
+  Enabled: false
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/FirstParameterIndentation:
+  Enabled: false
+Layout/IndentationWidth:
+  Enabled: false
+Layout/LeadingCommentSpace:
+  Enabled: false
+Layout/SpaceAfterComma:
+  Enabled: false
+Layout/SpaceAroundOperators:
+  Enabled: false
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+Layout/TrailingBlankLines:
+  Enabled: false
+
+
+Lint/AssignmentInCondition:
+  Enabled: false
+Lint/StringConversionInInterpolation:
+  Enabled: false
+Lint/UselessAssignment:
+  Enabled: false
+Lint/UnusedBlockArgument:
+  Enabled: false
+Lint/Void:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+Metrics/LineLength:
+  Enabled: false
+
+Performance/StringReplacement:
+  Enabled: false
+
+
+Style/AndOr:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
+Style/IdenticalConditionalBranches:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+Style/NegatedIf:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/PreferredHashMethods:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/UnlessElse:
+  Enabled: false
+Style/UnneededInterpolation:
+  Enabled: false


### PR DESCRIPTION
By removing the following lines from the ./ruumba/.rummba.yml file

Style/NegatedIf:
  Enabled: false

Style checks for negated if are enabled.

NOTE: Not everything in the .rummba.yml should be re-enabled since rummba strips all html before calling rubocop, hence context is lost and false positives are possible.