### PR TITLE
Resolves #1591: Display pop-up for Co-Sign users

### DIFF
--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Guest < User
+  def save(*_args, &_block)
+    false
+  end
+
+  def save!(*_args, &_block)
+    raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", self))
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,4 +95,8 @@ class User < ApplicationRecord
   def to_s
     user_key
   end
+
+  def self.guest(user_key:)
+    Guest.new(user_key: user_key)
+  end
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -13,4 +13,4 @@ cosign_logout_url: ""
 
 # Should we create users automatically on first login?
 # This supports convenient single sign-on account provisioning
-create_user_on_login: true
+create_user_on_login: false

--- a/lib/devise/strategies/http_header_authenticatable.rb
+++ b/lib/devise/strategies/http_header_authenticatable.rb
@@ -35,14 +35,15 @@ module Devise
         end
 
         def new_user
-          user = nil
-          if Rails.configuration.create_user_on_login
-            debug_log "New user: '#{user_key}'"
-            user = User.new(user_key: user_key)
-            user.populate_attributes
-          else
-            debug_log "Did not find and will not create: '#{user_key}'"
-          end
+          user =
+            if Rails.configuration.create_user_on_login
+              debug_log "New user: '#{user_key}'"
+              User.new(user_key: user_key)
+            else
+              debug_log "Guest user: '#{user_key}'"
+              User.guest(user_key: user_key)
+            end
+          user.populate_attributes
           user
         end
 

--- a/spec/models/guest_spec.rb
+++ b/spec/models/guest_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Guest do
+  subject { user }
+
+  let(:user) { described_class.new(email: email) }
+  let(:email) { 'wolverine@umich.edu' }
+
+  it { is_expected.to be_kind_of(User) }
+
+  context 'save' do
+    it { expect { user.save }.to change { User.count }.by(0) }
+
+    it { expect(user.save).to be false }
+
+    it { expect { user.save! }
+      .to raise_exception(ActiveRecord::RecordNotSaved)
+      .and(change { User.count }.by(0)) }
+  end
+
+  context 'create' do
+    it { expect { described_class.create(email: email) }
+      .to change { User.count }.by(0) }
+
+    it { expect { described_class.create!(email: email) }
+      .to raise_exception(ActiveRecord::RecordNotSaved)
+      .and(change { User.count }.by(0)) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe User do
+RSpec.describe User do
   describe '#user_key' do
     subject { user.user_key }
     let(:user) { described_class.new(email: 'foo@example.com') }
@@ -85,5 +85,17 @@ describe User do
       expect(editor.groups).to eq ["blue_editor"]
       expect(platform_admin.groups).to eq ["blue_admin", "blue_editor", "red_admin", "red_editor", "admin"]
     end
+  end
+
+  describe '#guest' do
+    subject { described_class.guest(user_key: email) }
+
+    let(:email) { 'wolverine@umich.edu' }
+
+    it { is_expected.to be_a_kind_of(described_class) }
+
+    it { is_expected.to be_an_instance_of(Guest) }
+
+    it { expect(subject.email).to eq(email) }
   end
 end


### PR DESCRIPTION
Since we have to lock down the interface for friends accounts anyway I changed the header authentication code so it can create a new user that cannot be saved to the users table.

This side steps the issue of having to inform cosign users when they login to cosign they weren't logged in to the application because they are not in the user table.

Now all that is left is locking down the interface for authenticated users that have no role a.k.a. privileges.