### PR TITLE
Fixes #1459 (the search part). Addresses search performance issues:

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -38,11 +38,25 @@ class EPubsController < ApplicationController
       headers['Access-Control-Allow-Methods'] = 'GET'
       headers['Access-Control-Request-Method'] = '*'
     end
-    results = FactoryService.e_pub_publication(params[:id]).search(params[:q])
+
+    # due to performance issues, must have 3 or more characters to search
+    return head :not_found if params[:q].length < 3
+
+    results = Rails.cache.fetch(search_cache_key(params[:id], params[:q]), expires_in: 30.days) do
+      FactoryService.e_pub_publication(params[:id]).search(params[:q])
+    end
+
     if results[:search_results]
       render json: results
     else
       head :not_found
     end
+  end
+
+  def search_cache_key(id, query)
+    "epub:" +
+      Digest::MD5.hexdigest(query) +
+      id +
+      ActiveFedora::SolrService.query("{!terms f=id}#{id}", rows: 1).first["timestamp"]
   end
 end

--- a/lib/e_pub/search.rb
+++ b/lib/e_pub/search.rb
@@ -18,7 +18,10 @@ module EPub
       # when searching for "music". Any sort of stemming is going to be super hard
       # since we need to parse the DOM for results.
       # Try this for now.
-      node.content.index(/#{query}\W/i, offset)
+      # node.content.index(/#{query}\W/i, offset)
+      # Allowing regexes really messes up CFIs and highlighting and isn't really
+      # appropriate for this simple search feature
+      node.content.index(/#{Regexp.escape(query)}\W/i, offset)
     end
 
     private

--- a/lib/spec/e_pub/search_spec.rb
+++ b/lib/spec/e_pub/search_spec.rb
@@ -50,5 +50,11 @@ RSpec.describe EPub::Search do
       let(:query) { "search" }
       it { expect(subject.node_query_match(node, query)).to eq nil }
     end
+
+    context "regexes don't work: looking for sea*.ch will not match 'search'" do
+      let(:node) { doc.xpath("//p")[0].children[0] }
+      let(:query) { "sea*.ch" }
+      it { expect(subject.node_query_match(node, query)).to eq nil }
+    end
   end
 end


### PR DESCRIPTION
1) Searches are now cached (30 days expiration)
2) Search terms must be 3 characters or more
3) Regexes aren't allowed in search terms