### PR TITLE
Create parent/child self-referential relationship for Press (soon to …

### DIFF
--- a/app/controllers/presses_controller.rb
+++ b/app/controllers/presses_controller.rb
@@ -30,6 +30,6 @@ class PressesController < ApplicationController
 
     def press_params
       params.require(:press).permit(:subdomain, :name, :logo_path, :description, :press_url, :google_analytics,
-                                    :typekit, :footer_block_a, :footer_block_c, :remove_logo_path)
+                                    :typekit, :footer_block_a, :footer_block_c, :remove_logo_path, :parent_id)
     end
 end

--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -22,28 +22,56 @@ module PressHelper
     press.present? ? press.logo_path_url : 'fulcrum-white-50px.png'
   end
 
-  def footer_block_a(subdomain)
-    press = Press.where(subdomain: subdomain)&.first
-    press.footer_block_a if press.present?
-  end
-
-  def footer_block_c(subdomain)
-    press = Press.where(subdomain: subdomain)&.first
-    press.footer_block_c if press.present?
-  end
-
   def url(subdomain)
     press = Press.where(subdomain: subdomain)&.first
     press.press_url if press.present?
   end
 
+  # These are not required. If there's no value we'll try to get the parent's (if one exists)
+
+  def footer_block_a(subdomain)
+    press = Press.where(subdomain: subdomain)&.first
+    return if press.blank?
+    if press.footer_block_a.blank?
+      parent_press(press)&.footer_block_a
+    else
+      press.footer_block_a
+    end
+  end
+
+  def footer_block_c(subdomain)
+    press = Press.where(subdomain: subdomain)&.first
+    return if press.blank?
+    if press.footer_block_c.blank?
+      parent_press(press)&.footer_block_c
+    else
+      press.footer_block_c
+    end
+  end
+
   def google_analytics(subdomain)
     press = Press.where(subdomain: subdomain)&.first
-    press.google_analytics if press.present?
+    return if press.blank?
+    if press.google_analytics.blank?
+      parent_press(press)&.google_analytics
+    else
+      press.google_analytics
+    end
   end
 
   def typekit(subdomain)
     press = Press.where(subdomain: subdomain)&.first
-    press.typekit if press.present?
+    return if press.blank?
+    if press.typekit.blank?
+      parent_press(press)&.typekit
+    else
+      press.typekit
+    end
   end
+
+  private
+
+    def parent_press(child_press)
+      Press.find(child_press.parent_id) if child_press.parent_id.present?
+    end
 end

--- a/app/models/press.rb
+++ b/app/models/press.rb
@@ -12,6 +12,12 @@ class Press < ApplicationRecord
   has_many :sub_brands
   accepts_nested_attributes_for :roles, allow_destroy: true, reject_if: proc { |attr| attr['user_key'].blank? && attr['id'].blank? }
 
+  # A Press can have a parent press and can have children presses
+  belongs_to :parent, class_name: 'Press', optional: true
+  has_many :children, class_name: 'Press', foreign_key: 'parent_id'
+  # Get only presses that are "root" parents
+  scope :parent_presses, -> { where(parent_id: nil) }
+
   def to_param
     subdomain
   end

--- a/app/views/presses/_form.html.erb
+++ b/app/views/presses/_form.html.erb
@@ -29,5 +29,6 @@
   <%= f.input :typekit, label: 'Typekit ID' %>
   <%= f.input :footer_block_a %>
   <%= f.input :footer_block_c %>
+  <%= f.input :parent_id, collection: Press.parent_presses, prompt: "Choose a parent press (optional)" %>
   <%= f.submit label: 'Save Publisher' %>
 <% end %>

--- a/db/migrate/20171212164112_add_parent_id_to_presses.rb
+++ b/db/migrate/20171212164112_add_parent_id_to_presses.rb
@@ -1,0 +1,6 @@
+class AddParentIdToPresses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :presses, :parent_id, :integer
+    add_index :presses, :parent_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171019191061) do
+ActiveRecord::Schema.define(version: 20171212164112) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -213,6 +213,8 @@ ActiveRecord::Schema.define(version: 20171019191061) do
     t.string "typekit"
     t.text "footer_block_a"
     t.text "footer_block_c"
+    t.integer "parent_id"
+    t.index ["parent_id"], name: "index_presses_on_parent_id"
   end
 
   create_table "proxy_deposit_requests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/helpers/press_helper_spec.rb
+++ b/spec/helpers/press_helper_spec.rb
@@ -57,4 +57,36 @@ describe PressHelper do
     #   end
     # end
   end
+
+  describe "when a child press has a parent" do
+    let(:press) { create(:press, subdomain: "blue",
+                                 name: "Blue Press",
+                                 logo_path: Rack::Test::UploadedFile.new(File.open(Rails.root.join('spec', 'fixtures', 'csv', 'import', 'shipwreck.jpg')), 'image/jpg'),
+                                 description: "This is Blue Press",
+                                 press_url: "http://blue.com",
+                                 google_analytics: "GA-ID-BLUE",
+                                 typekit: "BLUE-TYPEKIT",
+                                 footer_block_a: "blue-footer-a",
+                                 footer_block_c: "blue-footer-c",
+                                 parent_id: nil) }
+    let(:child) { create(:press, subdomain: "maize",
+                                 name: "Maize Press",
+                                 logo_path: Rack::Test::UploadedFile.new(File.open(Rails.root.join('spec', 'fixtures', 'csv', 'import', 'miranda.jpg')), 'image/jpg'),
+                                 description: "This is Maize Press",
+                                 press_url: "http://blue.com/maize",
+                                 google_analytics: nil, # factorybot will fake a ga-id without this
+                                 parent_id: press.id) }
+
+    context "when the child is missing a field" do
+      it "uses the parent's field" do
+        expect(footer_block_a(child.subdomain)).to eq press.footer_block_a
+        expect(footer_block_c(child.subdomain)).to eq press.footer_block_c
+        expect(google_analytics(child.subdomain)).to eq press.google_analytics
+        expect(typekit(child.subdomain)).to eq press.typekit
+      end
+      it "does not use the parent's name, since a name is required for all presses" do
+        expect(name(child.subdomain)).to eq child.name
+      end
+    end
+  end
 end

--- a/spec/models/press_spec.rb
+++ b/spec/models/press_spec.rb
@@ -44,4 +44,43 @@ RSpec.describe Press, type: :model do
     let(:press) { build(:press) }
     it { is_expected.to eq [] }
   end
+
+  describe "a parent press" do
+    let(:parent_press) { create(:press, subdomain: "blue") }
+
+    context "with children" do
+      let!(:child1) { create(:press, subdomain: "maize", parent_id: parent_press.id) }
+      let!(:child2) { create(:press, subdomain: "green", parent_id: parent_press.id) }
+
+      it "the parent press knows it's children presses (that are series, imprints, whatever)" do
+        expect(parent_press.children.count).to eq 2
+        expect(parent_press.children.first.subdomain).to eq "maize"
+        expect(parent_press.children.last.subdomain).to eq "green"
+      end
+
+      it "the child presses know their parent" do
+        expect(child1.parent).to eq parent_press
+        expect(child2.parent).to eq parent_press
+      end
+
+      context "a child press can itself have children" do
+        # TODO: While this works in the model, it's not really supported anywhere else
+        # so if we ever actually need parent -> child -> child we'll have to make some code changes
+        let!(:child_child) { create(:press, subdomain: "orange", parent_id: child1.id) }
+
+        it "the child's child press knows it's parent" do
+          expect(child_child.parent).to eq child1
+        end
+
+        context "while there are many presses now, we can get a list of 'root' or 'ultimate parent' presses" do
+          it "there is only be one parent press" do
+            expect(Press.parent_presses.count).to be 1
+          end
+          it "there are 4 presses total" do
+            expect(Press.all.count).to be 4
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
…be Publisher)

With this PR a child publisher will inherit these field from it's parent if the child doesn't have their own:

footer_block_a
footer_block_b
google_analytics
typekit

Resolves #1387 
