### PR TITLE
Addresses #1055 adding Analytics page for platform admins.

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AnalyticsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    if current_user.platform_admin?
+      @analytics = AnalyticsPresenter.new(current_user)
+      render
+    else
+      render 'hyrax/base/unauthorized', status: :unauthorized
+    end
+  end
+end

--- a/app/models/pageview.rb
+++ b/app/models/pageview.rb
@@ -6,3 +6,49 @@ class Pageview
   metrics :pageviews
   dimensions :date, :pagePath
 end
+
+class GABounceRate
+  extend Legato::Model
+
+  metrics :bounceRate
+end
+
+class GASessions
+  extend Legato::Model
+
+  metrics :sessions
+end
+
+class GAUsers
+  extend Legato::Model
+
+  metrics :users
+end
+
+class GAPages
+  extend Legato::Model
+
+  dimensions :pageTitle
+  metrics :pageviews
+end
+
+class GALandingPages
+  extend Legato::Model
+
+  dimensions :landingPagePath, :pageTitle
+  metrics :pageviews
+end
+
+class GAChannels
+  extend Legato::Model
+
+  dimensions :channelGrouping
+  metrics :pageviews
+end
+
+class GAReferrers
+  extend Legato::Model
+
+  dimensions :fullReferrer
+  metrics :pageviews
+end

--- a/app/presenters/analytics_presenter.rb
+++ b/app/presenters/analytics_presenter.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class AnalyticsPresenter
+  attr_reader :current_user
+
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def can_read?
+    @current_user.platform_admin?
+  end
+
+  def users
+    Rails.cache.read('ga_users') || 0
+  end
+
+  def sessions
+    Rails.cache.read('ga_sessions') || 0
+  end
+
+  def page_views
+    Rails.cache.read('ga_pageviews').nil? ? 0 : Rails.cache.read('ga_pageviews').count
+  end
+
+  def bounce_rate
+    Rails.cache.read('ga_bouncerate') || 0.0
+  end
+
+  def top_pages
+    top_ten('ga_pages')
+  end
+
+  def landing_pages
+    top_ten('ga_landing_pages')
+  end
+
+  def channels
+    top_ten('ga_channels')
+  end
+
+  def referrers
+    top_ten('ga_referrers')
+  end
+
+  private
+
+    def top_ten(cache_name)
+      top = []
+      ga_pages = Rails.cache.read(cache_name)
+      return top unless ga_pages.is_a?(Array)
+      last = [9, ga_pages.count - 1].min
+      (0..last).each do |i|
+        top << { name: ga_pages[i].pageTitle, count: ga_pages[i].pageviews }
+      end
+      top
+    end
+end

--- a/app/presenters/concerns/cc_analytics_presenter.rb
+++ b/app/presenters/concerns/cc_analytics_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AnalyticsPresenter
+module CCAnalyticsPresenter
   extend ActiveSupport::Concern
 
   def pageviews_by_path(path)
@@ -12,7 +12,7 @@ module AnalyticsPresenter
         count += entry[:pageviews].to_i if entry[:pagePath] == path
       end
     end
-    return count
+    count
   end
 
   def pageviews_by_ids(ids)
@@ -26,6 +26,6 @@ module AnalyticsPresenter
         end
       end
     end
-    return count
+    count
   end
 end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -3,7 +3,7 @@
 module Hyrax
   class FileSetPresenter
     include TitlePresenter
-    include AnalyticsPresenter
+    include CCAnalyticsPresenter
     include OpenUrlPresenter
     include ModelProxy
     include PresentsAttributes

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -2,7 +2,7 @@
 
 module Hyrax
   class MonographPresenter < WorkShowPresenter
-    include AnalyticsPresenter
+    include CCAnalyticsPresenter
     include ISBNPresenter
     include OpenUrlPresenter
     include TitlePresenter

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -1,0 +1,104 @@
+<h2>Analytics</h2>
+
+<div class="row">
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Google Analytics</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-google-analytics" style="height: 200px">
+          <ul>
+            <li>Users: <%= @analytics.users %></li>
+            <li>Sessions: <%= @analytics.sessions %></li>
+            <li>Pageviews: <%= @analytics.page_views %></li>
+            <li>Bounce Rate: <%= number_to_percentage(@analytics.bounce_rate, precision: 2) %></li>
+          <ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Top Pages</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-top-pages" style="height: 200px">
+          <ul>
+            <% @analytics.top_pages.each do |val| %>
+            <li><%= val[:name] %> (<%= val[:count] %>)</li>
+            <% end %>
+          <ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Top Landing Pages</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-top-landing-pages" style="height: 200px">
+          <ul>
+            <% @analytics.landing_pages.each do |val| %>
+            <li><%= val[:name] %> (<%= val[:count] %>)</li>
+            <% end %>
+          <ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Channels</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-channels" style="height: 200px">
+          <ul>
+            <% @analytics.channels.each do |val| %>
+            <li><%= val[:name] %> (<%= val[:count] %>)</li>
+            <% end %>
+          <ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Referrers</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-blah1" style="height: 200px">
+          <ul>
+            <% @analytics.referrers.each do |val| %>
+            <li><%= val[:name] %> (<%= val[:count] %>)</li>
+            <% end %>
+          <ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="h3 panel-title">Blah</div>
+      </div>
+      <div class="panel-body">
+        <div id="dashboard-blah2" style="height: 200px">
+          
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -8,6 +8,10 @@
     <ul class="dropdown-menu">
       <li><%= link_to 'Fulcrum', main_app.fulcrum_path, role: 'menuitem'  %></li>
       <li class="divider"></li>
+      <% show_analytics_link = current_user && current_user.platform_admin? %>
+      <% if show_analytics_link %>
+        <li><%= link_to 'Analytics', main_app.analytics_path, role: 'menuitem' %></li>
+      <% end %>
       <li><%= link_to 'Admin', hyrax.admin_path, role: 'menuitem'  %></li>
       <li><%= link_to 'Dashboard', hyrax.dashboard_index_path, role: 'menuitem'  %></li>
       <li class="divider"></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get 'embed', controller: :embed, action: :show
   get 'fulcrum', controller: :fulcrum, action: :index, as: :fulcrum
   get 'fulcrum/:partial', controller: :fulcrum, action: :show, as: :partial_fulcrum
+  get 'analytics', controller: :analytics, action: :show
 
   mount Blacklight::Engine => '/'
   mount Riiif::Engine => '/image-service', as: 'riiif'

--- a/lib/tasks/ga_cache.rake
+++ b/lib/tasks/ga_cache.rake
@@ -27,6 +27,39 @@ namespace :heliotrope do
 
           Rails.cache.write('ga_pageviews', cached)
           Rails.logger.info("Wrote ga_pageviews to cache")
+
+          GASessions.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 1).each do |entry|
+            Rails.cache.write('ga_sessions', entry.sessions)
+          end
+          Rails.logger.info("Wrote ga_sessions to cache")
+          GAUsers.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 1).each do |entry|
+            Rails.cache.write('ga_users', entry.users)
+          end
+          Rails.logger.info("Wrote ga_users to cache")
+          cached = []
+          GAPages.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 100, sort: '-pageviews').each do |entry|
+            cached << entry
+          end
+          Rails.cache.write('ga_pages', cached)
+          Rails.logger.info("Wrote #{cached.count} ga_pages to cache")
+          cached = []
+          GALandingPages.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 100, sort: '-pageviews').each do |entry|
+            cached << entry
+          end
+          Rails.cache.write('ga_landing_pages', cached)
+          Rails.logger.info("Wrote #{cached.count} ga_landing_pages to cache")
+          cached = []
+          GAChannels.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 100, sort: '-pageviews').each do |entry|
+            cached << entry
+          end
+          Rails.cache.write('ga_channels', cached)
+          Rails.logger.info("Wrote #{cached.count} ga_channels to cache")
+          cached = []
+          GAReferrers.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 100, sort: '-pageviews').each do |entry|
+            cached << entry
+          end
+          Rails.cache.write('ga_referrers', cached)
+          Rails.logger.info("Wrote #{cached.count} ga_referrers to cache")
         else
           Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
         end

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnalyticsController, type: :controller do
+  describe "GET #show" do
+    context 'unauthenticated user' do
+      before { get :show }
+      it { expect(response).to redirect_to('/users/sign_in') }
+    end
+    context "authenticated user" do
+      before do
+        sign_in current_user
+        get :show
+      end
+      context "non-admin" do
+        let(:current_user) { create(:user) }
+        it { expect(response).to be_unauthorized }
+      end
+      context "platform admin" do
+        let(:current_user) { create(:platform_admin) }
+        it { expect(response).to_not be_unauthorized }
+        it { expect(response).to be_success }
+      end
+    end
+  end
+end

--- a/spec/presenters/concerns/cc_analytics_presenter_spec.rb
+++ b/spec/presenters/concerns/cc_analytics_presenter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AnalyticsPresenter do
+describe CCAnalyticsPresenter do
   let(:ability) { double('ability') }
   let(:presenter) { Hyrax::FileSetPresenter.new(fileset_doc, ability) }
   let(:fileset_doc) { SolrDocument.new(id: 'fs') }

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::MonographPresenter do
   describe '#presenters' do
     subject { described_class.new(nil, nil) }
     it do
-      is_expected.to be_a AnalyticsPresenter
+      is_expected.to be_a CCAnalyticsPresenter
       is_expected.to be_a ISBNPresenter
       is_expected.to be_a OpenUrlPresenter
       is_expected.to be_a TitlePresenter

--- a/spec/views/analytics/show.html.erb_spec.rb
+++ b/spec/views/analytics/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "analytics/show.html.erb", type: :view do
+  let(:current_user) { create(:platform_admin) }
+  before do
+    @analytics = AnalyticsPresenter.new(current_user)
+    render
+  end
+  it { expect(rendered).to match(/Analytics/) }
+end

--- a/spec/views/shared/_my_actions.html.erb_spec.rb
+++ b/spec/views/shared/_my_actions.html.erb_spec.rb
@@ -19,6 +19,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has correct links' do
+        expect(rendered).to have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Jobs", href: resque_web_path)
@@ -32,6 +33,7 @@ describe 'shared/_my_actions.html.erb' do
       before { render }
 
       it 'has correct links' do
+        expect(rendered).to have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Jobs", href: resque_web_path)
@@ -52,6 +54,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has the correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Embargos", href: embargoes_path)
@@ -68,6 +71,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has the correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Embargos", href: embargoes_path)
@@ -87,6 +91,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has the correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Embargos", href: embargoes_path)
@@ -103,6 +108,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has the correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Embargos", href: embargoes_path)
@@ -122,6 +128,7 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to     have_link("Dashboard")
         expect(rendered).to     have_link("Log Out")
         expect(rendered).to_not have_link("Jobs", href: resque_web_path)
@@ -137,6 +144,7 @@ describe 'shared/_my_actions.html.erb' do
       before { render }
 
       it 'has correct links' do
+        expect(rendered).to_not have_link("Analytics")
         expect(rendered).to     have_link("Dashboard")
         expect(rendered).to     have_link("Log Out")
         expect(rendered).to_not have_link("Users")


### PR DESCRIPTION
This will probably not suffice to close the ticket, since I believe the intent is for press admins to be able to see analytics tailored for them.

Renamed concerns/analytics_presenter.rb to CCAnalyticsPresenter to avoid a naming conflict. That and my AnalyticsPresenter should probably be merged or refactored in some dramatically smarter way.