### PR TITLE
remove jquery.turbolinks; include turbolinks before blacklight

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,23 +10,16 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-// The order of inclusion of jQuery is important –
-// ensure you load jquery.turbolinks before turbolinks and after jquery.
-// note: jquery is in ./common.js
-//= require common
-//= require jquery.turbolinks
-// Include all your custom js between jquery-turbolinks.js
+//= require jquery
 //= require jquery_ujs
+//= require turbolinks
 //= require jquery-ui/datepicker
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
-// Required by Blacklight
+// note: blacklight/blacklight must always be included after turbolinks
 //= require blacklight/blacklight
-// Required by Heliotrope?
 //= require cozy-sun-bear-main
 //= require 'bowser.min'
-// Required by Samvera/Rails?
-// and turbolinks.js
-//= require turbolinks
 //= require_tree ./application
+//= require common
 //= require hyrax

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,6 +1,7 @@
 // Scripts common to app and embed views
 //
-//= require jquery
+// removing jquery to have it before turbolinks atop application.js
+// require jquery
 //= require leaflet_1.0.3
 //= require leaflet-iiif_1.2.1_best_fit
 // Able Player stuff

--- a/app/assets/javascripts/embed.js
+++ b/app/assets/javascripts/embed.js
@@ -1,3 +1,5 @@
 // A place to put embed-specific scripts
 //
+// removing jquery from common.js to have it before turbolinks atop application.js
+//= require jquery
 //= require common


### PR DESCRIPTION
I don't think we need `jquery.turbolinks`, which is not currently compatible with Turbolinks 5/Rails 5.

The Turbolinks<->Blacklight ordering issue resolves problems with Able Player not loading on first page load. 
