### PR TITLE
Resolves #839, add a "draft" mode for monographs (repurposing Private…

### DIFF
--- a/app/actors/hyrax/actors/monograph_actor.rb
+++ b/app/actors/hyrax/actors/monograph_actor.rb
@@ -5,6 +5,31 @@
 module Hyrax
   module Actors
     class MonographActor < Hyrax::Actors::BaseActor
+      def create(attributes)
+        attributes = apply_default_group_permissions(attributes)
+        super
+      end
+
+      def update(attributes)
+        attributes = apply_default_group_permissions(attributes)
+        super
+      end
+
+      private
+
+        # Add some default read and edit groups for that Press, for that Role
+        def apply_default_group_permissions(attributes)
+          admin = "#{attributes['press']}_admin"
+          editor = "#{attributes['press']}_editor"
+
+          (attributes["read_groups"] ||= []).push(admin).push(editor)
+          (attributes["edit_groups"] ||= []).push(admin).push(editor)
+
+          if attributes["visibility"] == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            attributes["read_groups"].push("public")
+          end
+          attributes
+        end
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,11 +16,20 @@ class Ability
     can [:read], SubBrand
 
     # press admin
+    grant_press_admin_abilities
+
+    grant_platform_admin_abilities
+  end
+
+  def grant_press_admin_abilities
     can :manage, Role, resource_id: @user.admin_roles.pluck(:resource_id), resource_type: 'Press'
 
-    # monograph.press is a String (the subdomain of a Press)
     can %i[create update], Monograph do |m|
       @user.admin_presses.map(&:subdomain).include?(m.press)
+    end
+
+    can %i[create update], ::Hyrax::FileSet do |f|
+      @user.admin_presses.map(&:subdomain).include?(f.parent.press) unless f.parent.nil?
     end
 
     can :manage, SubBrand do |sb|
@@ -39,8 +48,6 @@ class Ability
     can :update, Hyrax::FileSetPresenter do |p|
       @user.admin_presses.map(&:subdomain).include?(p.monograph.subdomain)
     end
-
-    grant_platform_admin_abilities
   end
 
   def grant_platform_admin_abilities

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    visibility:
+      private:
+        text: "Draft"
+      restricted:
+        class: "label-danger"
+        text: "Draft"

--- a/spec/actors/hyrax/actors/monograph_actor_spec.rb
+++ b/spec/actors/hyrax/actors/monograph_actor_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate curation_concerns:work Monograph`
+require 'rails_helper'
+
+describe Hyrax::Actors::MonographActor do
+  subject { Hyrax::CurationConcern.actor(monograph, ::Ability.new(user)) }
+
+  let(:user) { create(:user) }
+  let(:monograph) { Monograph.new }
+  let(:admin_set) { create(:admin_set, with_permission_template: { with_active_workflow: true }) }
+
+  describe "create" do
+    before do
+      stub_out_redis
+    end
+
+    context "with a non-public visibility" do
+      let(:attributes) do
+        { title: ["Things About Stuff"],
+          press: "heliotrope",
+          visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      end
+
+      it "adds default group read and edit permissions" do
+        subject.create(attributes)
+
+        expect(monograph.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
+        expect(monograph.edit_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
+      end
+
+      it "updates to public" do
+        attributes["visibility"] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        subject.update(attributes)
+
+        expect(monograph.read_groups).to include("public")
+      end
+    end
+
+    context "with a public visibility" do
+      let(:attributes) do
+        { title: ["Things About Stuff"],
+          press: "heliotrope",
+          visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      end
+
+      it "adds default group read and edit permissions including public read" do
+        subject.create(attributes)
+
+        expect(monograph.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor", "public"]
+        expect(monograph.edit_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
+      end
+
+      it "updates with a new group" do
+        (attributes["edit_groups"] ||= []).push("anotherpress_editor")
+        subject.update(attributes)
+
+        expect(monograph.edit_groups).to match_array ["heliotrope_admin", "heliotrope_editor", "anotherpress_editor"]
+      end
+
+      it "updates to private" do
+        attributes["visibility"] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        subject.update(attributes)
+
+        expect(monograph.read_groups).to_not include("public")
+      end
+    end
+  end
+end

--- a/spec/actors/hyrax/monograph_actor_spec.rb
+++ b/spec/actors/hyrax/monograph_actor_spec.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Generated via
-#  `rails generate curation_concerns:work Monograph`
-require 'rails_helper'
-
-describe Hyrax::Actors::MonographActor do
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,4 +64,26 @@ describe User do
       it { is_expected.to be false }
     end
   end
+
+  describe '#groups' do
+    let(:press1) { create(:press, subdomain: 'red') }
+    let(:press2) { create(:press, subdomain: 'blue') }
+
+    let(:admin) { create(:user) }
+    let(:editor) { create(:user) }
+    let(:platform_admin) { create(:platform_admin) }
+
+    before do
+      Press.delete_all
+      Role.delete_all
+      create(:role, resource: press1, user: admin, role: 'admin')
+      create(:role, resource: press2, user: editor, role: 'editor')
+    end
+
+    it "returns the right groups for users" do
+      expect(admin.groups).to eq ["red_admin"]
+      expect(editor.groups).to eq ["blue_editor"]
+      expect(platform_admin.groups).to eq ["blue_admin", "blue_editor", "red_admin", "red_editor", "admin"]
+    end
+  end
 end


### PR DESCRIPTION
… as Draft like umrdr)

Also adds default press roles (editor, admin) with read/edit access to all new and updated monographs.

Without this the only user able to see/edit a draft would be the one who uploaded it (or ran the importer).