### PR TITLE
add survey info block to asset and monograph catalog views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mlibrary/heliotrope/badge.svg?branch=master)](https://coveralls.io/github/mlibrary/heliotrope?branch=master)
 [![Stories in Ready](https://badge.waffle.io/mlibrary/heliotrope.png?label=ready&title=Ready)](https://waffle.io/mlibrary/heliotrope)
 
-[Samvera](https://wiki.duraspace.org/display/samvera/Samvera)based digital publishing platform built by the [University of Michigan Library](https://www.lib.umich.edu/)
+[Samvera](https://wiki.duraspace.org/display/samvera/Samvera) based digital publishing platform built by the [University of Michigan Library](https://www.lib.umich.edu/)
 
 ## Development
 
@@ -34,7 +34,7 @@ If you need to run this when the app has been deployed, run:
 
 ```
 $ vi ./config/role_map.yml
-   
+
 development:
   admin:   
     - yourself@domain.com
@@ -67,7 +67,7 @@ solr_wrapper --config .wrap_conf/solr_dev
 #### Create [default administrative set](https://github.com/samvera/hyrax#create-default-administrative-set) and load [workflows](https://github.com/samvera/hyrax/wiki/Defining-a-Workflow)
 
 `bundle exec rake hyrax:default_admin_set:create`
- 
+
 `bundle exec rake hyrax:workflow:load`
 
 ## Debugging

--- a/app/assets/javascripts/application/survey.js
+++ b/app/assets/javascripts/application/survey.js
@@ -1,0 +1,32 @@
+$(document).ready(function () {
+  if ($(".asset").length > 0 || (".monograph").length > 0) {
+    displaySurvey();
+    closeSurvey();
+  }
+});
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Display the survey, but
+// if the users chooses to ignore the survey or clicks the link to the survey
+// don't show the survey message again.
+
+function displaySurvey() {
+  var surveyStatus = Cookies.get('survey');
+  if (( surveyStatus == 'ignore') || (surveyStatus == 'clicked')) {
+    $("div.survey").hide();
+  } else {
+    $("div.survey").show();
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+function closeSurvey() {
+  $(".survey a.close").click(function() {
+    $("div.survey").hide();
+  });
+
+  $(".survey a.btn-primary").click(function() {
+    $("div.survey").hide();
+  });
+}

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -459,6 +459,28 @@ footer.press {
 }
 
 ///////////////////////////////////
+// SURVEY
+///////////////////////////////////
+.survey {
+  font-size: 1.5em;
+
+  .message {
+    padding-bottom: 1em;
+  }
+
+  a.btn-primary, a.btn-primary:hover, a.btn-primary:active {
+    color: #fff;
+  }
+
+  a.btn-default, a.btn-default:active, a.btn-default:hover {
+    color: inherit;
+    background-color: #d9edf7;
+    border-color: #d9edf7;
+  }
+
+}
+
+///////////////////////////////////
 // EPUB READER - cozy-sun-bear
 ///////////////////////////////////
 #epub {

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,5 +1,13 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
+  <!-- survey -->
+  <div class="alert alert-info alert-dismissible survey" alert="role" style="display: none;">
+     <a class="close" data-dismiss="alert" aria-label="Close" href="#" onclick="Cookies.set('survey', 'ignore', { expires: 15 });">&#x2715</a>
+     <p class="message">Got two minutes? Help us improve your experience on Fulcrum by answering a few questions about your visit.</p>
+     <a href="https://umich.qualtrics.com/jfe/form/SV_5clJsgxZXioWanH?Book=<%= @presenter.monograph.page_title %>&Asset=<%= @presenter.page_title %>" class="btn btn-primary btn-lg" role="button" target="_blank" onclick="Cookies.set('survey', 'clicked', { expires: 30 });" data-dismiss="alert">Yes, I can help.</a>
+     <a href="#" class="btn btn-default btn-lg" role="button" data-dismiss="alert" aria-label="Close" onclick="Cookies.set('survey', 'ignore', { expires: 15 });">No thanks.</a>
+  </div>
+
   <!-- breadcrumbs -->
   <div class="row">
     <nav class="breadcrumbs col-sm-12">

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -2,6 +2,14 @@
 <% provide :page_class, 'search monograph' %>
 
 <% provide :page_header do %>
+  <!-- survey -->
+  <div class="alert alert-info  alert-dismissible survey" role="alert" style="display: none;">
+    <a class="close" data-dismiss="alert" aria-label="Close" href="#" onclick="Cookies.set('survey', 'ignore', { expires: 15 });">&#x2715</a>
+    <p class="message">Got two minutes? Help us improve your experience on Fulcrum by answering a few questions about your visit.</p>
+    <a class="btn btn-primary btn-lg" role="button" href="https://umich.qualtrics.com/jfe/form/SV_5clJsgxZXioWanH?Book=<%= @monograph_presenter.page_title %>" target="_blank" onclick="Cookies.set('survey', 'clicked', { expires: 30 });" data-dismiss="alert">Yes, I can help.</a>
+    <a href="#" class="btn btn-default btn-lg" role="button" data-dismiss="alert" aria-label="Close" onclick="Cookies.set('survey', 'ignore', { expires: 15 });">No thanks.</a>
+  </div>
+
   <!-- breadcrumbs -->
   <div class="row">
     <nav class="breadcrumbs col-sm-12">


### PR DESCRIPTION
Resolves #1092 

- adds survey info block to asset and monograph catalog views
- link to survey passes book or book and asset titles to the survey and is displayed on survey
- survey is hidden by default and shown only if a survey cookie does not exist
- cookie is registered if user closes survey info block or clicks survey button
- cookie length for taking survey is 30 days; cookie length for closing survey is 15 days
- fixed typo in README :)