### PR TITLE
change sidebar class to fulcrum_sidebar to avoid hyrax conflicts

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -152,7 +152,7 @@ footer.press {
 ///////////////////////////////////
 .monograph {
 
-  .sidebar {
+  .fulcrum_sidebar {
     // In hyrax2 this defaults to grey which we don't want
     background-color: white;
   }

--- a/app/views/layouts/curation_concerns/catalog.html.erb
+++ b/app/views/layouts/curation_concerns/catalog.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
   <% if content_for?(:sidebar) %>
 
-    <div class="col-md-3 sidebar">
+    <div class="col-md-3 fulcrum_sidebar">
       <%= yield(:sidebar) %>
     </div>
 

--- a/app/views/monograph_catalog/_index_epub.html.erb
+++ b/app/views/monograph_catalog/_index_epub.html.erb
@@ -103,7 +103,7 @@ $(document).ready(function() {
       </div>
       <% if @monograph_presenter.assets? %>
         <div role="tabpanel" class="tab-pane media row" id="media">
-          <div class="col-sm-3 sidebar">
+          <div class="col-sm-3 fulcrum_sidebar">
             <%= render 'catalog/search_sidebar' %>
           </div>
           <div class="col-sm-9">


### PR DESCRIPTION
Resolves #1416 

Renamed `.sidebar` to `.fulcrum_sidebar` to avoid inheriting hyrax dashboard class. 