### PR TITLE
Addresses #821 cover images alt text.

### DIFF
--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -160,5 +160,15 @@ module Hyrax
       return nil if representative_id.blank?
       @representative_presenter ||= Hyrax::PresenterFactory.build_presenters([representative_id], Hyrax::FileSetPresenter, current_ability).first
     end
+
+    def representative_alt_text?
+      solr_document.representative_id.present?
+    end
+
+    # Alt text for cover page/thumbnail. Defaults to first title if not found.
+    def representative_alt_text
+      rep = representative_presenter
+      rep.nil? || rep.alt_text.empty? ? solr_document.title.first : rep.alt_text.first
+    end
   end
 end

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -9,8 +9,8 @@
     <% end %>
 <% else %>
     <figure>
+        <% alt = file_set.alt_text.present? ? file_set.alt_text : "Thumbnail of #{file_set.to_s}" %>
         <%= image_tag thumbnail_url(file_set),
-                      class: "img-responsive",
-                      alt: "Thumbnail of #{file_set.to_s}" %>
+                      class: "img-responsive", alt: alt %>
     </figure>
 <% end %>

--- a/app/views/press_catalog/_thumbnail_list_monograph.html.erb
+++ b/app/views/press_catalog/_thumbnail_list_monograph.html.erb
@@ -1,5 +1,9 @@
 <%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
 <div class="col-sm-3">
-  <a href="<%= polymorphic_path(url_for_document(document)) %>" ><img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/225,/0/default.jpg" alt="<%= document.title.first %>"></a>
+  <% presenter = Hyrax::MonographPresenter.new(document, current_ability) %>
+  <a href="<%= polymorphic_path(url_for_document(document)) %>" >
+    <img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/225,/0/default.jpg"
+         alt="<%= presenter.representative_alt_text %>">
+  </a>
 </div>
 <%- end %>


### PR DESCRIPTION
Monograph catalog page only tested via a hack because my dev machine is using placeholders instead of images for cover pages.