### PR TITLE
Resolves #1541: Restrict the Gabii EPUB

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -1,38 +1,37 @@
 # frozen_string_literal: true
 
 class EPubsController < ApplicationController
+  before_action :set_presenter, only: %i[show lock]
+  before_action :set_show, only: %i[show]
+
   def show
-    @presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(params[:id]).to_solr), current_ability, request)
-    if @presenter.epub?
-      FactoryService.e_pub_publication(params[:id]) # cache epub
-      @title = @presenter.parent.present? ? @presenter.parent.title : @presenter.title
-      @citable_link = @presenter.citable_link
-      @creator_given_name = @presenter.creator_given_name
-      @creator_family_name = @presenter.creator_family_name
-      @back_link = params[:publisher].present? ? URI.join(main_app.root_url, params[:publisher]).to_s : main_app.monograph_catalog_url(@presenter.monograph_id)
-      @subdomain = @presenter.monograph.subdomain
-      @search_url = main_app.epub_search_url(params[:id], q: "").gsub!(/locale=en&/, '')
-      @monograph_presenter = nil
-      if @presenter.parent.present?
-        @monograph_presenter = Hyrax::PresenterFactory.build_for(ids: [@presenter.parent.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first
-      end
-      render layout: false
-    else
-      Rails.logger.info("EPubsController.show(#{params[:id]}) is not an EPub.")
-      render 'hyrax/base/unauthorized', status: :unauthorized
+    return render 'hyrax/base/unauthorized', status: :unauthorized unless show?
+    @title = @presenter.parent.present? ? @presenter.parent.title : @presenter.title
+    @citable_link = @presenter.citable_link
+    @creator_given_name = @presenter.creator_given_name
+    @creator_family_name = @presenter.creator_family_name
+    @back_link = params[:publisher].present? ? URI.join(main_app.root_url, params[:publisher]).to_s : main_app.monograph_catalog_url(@presenter.monograph_id)
+    @subdomain = @presenter.monograph.subdomain
+    @search_url = main_app.epub_search_url(params[:id], q: "").gsub!(/locale=en&/, '')
+    @monograph_presenter = nil
+    if @presenter.parent.present?
+      @monograph_presenter = Hyrax::PresenterFactory.build_for(ids: [@presenter.parent.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first
     end
-  rescue Ldp::Gone # tombstone
-    raise CanCan::AccessDenied
+    render layout: false
   end
 
   def file
-    render plain: FactoryService.e_pub_publication(params[:id]).read(params[:file] + '.' + params[:format]), content_type: Mime::Type.lookup_by_extension(params[:format]), layout: false
-  rescue StandardError => e
-    Rails.logger.info("EPubsController.file(#{params[:file] + '.' + params[:format]}) mapping to 'Content-Type': #{Mime::Type.lookup_by_extension(params[:format])} raised #{e}")
-    head :no_content
+    return head :no_content unless show?
+    begin
+      render plain: FactoryService.e_pub_publication(params[:id]).read(params[:file] + '.' + params[:format]), content_type: Mime::Type.lookup_by_extension(params[:format]), layout: false
+    rescue StandardError => e
+      Rails.logger.info("EPubsController.file(#{params[:file] + '.' + params[:format]}) mapping to 'Content-Type': #{Mime::Type.lookup_by_extension(params[:format])} raised #{e}")
+      head :no_content
+    end
   end
 
   def search
+    return head :not_found unless show?
     if Rails.env == 'development'
       headers['Access-Control-Allow-Origin'] = '*'
       headers['Access-Control-Allow-Methods'] = 'GET'
@@ -59,4 +58,104 @@ class EPubsController < ApplicationController
       id +
       ActiveFedora::SolrService.query("{!terms f=id}#{id}", rows: 1).first["timestamp"]
   end
+
+  def lock # rubocop:disable Metrics/PerceivedComplexity
+    clear_session_show
+    if request.request_method_symbol == :get
+      if unlocked?
+        set_session_show
+        redirect_to epub_path(params[:id])
+      elsif subscription?
+        set_session_show
+        redirect_to epub_path(params[:id])
+      elsif valid_user_signed_in?
+        @subscriptions = Subscription.where(publication: publication.id)
+        render
+      else
+        redirect_to new_user_session_path
+      end
+    else
+      request.request_method_symbol == :delete ? clear_lock : set_lock
+      redirect_to monograph_show_path(@presenter.monograph_id)
+    end
+  end
+
+  def subscription
+    clear_session_show
+    request.request_method_symbol == :post ? subscribe : unsubscribe
+    redirect_to stored_location_for(:user) || root_url
+  end
+
+  private
+
+    def set_presenter
+      @presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(params[:id]).to_solr), current_ability, request)
+      if @presenter.epub?
+        FactoryService.e_pub_publication(params[:id]) # cache epub
+      else
+        Rails.logger.info("EPubsController.set_presenter(#{params[:id]}) is not an EPub.")
+        render 'hyrax/base/unauthorized', status: :unauthorized
+      end
+    rescue Ldp::Gone # tombstone
+      raise CanCan::AccessDenied
+    end
+
+    def set_show
+      return if show?
+      redirect_to lock_epub_path(params[:id])
+    end
+
+    def show?
+      session[:show_set]&.include?(params[:id])
+    end
+
+    def set_session_show
+      session[:show_set] ||= []
+      session[:show_set] << params[:id] unless session[:show_set].include?(params[:id])
+    end
+
+    def clear_session_show
+      session[:show_set] ||= []
+      session[:show_set].delete(params[:id]) if session[:show_set].include?(params[:id])
+    end
+
+    def set_lock
+      Subscription.find_or_create_by(subscriber: publication.id, publication: publication.id)
+      @locked = true
+    end
+
+    def clear_lock
+      Subscription.find_by(subscriber: publication.id, publication: publication.id)&.delete
+      @locked = false
+    end
+
+    def locked?
+      @locked ||= Subscription.find_by(subscriber: publication.id, publication: publication.id).present?
+    end
+
+    def unlocked?
+      !locked?
+    end
+
+    def subscription?
+      Subscription.find_by(subscriber: subscriber.id, publication: publication.id).present?
+    end
+
+    def subscribe
+      return unless valid_user_signed_in?
+      Subscription.find_or_create_by(subscriber: subscriber.id, publication: publication.id)
+    end
+
+    def unsubscribe
+      return unless valid_user_signed_in?
+      Subscription.find_by(subscriber: subscriber.id, publication: publication.id)&.delete
+    end
+
+    def subscriber
+      @subscriber ||= valid_user_signed_in? ? Entity.new(type: :email, identifier: current_user.email) : Entity.null_object
+    end
+
+    def publication
+      @publication ||= Entity.new(type: :epub, identifier: params[:id])
+    end
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Entity
+  include ActiveModel::Model
+
+  TYPES = %w[email epub].freeze
+
+  attr_reader :type, :identifier
+
+  validates :type, presence: true, allow_blank: false, inclusion: { in: TYPES }
+  validates :identifier, presence: true, allow_blank: false
+
+  def initialize(type:, identifier:)
+    @type = type.to_s
+    @identifier = identifier.to_s
+  end
+
+  def self.null_object
+    EntityNullObject.send(:new)
+  end
+
+  def null_object?
+    is_a? EntityNullObject
+  end
+
+  def id
+    "#{type}:#{identifier}"
+  end
+end
+
+class EntityNullObject < Entity
+  private_class_method :new
+
+  private
+
+    def initialize
+      @type = :null.to_s
+      @identifier = :null.to_s
+    end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Subscription < ApplicationRecord
+  validates :subscriber, presence: true, allow_blank: false
+  validates :publication, presence: true, allow_blank: false
+  validates_uniqueness_of :subscriber, scope: :publication # rubocop:disable Rails/Validation
+end

--- a/app/presenters/concerns/featured_representatives/file_set_presenter.rb
+++ b/app/presenters/concerns/featured_representatives/file_set_presenter.rb
@@ -12,6 +12,16 @@ module FeaturedRepresentatives
       featured_representative ? true : false
     end
 
+    def epub_locked?
+      return false unless epub?
+      entity = Entity.new(type: :epub, identifier: id)
+      !Subscription.find_by(subscriber: entity.id, publication: entity.id).nil?
+    end
+
+    def epub_unlocked?
+      !epub_locked?
+    end
+
     def epub?
       # ['application/epub+zip'].include? mime_type
       featured_representative&.kind == 'epub'

--- a/app/views/e_pubs/_form.html.erb
+++ b/app/views/e_pubs/_form.html.erb
@@ -1,0 +1,21 @@
+<% if member.epub? %>
+  <% if can? :edit, member.id %>
+    <% if member.epub_locked? %>
+      <%= link_to t('.open'), main_app.unlock_epub_path(member.id),
+        method: :delete, title: t('.open'),
+        data: { confirm: t('.open') },
+        class: 'btn btn-default' %>
+    <% else %>
+      <%= link_to t('.restrict'), main_app.lock_epub_path(member.id),
+        method: :post, title: t('.restrict'),
+        data: { confirm: t('.restrict') },
+        class: 'btn btn-default' %>
+    <% end %>
+  <% else %>
+    <% if member.epub_locked? %>
+      <%= t('.open') %>
+    <% else %>
+      <%= t('.restricted') %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/e_pubs/lock.html.erb
+++ b/app/views/e_pubs/lock.html.erb
@@ -1,0 +1,11 @@
+<h2>EPUB Subscriptions</h2>
+<ul>
+  <% @subscriptions.each do |subscription| %>
+    <% if subscription.subscriber == @subscriber %>
+      <li><%= link_to "#{subscription.subscriber} => #{subscription.publication}", main_app.unsubscribe_epub_path(id: subscription.publication.split(':').last), method: :delete %></li>
+    <% else %>
+      <li><%= "#{subscription.subscriber} => #{subscription.publication}" %></li>
+    <% end %>
+  <% end %>
+  <li><%= link_to "#{@subscriber.id} => #{@publication.id}", main_app.subscribe_epub_path(id: @publication.id.split(':').last), method: :post %></li>
+</ul>

--- a/app/views/featured_representatives/_form.html.erb
+++ b/app/views/featured_representatives/_form.html.erb
@@ -4,7 +4,7 @@
     <b><%= member.featured_representative.kind %></b>
   </div>
   <div class="col-sm-4">
-    <% if can? :edit, member.id %>
+    <% if member.epub_unlocked? && (can? :edit, member.id) %>
       <%= link_to "Unset", main_app.featured_representatives_path(id: member.featured_representative.id, monograph_id: member.monograph.id),
           method: :delete, title: "Delete #{member.featured_representative.kind}",
           data: { confirm: "Unset Featured Representative?" },

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -8,6 +8,7 @@
         <th><%= t('.date_uploaded') %></th>
         <th><%= t('.visibility') %></th>
         <th><%= t('.actions') %></th>
+        <th><%= t('.access') %></th>
         <th><%= t('.set_representative') %></th>
       </tr>
     </thead>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -9,6 +9,9 @@
     <%= render 'actions', member: member %>
   </td>
   <td>
+    <%= render 'e_pubs/form', member: member %>
+  </td>
+  <td>
     <%= render 'featured_representatives/form', member: member %>
   </td>
 </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,11 @@ en:
   doi: "DOI"
   editor: "Editors"
   embargo_release_date: "Embargo Release Date"
+  e_pubs:
+    form:
+      open: "Open"
+      restrict: "Restrict"
+      restricted: "Restricted"
   errors:
     messages:
       carrierwave_processing_error: failed to be processed
@@ -99,6 +104,10 @@ en:
         destroyed: "User role has been removed."
         batch_error: "There was a problem saving the user role(s)."
   holding_contact: "Holding Contact"
+  hyrax:
+    base:
+      items:
+        access: "Access"
   isbn: "ISBN (Hardcover)"
   isbn_ebook: "ISBN (E-Book)"
   isbn_paper: "ISBN (Paper)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ resque_web_constraint = lambda do |request|
 end
 
 Rails.application.routes.draw do
+  get 'lock/epubs/:id', controller: :e_pubs, action: :lock, as: :epub_lock
+  post 'lock/epubs/:id', controller: :e_pubs, action: :lock, as: :lock_epub
+  delete 'lock/epubs/:id', controller: :e_pubs, action: :lock, as: :unlock_epub
+  post 'subscription/epubs/:id', controller: :e_pubs, action: :subscription, as: :subscribe_epub
+  delete 'subscription/epubs/:id', controller: :e_pubs, action: :subscription, as: :unsubscribe_epub
   get 'epubs/:id', controller: :e_pubs, action: :show, as: :epub
   get 'epubs/:id/*file', controller: :e_pubs, action: :file, as: :epub_file
   get 'epub_search/:id', controller: :e_pubs, action: :search, as: :epub_search

--- a/db/migrate/20180228213312_create_subscriptions.rb
+++ b/db/migrate/20180228213312_create_subscriptions.rb
@@ -1,0 +1,9 @@
+class CreateSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscriptions do |t|
+      t.string :subscriber, index: true, unique: true
+      t.string :publication, index: true, unique: true
+    end
+    add_index :subscriptions, [:subscriber, :publication], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180109210107) do
+ActiveRecord::Schema.define(version: 20180228213312) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -432,6 +432,14 @@ ActiveRecord::Schema.define(version: 20180109210107) do
     t.integer "permission_template_id"
     t.boolean "active"
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
+  end
+
+  create_table "subscriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "subscriber"
+    t.string "publication"
+    t.index ["publication"], name: "index_subscriptions_on_publication"
+    t.index ["subscriber", "publication"], name: "index_subscriptions_on_subscriber_and_publication", unique: true
+    t.index ["subscriber"], name: "index_subscriptions_on_subscriber"
   end
 
   create_table "tinymce_assets", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 require 'json'
 
 RSpec.describe EPubsController, type: :controller do
+  let(:show) { true }
+
+  before { allow_any_instance_of(described_class).to receive(:show?).and_return(show) }
+
   describe "#show" do
     context 'not found' do
       before { get :show, params: { id: :id } }
@@ -35,9 +39,19 @@ RSpec.describe EPubsController, type: :controller do
         get :show, params: { id: file_set.id }
       end
       after { FeaturedRepresentative.destroy_all }
+
       it do
-        expect(response).to_not have_http_status(:unauthorized)
         expect(response).to have_http_status(:success)
+        expect(response.body.empty?).to be true
+      end
+
+      context 'access denied' do
+        let(:show) { false }
+
+        it do
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(lock_epub_path)
+        end
       end
     end
 
@@ -64,7 +78,6 @@ RSpec.describe EPubsController, type: :controller do
     context 'not found' do
       before { get :file, params: { id: :id, file: 'META-INF/container', format: 'xml' } }
       it do
-        expect(response).to_not have_http_status(:unauthorized)
         expect(response).to have_http_status(:success)
         expect(response.body.empty?).to be true
       end
@@ -75,7 +88,6 @@ RSpec.describe EPubsController, type: :controller do
 
       before { get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'xml' } }
       it do
-        expect(response).to_not have_http_status(:unauthorized)
         expect(response).to have_http_status(:success)
         expect(response.body.empty?).to be true
       end
@@ -86,7 +98,6 @@ RSpec.describe EPubsController, type: :controller do
 
       before { get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'xml' } }
       it do
-        expect(response).to_not have_http_status(:unauthorized)
         expect(response).to have_http_status(:success)
         expect(response.body.empty?).to be true
       end
@@ -106,7 +117,6 @@ RSpec.describe EPubsController, type: :controller do
       context 'file not found' do
         before { get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'txt' } }
         it do
-          expect(response).to_not have_http_status(:unauthorized)
           expect(response).to have_http_status(:success)
           expect(response.body.empty?).to be true
         end
@@ -115,10 +125,17 @@ RSpec.describe EPubsController, type: :controller do
       context 'file exist' do
         before { get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'xml' } }
         it do
-          expect(response).to_not have_http_status(:unauthorized)
           expect(response).to have_http_status(:success)
           expect(response.body.empty?).to be false
           expect(response.header['Content-Type']).to include('application/xml')
+        end
+
+        context 'access denied' do
+          let(:show) { false }
+          it do
+            expect(response).to have_http_status(:success)
+            expect(response.body.empty?).to be true
+          end
         end
       end
 
@@ -138,7 +155,6 @@ RSpec.describe EPubsController, type: :controller do
             get :file, params: { id: file_set.id, file: 'META-INF/container', format: 'xml' }
           end
           it "is not found" do
-            expect(response).to_not have_http_status(:unauthorized)
             expect(response).to have_http_status(:success)
             expect(response.body.empty?).to be true
           end
@@ -177,6 +193,15 @@ RSpec.describe EPubsController, type: :controller do
         expect(response).to have_http_status(:success)
         expect(JSON.parse(response.body)["search_results"].length).to eq 3
       end
+
+      context 'access denied' do
+        let(:show) { false }
+
+        it do
+          expect(response).to have_http_status(:not_found)
+          expect(response.body.empty?).to be true
+        end
+      end
     end
 
     context "searches must be 3 or more characters" do
@@ -204,6 +229,87 @@ RSpec.describe EPubsController, type: :controller do
         expect(JSON.parse(response.body)["search_results"].length).to eq 1
         expect(JSON.parse(response.body)["search_results"][0]["snippet"]).to eq "This is a snippet"
       end
+    end
+  end
+
+  describe '#lock' do
+    let(:user) { create(:user) }
+    let(:monograph) { create(:monograph) }
+    let(:file_set) { create(:file_set, id: '999999999', content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
+    let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
+    before do
+      monograph.ordered_members << file_set
+      monograph.save!
+      file_set.save!
+    end
+    after { FeaturedRepresentative.destroy_all }
+
+    it do
+      # Open Access
+      session[:show_set] = []
+      get :lock, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be true
+      expect(response).to redirect_to(epub_path)
+
+      # Restricted Access
+      post :lock, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be false
+
+      # Anonymous User
+      get :lock, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be false
+      expect(response).to redirect_to(new_user_session_path)
+
+      # Authenticated User
+      cosign_sign_in(user)
+      get :lock, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be false
+      expect(response).to render_template(:lock)
+
+      # Subscribed User
+      post :subscription, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be false
+      get :lock, params: { id: file_set.id }
+      expect(session[:show_set].include?(file_set.id)).to be true
+      expect(response).to redirect_to(epub_path)
+    end
+
+    context 'set/clear lock' do
+      let(:epub_1) { '1' }
+      let(:epub_2) { '2' }
+
+      it do
+        session[:show_set] = [epub_1, file_set.id, epub_2]
+        expect { post :lock, params: { id: file_set.id } }.to change { Subscription.count }.by(1)
+        expect(response).to redirect_to(monograph_show_path(monograph.id))
+        expect(session[:show_set].include?(epub_1)).to be true
+        expect(session[:show_set].include?(file_set.id)).to be false
+        expect(session[:show_set].include?(epub_2)).to be true
+        session[:show_set] << file_set.id
+        expect { delete :lock, params: { id: file_set.id } }.to change { Subscription.count }.by(-1)
+        expect(response).to redirect_to(monograph_show_path(monograph.id))
+        expect(session[:show_set].include?(epub_1)).to be true
+        expect(session[:show_set].include?(file_set.id)).to be false
+        expect(session[:show_set].include?(epub_2)).to be true
+      end
+    end
+  end
+
+  describe '#subscription' do
+    let(:epub_1) { '1' }
+    let(:epub_2) { '2' }
+    let(:user) { create(:user) }
+
+    it do
+      cosign_sign_in(user)
+      session[:show_set] = [epub_1, epub_2]
+      expect { post :subscription, params: { id: epub_1 } }.to change { Subscription.count }.by(1)
+      expect(session[:show_set].include?(epub_1)).to be false
+      expect(session[:show_set].include?(epub_2)).to be true
+      session[:show_set] << epub_1
+      expect { delete :subscription, params: { id: epub_1 } }.to change { Subscription.count }.by(-1)
+      expect(session[:show_set].include?(epub_1)).to be false
+      expect(session[:show_set].include?(epub_2)).to be true
     end
   end
 end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Authentication, type: :model do
 
   let(:args) { { email: email } }
   let(:email) { user.email }
-  let(:user) { create(:user) }
+  let(:user) { build(:user) }
 
   it 'is valid' do
     expect(subject).to be_valid

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Entity, type: :model do
+  describe 'null entity' do
+    subject { described_class.null_object }
+
+    it 'is invalid' do
+      expect(subject).to be_invalid
+      expect(subject).to be_a_kind_of(described_class)
+      expect(subject.null_object?).to be true
+      expect(subject.id).to eq "null:null"
+    end
+  end
+
+  describe 'entities' do
+    subject { described_class.new(type: type, identifier: identifier) }
+
+    describe 'invalid entity' do
+      let(:type) { '' }
+      let(:identifier) { '' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages).not_to be_empty
+        expect(subject.null_object?).not_to be true
+        expect(subject.id).to eq "#{type}:#{identifier}"
+      end
+    end
+
+    describe 'user entity' do
+      let(:type) { :email.to_s }
+      let(:identifier) { user.email }
+      let(:user) { build(:user) }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.errors.messages).to be_empty
+        expect(subject.null_object?).not_to be true
+        expect(subject.id).to eq "#{type}:#{identifier}"
+      end
+    end
+
+    describe 'epub entity' do
+      let(:type) { :epub.to_s }
+      let(:identifier) { :noid.to_s }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+        expect(subject.errors.messages).to be_empty
+        expect(subject.null_object?).not_to be true
+        expect(subject.id).to eq "#{type}:#{identifier}"
+      end
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  subject { described_class.new(args) }
+
+  let(:args) { { subscriber: subscriber.id, publication: publication.id } }
+  let(:subscriber) { Entity.new(type: :email, identifier: 'user@domain.com') }
+  let(:publication) { Entity.new(type: :epub, identifier: 'validnoid') }
+
+  it 'is valid' do
+    expect(subject).to be_valid
+    expect(subject.errors.messages).to be_empty
+  end
+end

--- a/spec/presenters/concerns/featured_representatives/file_set_presenter_spec.rb
+++ b/spec/presenters/concerns/featured_representatives/file_set_presenter_spec.rb
@@ -42,6 +42,30 @@ describe FeaturedRepresentatives::FileSetPresenter do
       it "is an epub" do
         expect(subject.epub?).to be true
       end
+
+      context "lock" do
+        let(:epub_entity) { Entity.new(type: :epub, identifier: 'fid1') }
+
+        before { allow(Subscription).to receive(:find_by).with(subscriber: epub_entity.id, publication: epub_entity.id).and_return(subscription) }
+
+        context "unlocked" do
+          let(:subscription) { nil }
+
+          it do
+            expect(subject.epub_locked?).to be false
+            expect(subject.epub_unlocked?).to be true
+          end
+        end
+
+        context "locked" do
+          let(:subscription) { double('subscription') }
+
+          it do
+            expect(subject.epub_locked?).to be true
+            expect(subject.epub_unlocked?).to be false
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
POLICY:

If an EPUB is "locked" then you must be an "authorized" user to view the EPUB using the reader, otherwise any user may view the EPUB using the reader.

IMPLEMENTATION: (First Iteration)

A "subscriptions" table was added to the database which consists of two columns: "subscriber" and "publication". They are both string fields that will hold "entity ids" such that each subscriber/publication pair is unique a.k.a. a compound key.

An "entity" model has been added to the application which has two attributes: "type" and "identifier". These attributes are strings and the type attribute is currently restricted to be either "email" or "epub". An "entity id" is constructed like so: "#{type}:#{identifier}".

A "subscriber" is uniquely identified by an "entity" of type "email" with the user's email address being the identifier.

A "publication" is uniquely identified by an "entity" of type "epub" with the EPUB's noid being the identifier.

An EPUB is "locked" when there exist a subscription record where the "subscriber" and the "publisher" both equal the EPUB's "entity id". For example an EPUB with noid 999999999 would be lock by row "epub:999999999", "epub:999999999".

A user is "authorized" when there exist a subscription record where the "subscriber" field equals "email:<user's email>" and the "publication" field equals "epub:. For example a user "wolverine@umich.edu" is authorized to read the EPUB "999999999" if the row "email:wolverive@umich.edu", "epub:99999999" exist.

An EPUB must be "locked" for subscription authorization to be enforced. When an EPUB is "unlocked" subscription authorization will not be enforced and any user will be able to read the EPUB regardless if there exist user subscription records for that EPUB in the subscriptions table.

An EPUB can be locked and unlocked by toggling the "Open"/"Restricted" button which is located near the feature representative drop down menu and "Set/Unset" button. When the EPUB is locked the toggle button will display the label "Open" and the "Unset" button will be hidden. Hence, you may only unset a epub feature representative when it is unlocked; the toggle button will display the label "Restrict" and the "Unset" button will be visible.

Currently if you attempt to read a locked EPUB while not logged in you'll be redirected to the login page. If you are logged in but do not have authorization you'll be shown a list of subscriptions for the EPUB beginning with the "lock" and ending with a link that will create a subscription for you in the subscriptions table. Hence after clicking the link the next time you attempt to read the EPUB it will succeed.

One final implementation note. Currently the session variable session[:show_set] is being used to cache the set of epub noids a users may view. I'm not sure how secure this is but I think HTTP Authentication is using a session variable to cache an authenticated user's id. I'm caching the noid to avoid checking authorization for every request for an EPUB's internal files.

I'm not attached to this solution so if anyone has better or different ideas on how to implement this authorization stuff please let me know.