### PR TITLE
Resolves #1580: Asset Link 422 Error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,16 +50,22 @@ class ApplicationController < ActionController::Base
     #   * ensuring the user will be logged out if REMOTE_USER is not set
     def clear_session_user
       return nil_request if request.nil?
+
       search = session[:search].dup if session[:search]
-      redirect_to_url = stored_location_for(:user)
+      user_return_to = session[:user_return_to].dup if session[:user_return_to]
+      flash_notice = flash[:notice]
+
       if valid_user_signed_in?
         sign_in_static_cookie
       else
         sign_out_static_cookie
-        request.env['warden'].logout
+        request.env['warden'].logout(:default)
+        expire_data_after_sign_out!
       end
+
       session[:search] = search
-      store_location_for(:user, redirect_to_url)
+      session[:user_return_to] = user_return_to
+      flash[:notice] = flash_notice
     end
 
     def valid_user_signed_in?


### PR DESCRIPTION
Stole Roger's tweak from FishRappr and it seems to have resolved the issue.

Roger Espinosa [10:08]
Actually. We found (in fishrappr) that the code we took from DBD _was_ stripping too much for anonymous users.


Greg Kostin [10:11]
@roger Did you fix it in fishrappr?  If so, how?

Roger Espinosa [10:13]
I tweaked the `clear_session_user` method we borrowed.
Because it seemed that UMRDR was aggressively assuming you were going to log in.