### PR TITLE
Resolves #941: Monograph EPub indexing bug

### DIFF
--- a/app/indexers/monograph_indexer.rb
+++ b/app/indexers/monograph_indexer.rb
@@ -14,8 +14,10 @@ class MonographIndexer < Hyrax::WorkIndexer
       existing_fileset_order = existing_filesets
       solr_doc[Solrizer.solr_name('ordered_member_ids', :symbol)] = object.ordered_member_ids
       solr_doc[Solrizer.solr_name('representative_id', :symbol)] = object.representative_id
-      solr_doc[Solrizer.solr_name('representative_epub_id', :symbol)] = existing_fileset_order.find { |id| ['application/epub+zip'].include? FileSet.find(id).mime_type }
       trigger_fileset_reindexing(existing_fileset_order, object.ordered_member_ids)
+
+      # grab the first fileset that is an epub and set it as the representative_epub_id
+      solr_doc[Solrizer.solr_name('representative_epub_id', :symbol)] = existing_filesets.find { |id| ['application/epub+zip'].include? FileSet.find(id).mime_type }
     end
   end
 


### PR DESCRIPTION
Was using 'existing_fileset_order' which didn't include the recently added fileset.
Now using 'existing_filesets' which includes the recently added fileset.