### PR TITLE
Resolves #1264 Add EPUB navigation slider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '363898fc7a14787dae627eeb4fd0b8fc5c3d8a9a'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '0f25581d4ec498662d59d1b2bb62d8a235d1782b'
 
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 363898fc7a14787dae627eeb4fd0b8fc5c3d8a9a
-  ref: 363898fc7a14787dae627eeb4fd0b8fc5c3d8a9a
+  revision: 0f25581d4ec498662d59d1b2bb62d8a235d1782b
+  ref: 0f25581d4ec498662d59d1b2bb62d8a235d1782b
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)
@@ -938,4 +938,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0.pre.1
+   1.16.0.pre.3

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -79,6 +79,7 @@
       cozy.control.pagePrevious({ region: 'left.sidebar' }).addTo(reader);
       cozy.control.pageNext({ region: 'right.sidebar' }).addTo(reader);
       // cozy.control.pageLast({ region: 'right.sidebar' }).addTo(reader);
+      cozy.control.navigator({ region: 'book.navigator' }).addTo(reader);
 
       // Publisher/copyright widgets
       cozy.control.publicationMetadata({ region: 'bottom.footer' }).addTo(reader);


### PR DESCRIPTION
I've tested this with a couple of epubs (nyupress and an heb book) and it seems fine, but it can have the problem that CSB ticket 69 (which isn't done yet), https://github.com/mlibrary/cozy-sun-bear/issues/69, should solve.

![slides-off-screen](https://user-images.githubusercontent.com/3924142/31741747-5f186fa8-b423-11e7-91bd-288b13bc5d29.png)

I guess it doesn't matter if this is merged first, then CSB 69 is done, or the other way around.
