### PR TITLE
Remove skip link from EPUB show page

### DIFF
--- a/app/views/fulcrum/show.html.erb
+++ b/app/views/fulcrum/show.html.erb
@@ -1,5 +1,6 @@
 <!--<%#= content_for(:body_attributes, 'data-no-turbolink') %>-->
 <% provide :page_title, "Dashboard #{@partial.capitalize}" %>
+<%= render 'shared/skip_links' %>
 <div id="dashboard" class="container-fluid">
   <div class="row">
     <div class="col col-sm-3 col-md-2" id="sidebar" role="navigation">

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -48,8 +48,6 @@
   <% end %>
   </head>
   <%= tag.body class: press_subdomains(press_subdomain) %>
-    <div class="skip"><a href="#maincontent">Skip to main content</a></div>
-
 
     <%= content_for?(:body) ? yield(:body) : yield %>
 

--- a/app/views/monograph_catalog/_index_epub.html.erb
+++ b/app/views/monograph_catalog/_index_epub.html.erb
@@ -1,4 +1,4 @@
-<div class="row monograph-info-epub">
+<div id="maincontent" class="row monograph-info-epub">
   <% if @monograph_presenter.monograph_coins_title? %>
       <!-- COinS for Zotero, etc -->
       <span class="Z3988" title="<%= @monograph_presenter.monograph_coins_title %>"></span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/skip_links' %>
 <header id="banner" role="banner">
   <hgroup>
     <% unless press_subdomain.nil? %>

--- a/app/views/shared/_skip_links.html.erb
+++ b/app/views/shared/_skip_links.html.erb
@@ -1,0 +1,1 @@
+<div class="skip"><a href="#maincontent">Skip to main content</a></div>


### PR DESCRIPTION
Resolves part 1 of #1409 

Moves skip link markup out of `app/views/layouts/boilerplate.html.erb` and to its own partial that is called on pages that use the navigation menu header (the idea of the skip link is to give keyboard users an option to skip tabbing through the navigation so this seems to make the most sense to me); 

Discovered EPUB monograph catalog show page was missing `maincontent` anchor -- this is added now;

As a result of moving skip links to their own partial, it is no longer included on the EPUB show page. 