### PR TITLE
Work towards #1630, a POI to CFI mapping between webgl and epub

### DIFF
--- a/app/services/factory_service.rb
+++ b/app/services/factory_service.rb
@@ -198,12 +198,22 @@ module FactoryService # rubocop:disable Metrics/ModuleLength
       file = Tempfile.new(id)
       file.write(presenter.file.content.force_encoding("utf-8"))
       file.close
-      EPub::Publication.from(id: id, file: file.path)
+      EPub::Publication.from(id: id, file: file.path, webgl: create_epub_webgl_bridge(id))
     rescue StandardError => e
       Rails.logger.info("FactoryService.e_pub_publication_from(#{id}) raised #{e}")
       EPub::Publication.null_object
     end
     private_class_method :e_pub_publication_from
+
+    def self.create_epub_webgl_bridge(id)
+      epub_fr = FeaturedRepresentative.where(file_set_id: id).first
+      if FeaturedRepresentative.where(monograph_id: epub_fr.monograph_id, kind: 'webgl')&.first.present?
+        true
+      else
+        false
+      end
+    end
+    private_class_method :create_epub_webgl_bridge
 
     def self.mcvs_manifest_from(id)
       presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(id).to_solr), nil, nil)

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -257,6 +257,15 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
         }, true);
 
+
+        // POI to CFI webgl -> epub mapping stuff
+        var poiToCfiMap = {};
+
+        var fetch_poi = function() {
+          $.get("<%= "#{epub_file_path(id: @presenter.id, file: 'epub-webgl-map.json')}" %>", function(data) {
+            poiToCfiMap = data;
+          });
+        }
         // Take user to a POI when passed a string from WebGL
         function goToParagraph() {
           // don't do anything quite yet - here to prevent errors
@@ -281,6 +290,9 @@ webgl = FactoryService.webgl_unity(webgl_id)
             }],
         })
         toggle.addTo(reader);
+        <% else %>
+        // no-op for epubs without a webgl (so... almost all of them)
+        var fetch_poi = function() { }
         <% end %>
 
         // Database
@@ -361,7 +373,7 @@ webgl = FactoryService.webgl_unity(webgl_id)
         cozy.control.navigator({ region: 'bottom.navigator' }).addTo(reader);
 
         // Initiate EPUB Reader
-        reader.start();
+        reader.start(fetch_poi);
       }
     </script>
   </div>

--- a/lib/e_pub.rb
+++ b/lib/e_pub.rb
@@ -79,6 +79,7 @@ end
 #
 # Require Relative
 #
+require_relative './e_pub/bridge_to_webgl'
 require_relative './e_pub/cache'
 require_relative './e_pub/cfi'
 require_relative './e_pub/chapter'

--- a/lib/e_pub/bridge_to_webgl.rb
+++ b/lib/e_pub/bridge_to_webgl.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module EPub
+  class BridgeToWebgl
+    @mapping = []
+
+    class << self
+      attr_reader :mapping
+    end
+
+    def self.cache(publication)
+      json_mapfile = File.join(EPub.path(publication.id), 'epub-webgl-map.json')
+
+      publication.chapters.each do |chapter|
+        chapter.doc.xpath("//p[@data-poi]").each do |node|
+          poi = node.attr('data-poi')
+
+          indexes = []
+          # This is different enough from EPub::Cfi that I'm just going to
+          # cut-and-paste and endure the shame of that.
+          # We're not looking for text (which EPub::Cfi assumes), we're looking
+          # for elements, specifically paragraphs with a 'data-poi' attribute
+          # TODO: integrate into EPub::Cfi so this is all in one place
+          # this = node.parent
+          this = node
+
+          while this && this.name != "body"
+            # for the hierarchy, we only care about elements
+            siblings = this.parent.element_children
+            idx = siblings.index(this)
+
+            indexes << if this.text?
+                         idx + 1
+                       else
+                         (idx + 1) * 2
+                       end
+
+            indexes[-1] = "#{indexes[-1]}[#{this['id']}]" if this['id']
+
+            this = this.parent
+          end
+          indexes.reverse!
+
+          cfi = "#{chapter.basecfi}/4/#{indexes.join('/')}"
+
+          mapping << { poi: poi, cfi: cfi }
+        end
+      end
+
+      ::EPub.logger.info("EPUB-WEBGL-MAP: #{mapping}")
+      File.write(json_mapfile, mapping.to_json)
+    end
+  end
+end

--- a/lib/e_pub/cfi.rb
+++ b/lib/e_pub/cfi.rb
@@ -65,7 +65,8 @@ module EPub
         @node = node
         @query = query
         @section = find_section(node)
-        @pos0 = node.content.index(/#{query}\W/i, offset)
+        # @pos0 = node.content.index(/#{query}\W/i, offset)
+        @pos0 = node.content.index(/#{Regexp.escape(query)}\W/i, offset)
         @pos1 = @pos0 + query.length
       end
   end

--- a/lib/e_pub/publication.rb
+++ b/lib/e_pub/publication.rb
@@ -29,6 +29,10 @@ module EPub
         sql_lite = EPub::SqlLite.from(publication)
         sql_lite.create_table
         sql_lite.load_chapters
+
+        # Edge case for epubs with POI (Point of Interest) to map to CFI for a webgl (gabii)
+        # See 1630
+        EPub::BridgeToWebgl.cache(publication) if epub[:webgl]
       end
 
       publication

--- a/lib/spec/e_pub/bridge_to_webgl_spec.rb
+++ b/lib/spec/e_pub/bridge_to_webgl_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+RSpec.describe EPub::BridgeToWebgl do
+  let(:publication) { double('publication') }
+  let(:id) { 'epubid' }
+  let(:chapters) do
+    [
+      EPub::Chapter.send(:new,
+                         'chapter1',
+                         'chapter1.html',
+                         'Chapter 1',
+                         "/6/2[chapter1]!",
+                         Nokogiri::XML(chapter1))
+    ]
+  end
+  let(:chapter1) do
+    <<-EOT
+    <html>
+      <head>
+        <title>Chapter 1</title>
+      </head>
+      <body>
+        <div id="div1">
+          <p data-poi="par1">These are some things.</p>
+        </div>
+        <div id="div2">
+          <p>Not these things.</p>
+        </div>
+        <div id="div3">
+          <p>No.</p>
+          <div id="div4">
+            <p id="para2" data-poi="par2">Yes</p>
+          </div>
+        </div>
+      </body>
+    </html>
+    EOT
+  end
+
+  describe "#cache" do
+    it "creates the POI to CFI mapping" do
+      allow(File).to receive(:write).and_return(nil)
+      allow(EPub.logger).to receive(:info).and_return(nil)
+      allow(publication).to receive(:id).and_return(id)
+      allow(publication).to receive(:chapters).and_return(chapters)
+
+      described_class.cache(publication)
+
+      expect(described_class.mapping).to eq [{ poi: "par1", cfi: "/6/2[chapter1]!/4/2[div1]/2" },
+                                             { poi: "par2", cfi: "/6/2[chapter1]!/4/6[div3]/4[div4]/2[para2]" }]
+    end
+  end
+end


### PR DESCRIPTION
* Create a poi -> cfi mapping on the backend if the monograph has both
  a webgl and epub. Store the map as json in the epub cache
* Fetch the map on the frontend after the cozy reader has loaded