### PR TITLE
Fixes #1572, Non-privileged logged in users should have limited menus

### DIFF
--- a/app/helpers/heliotrope/ability_helper.rb
+++ b/app/helpers/heliotrope/ability_helper.rb
@@ -10,7 +10,7 @@ module Heliotrope
       can = false
       Hyrax.config.curation_concerns.each do |curation_concern_type|
         break if can
-        can = can?(:create, curation_concern_type)
+        can = can?(:create, curation_concern_type) && current_user.groups.length.positive?
       end
       can
     end

--- a/app/views/shared/_add_content.html.erb
+++ b/app/views/shared/_add_content.html.erb
@@ -1,6 +1,6 @@
 <% include_works_link ||= can_ever_create_works? %>
 
-<% if include_works_link || include_collections_link %>
+<% if include_works_link %>
   <ul class="nav navbar-nav">
     <li class="dropdown">
     <%= link_to main_app.concern_monographs_new_path, id: "add-content", class: "dropdown-toggle", data: { toggle: "dropdown"} do %>

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -13,18 +13,10 @@
     </a>
 
     <ul class="dropdown-menu">
-      <li><%= link_to 'Fulcrum', main_app.fulcrum_path, role: 'menuitem'  %></li>
-      <li class="divider"></li>
-      <li><%= link_to 'Dashboard', hyrax.dashboard_path, role: 'menuitem'  %></li>
-      <li class="divider"></li>
+      <% show_fulcrum_link = current_user && current_user.platform_admin? %>
+      <% show_dashboard_link = current_user.groups.length.positive? %>
       <% show_analytics_link = current_user && current_user.platform_admin? %>
-      <% if show_analytics_link %>
-        <li><%= link_to 'Analytics', main_app.analytics_path, role: 'menuitem' %></li>
-      <% end %>
-      <li class="divider"></li>
-
       <% include_collections_link ||= can?(:create, Collection) %>
-
       <% show_jobs_link = current_user && current_user.platform_admin? %>
       <%
         show_users_link = @press && (
@@ -32,8 +24,21 @@
           current_user.roles.where(role: 'admin', resource_id: @press.id, resource_type: 'Press').first
         )
       %>
-      <% show_embargo_link = can? :discover, Hydra::AccessControls::Embargo %>
-      <% show_lease_link = can? :discover, Hydra::AccessControls::Lease %>
+
+      <% if show_fulcrum_link %>
+        <li><%= link_to 'Fulcrum', main_app.fulcrum_path, role: 'menuitem'  %></li>
+        <li class="divider"></li>
+      <% end %>
+
+      <% if show_dashboard_link %>
+        <li><%= link_to 'Dashboard', hyrax.dashboard_path, role: 'menuitem'  %></li>
+        <li class="divider"></li>
+      <% end %>
+
+      <% if show_analytics_link %>
+        <li><%= link_to 'Analytics', main_app.analytics_path, role: 'menuitem' %></li>
+        <li class="divider"></li>
+      <% end %>
 
       <% if show_jobs_link %>
         <li><%= link_to "Jobs", main_app.resque_web_path %></li>
@@ -43,15 +48,7 @@
         <li><%= link_to "Users", main_app.press_roles_path(@press) %></li>
       <% end %>
 
-      <% if show_embargo_link %>
-        <li><%= link_to 'Embargos', hyrax.embargoes_path, role: 'menuitem' %></li>
-      <% end %>
-
-      <% if show_lease_link %>
-        <li><%= link_to 'Leases', hyrax.leases_path, role: 'menuitem' %></li>
-      <% end %>
-
-      <% if show_jobs_link || show_users_link || show_embargo_link || show_lease_link %>
+      <% if show_jobs_link || show_users_link %>
         <li class="divider"></li>
       <% end %>
 

--- a/spec/views/shared/_add_content.html.erb_spec.rb
+++ b/spec/views/shared/_add_content.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'shared/_my_actions.html.erb' do
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  context "a platform admin user" do
+    let(:user) { create(:platform_admin) }
+    before { render }
+    it "shows the add content button" do
+      expect(rendered).to have_link("New Monograph")
+    end
+  end
+
+  context "a non-privileged user" do
+    let(:user) { create(:user) }
+    before { render }
+    it "does not show the add content button" do
+      expect(rendered).to_not have_link("New Monograph")
+    end
+  end
+end

--- a/spec/views/shared/_my_actions.html.erb_spec.rb
+++ b/spec/views/shared/_my_actions.html.erb_spec.rb
@@ -23,8 +23,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Jobs", href: resque_web_path)
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to have_link("Users", href: press_roles_path(press))
       end
     end
@@ -37,8 +35,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
         expect(rendered).to have_link("Jobs", href: resque_web_path)
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to_not have_link("Users", href: press_roles_path(press))
       end
     end
@@ -57,8 +53,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to have_link("Users", href: press_roles_path(press))
       end
     end
@@ -74,8 +68,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to_not have_link("Users", href: press_roles_path(different_press))
       end
     end
@@ -94,8 +86,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to_not have_link("Users")
       end
     end
@@ -111,8 +101,6 @@ describe 'shared/_my_actions.html.erb' do
         expect(rendered).to_not have_link("Analytics")
         expect(rendered).to have_link("Dashboard")
         expect(rendered).to have_link("Log Out")
-        expect(rendered).to have_link("Embargos", href: hyrax.embargoes_path)
-        expect(rendered).to have_link("Leases", href: hyrax.leases_path)
         expect(rendered).to_not have_link("Users", href: press_roles_path(different_press))
       end
     end
@@ -128,15 +116,12 @@ describe 'shared/_my_actions.html.erb' do
       end
 
       it 'has correct links' do
+        expect(rendered).to_not have_link("Fulcrum")
+        expect(rendered).to_not have_link("Dashboard")
         expect(rendered).to_not have_link("Analytics")
-        expect(rendered).to     have_link("Dashboard")
-        expect(rendered).to     have_link("Log Out")
         expect(rendered).to_not have_link("Jobs", href: resque_web_path)
         expect(rendered).to_not have_link("Users")
-
-        # TODO: Fix this
-        # expect(rendered).to_not have_link("Embargos")
-        # expect(rendered).to_not have_link("Leases")
+        expect(rendered).to     have_link("Log Out")
       end
     end
 
@@ -144,15 +129,12 @@ describe 'shared/_my_actions.html.erb' do
       before { render }
 
       it 'has correct links' do
+        expect(rendered).to_not have_link("Fulcrum")
+        expect(rendered).to_not have_link("Dashboard")
         expect(rendered).to_not have_link("Analytics")
-        expect(rendered).to     have_link("Dashboard")
-        expect(rendered).to     have_link("Log Out")
-        expect(rendered).to_not have_link("Users")
         expect(rendered).to_not have_link("Jobs", href: resque_web_path)
-
-        # TODO: Fix this
-        # expect(rendered).to_not have_link("Embargos")
-        # expect(rendered).to_not have_link("Leases")
+        expect(rendered).to_not have_link("Users")
+        expect(rendered).to     have_link("Log Out")
       end
     end
   end # non-privileged user


### PR DESCRIPTION
Also removed Embargo and Lease from the menu. In hyrax these are available in the dashboard, not the "my_actions" dropdown menu.