### PR TITLE
"featured representatives", tabs for monograph_catalog page

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,6 +15,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/presenters/hyrax/file_set_presenter.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/controllers/featured_representatives_controller.rb
+++ b/app/controllers/featured_representatives_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FeaturedRepresentativesController < ApplicationController
+  before_action :authenticate_user!
+  load_and_authorize_resource
+
+  def save
+    fr = FeaturedRepresentative.where(monograph_id: params[:monograph_id],
+                                      file_set_id: params[:file_set_id],
+                                      kind: params[:kind]).first
+    if fr.blank?
+      FeaturedRepresentative.create!(monograph_id: params[:monograph_id],
+                                     file_set_id: params[:file_set_id],
+                                     kind: params[:kind])
+    end
+    redirect_to monograph_show_path(params[:monograph_id])
+  end
+
+  def delete
+    fr = FeaturedRepresentative.where(id: params[:id]).first
+    fr.destroy if fr.present?
+    redirect_to monograph_show_path(params[:monograph_id])
+  end
+end

--- a/app/indexers/monograph_indexer.rb
+++ b/app/indexers/monograph_indexer.rb
@@ -18,14 +18,8 @@ class MonographIndexer < Hyrax::WorkIndexer
       solr_doc[Solrizer.solr_name('representative_id', :symbol)] = object.representative_id
       trigger_fileset_reindexing(existing_fileset_order, object.ordered_member_ids)
 
-      # These are pulling all the FileSets for a monograph from fedora multiple times... TODO: make it not
-
-      # grab the first fileset that is an epub and set it as the representative_epub_id
-      solr_doc[Solrizer.solr_name('representative_epub_id', :symbol)] = existing_filesets.find { |id| ['application/epub+zip'].include? FileSet.find(id).mime_type }
       # grab the first fileset that is a csv and set it as the representative_manifest_id
       solr_doc[Solrizer.solr_name('representative_manifest_id', :symbol)] = existing_filesets.find { |id| ['text/csv', 'text/comma-separated-values'].include? FileSet.find(id).mime_type }
-      # grab the first fileset that is a webgl and set it
-      solr_doc[Solrizer.solr_name('representative_webgl_id', :symbol)] = existing_filesets.find { |id| ['application/zip'].include?(FileSet.find(id).mime_type) && File.extname(FileSet.find(id).original_file.file_name.first) == ".unity" }
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -51,6 +51,7 @@ class Ability
     can :publish, Monograph
     can :manage, Role
     can :manage, Press
+    can :manage, FeaturedRepresentative
   end
 
   def platform_admin?

--- a/app/models/concerns/solr_document_extensions/monograph.rb
+++ b/app/models/concerns/solr_document_extensions/monograph.rb
@@ -55,16 +55,8 @@ module SolrDocumentExtensions::Monograph
     Array(self[Solrizer.solr_name('primary_editor_given_name', :stored_searchable)]).first
   end
 
-  def representative_epub_id
-    Array(self[Solrizer.solr_name('representative_epub_id', :symbol)]).first
-  end
-
   def representative_manifest_id
     Array(self[Solrizer.solr_name('representative_manifest_id', :symbol)]).first
-  end
-
-  def representative_webgl_id
-    Array(self[Solrizer.solr_name('representative_webgl_id', :symbol)]).first
   end
 
   def section_titles

--- a/app/models/featured_representative.rb
+++ b/app/models/featured_representative.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FeaturedRepresentative < ApplicationRecord
+  KINDS = %w[epub webgl database aboutware].freeze
+
+  validates :monograph_id, presence: true
+  validates :file_set_id, presence: true
+  validates :kind, inclusion: { in: KINDS }
+  validates :kind, uniqueness: { scope: %i[monograph_id file_set_id],
+                                 message: "Only 1 type of Kind can be used for each Monograph's FileSet" }
+
+  def self.kinds
+    KINDS
+  end
+end

--- a/app/models/monograph_search_builder.rb
+++ b/app/models/monograph_search_builder.rb
@@ -25,10 +25,16 @@ class MonographSearchBuilder < ::SearchBuilder
       return if ids.blank?
 
       ids.delete(monograph.first['representative_id_ssim']&.first)
-      ids.delete(monograph.first['representative_epub_id_ssim']&.first)
       ids.delete(monograph.first['representative_manifest_id_ssim']&.first)
-      ids.delete(monograph.first['representative_webgl_id_ssim']&.first)
+      featured_representatives(monograph.first['id']).each do |fr|
+        ids.delete(fr.file_set_id)
+      end
+
       ids.join(',')
+    end
+
+    def featured_representatives(id)
+      FeaturedRepresentative.where(monograph_id: id)
     end
 
     def work_types

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -334,5 +334,13 @@ module Hyrax
                   'default'
                 end
     end
+
+    def featured_representative
+      FeaturedRepresentative.where(monograph_id: monograph_id, file_set_id: id).first
+    end
+
+    def featured_representative?
+      featured_representative
+    end
   end
 end

--- a/app/views/featured_representatives/_form.html.erb
+++ b/app/views/featured_representatives/_form.html.erb
@@ -1,0 +1,33 @@
+<% if member.featured_representative? %>
+<div class="row">
+  <div class="col-sm-8">
+    <b><%= member.featured_representative.kind %></b>
+  </div>
+  <div class="col-sm-4">
+    <% if can? :edit, member.id %>
+      <%= link_to "Unset", main_app.featured_representatives_path(id: member.featured_representative.id, monograph_id: member.monograph.id),
+          method: :delete, title: "Delete #{member.featured_representative.kind}",
+          data: { confirm: "Unset Featured Representative?" },
+          class: "btn btn-default" %>
+    <% end %>
+  </div>
+</div>
+<% else %>
+  <% if can? :edit, member.id %>
+    <% if member.monograph.present? %>
+      <%= form_tag(main_app.featured_representatives_path, method: "post") do %>
+        <div class="row">
+          <div class="col-sm-8">
+            <%= select_tag(:kind, options_for_select(FeaturedRepresentative.kinds - member.monograph.featured_representatives.map(&:kind)), class: 'form-control') %>
+
+            <%= hidden_field_tag(:file_set_id, member.id) %>
+            <%= hidden_field_tag(:monograph_id, member.monograph.id) %>
+          </div>
+          <div class="col-sm-4">
+            <%= submit_tag("Set", class: 'btn btn-default') %>
+          </div>
+        </div>
+      <% end %>
+    <% end  %>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,0 +1,20 @@
+<h2><%= t('.header') %></h2>
+<% if presenter.member_presenters.present? %>
+  <table class="table table-striped related-files">
+    <thead>
+      <tr>
+        <th><%= t('.thumbnail') %></th>
+        <th><%= t('.title') %></th>
+        <th><%= t('.date_uploaded') %></th>
+        <th><%= t('.visibility') %></th>
+        <th><%= t('.actions') %></th>
+        <th><%= t('.set_representative') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'member', collection: presenter.member_presenters %>
+    </tbody>
+  </table>
+<% elsif can? :edit, presenter.id %>
+    <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
+<% end %>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,0 +1,14 @@
+<tr class="<%= dom_class(member) %> attributes">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag member %>
+  </td>
+  <td class="attribute filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
+  <td class="attribute permission"><%= member.permission_badge %></td>
+  <td>
+    <%= render 'actions', member: member %>
+  </td>
+  <td>
+    <%= render 'featured_representatives/form', member: member %>
+  </td>
+</tr>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,6 +1,9 @@
 en:
   hyrax:
     account_name: "Fulcrum"
+    base:
+      items:
+        set_representative: "Set Representative"
     monographs:
       show:
         last_modified: "Last Modified"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get 'analytics', controller: :analytics, action: :show
   get 'webgl/:id', controller: :webgls, action: :show, as: :webgl
   get 'webgl/:id/*file', controller: :webgls, action: :file, as: :webgl_file
+  post 'featured_representatives', controller: :featured_representatives, action: :save
+  delete 'featured_representatives', controller: :featured_representatives, action: :delete
 
   mount Blacklight::Engine => '/'
   mount Riiif::Engine => '/image-service', as: 'riiif'

--- a/db/migrate/20180109210107_create_featured_representatives.rb
+++ b/db/migrate/20180109210107_create_featured_representatives.rb
@@ -1,0 +1,11 @@
+class CreateFeaturedRepresentatives < ActiveRecord::Migration[5.1]
+  def change
+    create_table :featured_representatives do |t|
+      t.string :monograph_id
+      t.string :file_set_id
+      t.string :kind
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180102224401) do
+ActiveRecord::Schema.define(version: 20180109210107) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -63,6 +63,14 @@ ActiveRecord::Schema.define(version: 20180102224401) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "featured_representatives", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "monograph_id"
+    t.string "file_set_id"
+    t.string "kind"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "featured_works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/controllers/featured_representatives_controller_spec.rb
+++ b/spec/controllers/featured_representatives_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeaturedRepresentativesController, type: :controller do
+  let(:monograph) { create(:monograph) }
+  let(:file_set)  { create(:file_set) }
+  let(:user) { create(:platform_admin) }
+
+  context "as a platform_admin" do
+    # TODO: allow press admins to set/unset FeaturedRepresentatives
+    before { sign_in user }
+
+    describe '#save' do
+      before { post :save, params: { monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub' } }
+      after { FeaturedRepresentative.destroy_all }
+
+      it "saves the featured_representative" do
+        expect(FeaturedRepresentative.all.count).to be 1
+      end
+    end
+
+    describe '#delete' do
+      let(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
+      before do
+        delete :delete, params: { id: fr.id, monograph_id: monograph.id }
+      end
+
+      it "deletes the featured_representative" do
+        expect(FeaturedRepresentative.all.count).to be 0
+      end
+    end
+  end
+end

--- a/spec/factories/featured_representatives.rb
+++ b/spec/factories/featured_representatives.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :featured_representative do
+    monograph_id "MyString"
+    file_set_id "MyString"
+    kind "epub"
+  end
+end

--- a/spec/indexers/monograph_indexer_spec.rb
+++ b/spec/indexers/monograph_indexer_spec.rb
@@ -41,32 +41,6 @@ RSpec.describe MonographIndexer do
     end
   end
 
-  describe 'representative_epub_id' do
-    subject { indexer.generate_solr_document[Solrizer.solr_name('representative_epub_id', :symbol)] }
-
-    let(:indexer) { described_class.new(monograph) }
-    let(:monograph) { build(:monograph) }
-
-    context 'no file set' do
-      before { monograph.save! }
-      it { is_expected.to be_nil }
-    end
-    context 'file set' do
-      before do
-        monograph.ordered_members << file_set
-        monograph.save!
-      end
-      context 'non-epub file set' do
-        let(:file_set) { create(:file_set) }
-        it { is_expected.to be_nil }
-      end
-      context 'epub file set' do
-        let(:file_set) { create(:file_set, content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
-        it { is_expected.to eq file_set.id }
-      end
-    end
-  end
-
   describe 'representative_manifest_id' do
     subject { indexer.generate_solr_document[Solrizer.solr_name('representative_manifest_id', :symbol)] }
 

--- a/spec/models/featured_representative_spec.rb
+++ b/spec/models/featured_representative_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeaturedRepresentative, type: :model do
+  describe '#kinds' do
+    it { expect(described_class.kinds).to eq %w[epub webgl database aboutware] }
+  end
+
+  describe "the combination of mongraph_id, file_set_id and kind" do
+    let!(:fr1) { create(:featured_representative, monograph_id: 1, file_set_id: 1, kind: 'epub') }
+    it "is unique" do
+      expect(described_class.create(monograph_id: 1, file_set_id: 1, kind: 'epub')).to_not be_valid
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -33,7 +33,6 @@ describe SolrDocument do
   it { is_expected.to respond_to(:primary_editor_family_name) }
   it { is_expected.to respond_to(:primary_editor_full_name) }
   it { is_expected.to respond_to(:primary_editor_given_name) }
-  it { is_expected.to respond_to(:representative_epub_id) }
   it { is_expected.to respond_to(:representative_manifest_id) }
 
   # FileSet

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -376,8 +376,21 @@ RSpec.describe Hyrax::MonographPresenter do
       it { expect(subject).to be nil }
     end
 
-    context 'has epub' do
-      before { allow(mono_doc).to receive(:representative_epub_id).and_return(fs2_doc.id) }
+    context 'featured_representatives' do
+      let!(:fr1) { create(:featured_representative, monograph_id: presenter.id,
+                                                    file_set_id: fs2_doc.id,
+                                                    kind: 'epub') }
+      let!(:fr2) { create(:featured_representative, monograph_id: presenter.id,
+                                                    file_set_id: fs3_doc.id,
+                                                    kind: 'webgl') }
+      after do
+        FeaturedRepresentative.destroy_all
+      end
+
+      describe '#featured_representatives' do
+        subject { presenter.featured_representatives }
+        it { expect(subject.count).to be 2 }
+      end
 
       describe '#epub?' do
         subject { presenter.epub? }
@@ -387,6 +400,26 @@ RSpec.describe Hyrax::MonographPresenter do
       describe '#epub' do
         subject { presenter.epub }
         it { expect(subject.id).to eq fs2_doc.id }
+      end
+
+      describe '#epub_id' do
+        subject { presenter.epub_id }
+        it { expect(subject).to eq fs2_doc.id }
+      end
+
+      describe '#webgl?' do
+        subject { presenter.webgl? }
+        it { expect(subject).to be true }
+      end
+
+      describe '#webgl' do
+        subject { presenter.webgl }
+        it { expect(subject.id).to eq fs3_doc.id }
+      end
+
+      describe '#webgl_id' do
+        subject { presenter.webgl_id }
+        it { expect(subject).to eq fs3_doc.id }
       end
     end
   end # context 'a monograph with attached members' do


### PR DESCRIPTION
More work toward completing #1394. This provides some infrastructure but the display of the "database" and the "aboutware" is not included.