### PR TITLE
Explicitly target ruby version 2.3.1 for all cops.

### DIFF
--- a/ruumba/.ruumba.yml
+++ b/ruumba/.ruumba.yml
@@ -1,3 +1,7 @@
+AllCops:
+  TargetRubyVersion:
+    2.3.1
+
 Layout/AlignHash:
   Enabled: false
 Layout/AlignParameters:
@@ -49,6 +53,8 @@ Style/AndOr:
 Style/ConditionalAssignment:
   Enabled: false
 Style/EmptyElse:
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false
 Style/HashSyntax:
   Enabled: false


### PR DESCRIPTION
Was getting some ruumbacop warnings when I updated the hyrax2 branch and noticed it was targeting an earlier version of ruby, hence the explicit ruby version statement in the .ruumba.yml file of this pull request.