### PR TITLE
Accessibility mode for EPUBS with WebGL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '6cf9d28ad925da5fb376b923052b2e707c374bac'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '0631285e2a46d353800eb13d01ba0f57e3cacbaf'
 
 # Force epub search results to be sentences
 gem 'pragmatic_segmenter', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 6cf9d28ad925da5fb376b923052b2e707c374bac
-  ref: 6cf9d28ad925da5fb376b923052b2e707c374bac
+  revision: 0631285e2a46d353800eb13d01ba0f57e3cacbaf
+  ref: 0631285e2a46d353800eb13d01ba0f57e3cacbaf
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -1016,6 +1016,10 @@ $gabii-link-hover:    #1e5667;
   // EPUB Reader
   #reader {
 
+    .hint {
+      padding: 1em 2em;
+    }
+    
     .cozy-control .cozy-h1 {
       font-size: 1.5em;
     }
@@ -1041,6 +1045,11 @@ $gabii-link-hover:    #1e5667;
     .button--sm[disabled] {
       background: #e8e8e8;
       cursor: none;
+      color: $gabii-white;
+
+      &:hover {
+        color: $gabii-white;
+      }
     }
 
     i[class^='icon-chevron-'] {

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -1038,6 +1038,11 @@ $gabii-link-hover:    #1e5667;
       color: $gabii-brand-color;
     }
 
+    .button--sm[disabled] {
+      background: #e8e8e8;
+      cursor: none;
+    }
+
     i[class^='icon-chevron-'] {
       @include epub-prev-next-color($gabii-accent-color);
       transition: 0.2s ease-in;

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -152,7 +152,7 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
         // close panel function
         var close_panel = function() {
-          toggle.state('open-webgl');
+          panel_toggle.state('open-webgl');
           var $panel = $('.special-panel');
           if ($panel.length) {
             $('.special-panel').hide();
@@ -190,23 +190,28 @@ webgl = FactoryService.webgl_unity(webgl_id)
         })
 
         // Open SU panel in WebGL if SU link is clicked
+        // If in a11y mode, open database record
         var click_handler = function(event) {
           var s = event.target.getAttribute('data-uid');
-          var SendMessage = gameInstance.SendMessage;
-          var $panel= $(".special-panel");
-          function getToUnity(s) {
-            SendMessage("WebCommunicator", "ShowString", s);
-          };
-          var gameContainerDiv = document.getElementById("gameContainer");
-          if ($('body').hasClass('panel-open')) {
-            FocusCanvas("1");
-            gameContainerDiv.focus();
-            getToUnity(s);
+          if ($('body').hasClass('a11y')) {
+            window.open('https://doi.org/10.3998/gabii.1.' + s, '_blank');
           } else {
-            open_panel();
-            FocusCanvas("1");
-            gameContainerDiv.focus();
-            getToUnity(s);
+            var SendMessage = gameInstance.SendMessage;
+            var $panel= $(".special-panel");
+            function getToUnity(s) {
+              SendMessage("WebCommunicator", "ShowString", s);
+            };
+            var gameContainerDiv = document.getElementById("gameContainer");
+            if ($('body').hasClass('panel-open')) {
+              FocusCanvas("1");
+              gameContainerDiv.focus();
+              getToUnity(s);
+            } else {
+              open_panel();
+              FocusCanvas("1");
+              gameContainerDiv.focus();
+              getToUnity(s);
+            }
           }
         };
 
@@ -219,7 +224,9 @@ webgl = FactoryService.webgl_unity(webgl_id)
           }
         })
 
-        // Toggling for focus of canvas
+        // Toggling focus of canvas - if clicked on canvas, focus
+        // if clicked outside of canvas, remove focus
+        // if tab advance after focusing canvas, remove canvas focus
         function GameControlReady () {
           gameReady = true;
         }
@@ -279,7 +286,28 @@ webgl = FactoryService.webgl_unity(webgl_id)
           };
         }
 
-        var toggle = cozy.control.widget.toggle({
+        // accessibility mode functions
+        var a11y_on = function() {
+          $('body').addClass('a11y');
+          $('.toggle-a11y').addClass('on');
+          $('.toggle-a11y').attr('aria-disabled', 'false');
+          console.log('a11y-on');
+          close_panel();
+          //$('.webgl-content').detach();
+          // do something different with links to unity
+          // go to database in new window
+        }
+
+        var a11y_off = function() {
+          $('body').removeClass('a11y');
+          $('.toggle-a11y').removeClass('on');
+          $('.toggle-a11y').attr('aria-disabled', 'true');
+          console.log('a11y-off');
+          open_panel();
+        }
+
+        // 3D model toggler
+        var panel_toggle = cozy.control.widget.toggle({
           region: 'top.toolbar.left',
           template: '<button class="button--sm" id="webgl" data-toggle="button" aria-label="3D Model">3D Model</button>',
           states: [{
@@ -297,7 +325,28 @@ webgl = FactoryService.webgl_unity(webgl_id)
               }
             }],
         })
-        toggle.addTo(reader);
+        panel_toggle.addTo(reader);
+
+        // Accessibility mode toggler
+        var a11y_toggle = cozy.control.widget.toggle({
+          region: 'top.header.right',
+          template: '<a target="_top" class="toggle-a11y" data-toggle="button" aria-disabled="true">Accessibility Mode</a>',
+          states: [{
+            stateName: 'a11y-on',
+            onClick: function(btn, reader) {
+              a11y_on();
+              btn.state('a11y-off');
+            }
+          },
+            {
+              stateName: 'a11y-off',
+              onClick: function(btn, reader) {
+                a11y_off();
+                btn.state('a11y-on');
+              }
+            }],
+        })
+        a11y_toggle.addTo(reader);
         <% else %>
         // no-op for epubs without a webgl (so... almost all of them)
         var fetch_poi = function() { }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -286,26 +286,6 @@ webgl = FactoryService.webgl_unity(webgl_id)
           };
         }
 
-        // accessibility mode functions
-        var a11y_on = function() {
-          $('body').addClass('a11y');
-          $('.toggle-a11y').addClass('on');
-          $('.toggle-a11y').attr('aria-disabled', 'false');
-          console.log('a11y-on');
-          close_panel();
-          //$('.webgl-content').detach();
-          // do something different with links to unity
-          // go to database in new window
-        }
-
-        var a11y_off = function() {
-          $('body').removeClass('a11y');
-          $('.toggle-a11y').removeClass('on');
-          $('.toggle-a11y').attr('aria-disabled', 'true');
-          console.log('a11y-off');
-          open_panel();
-        }
-
         // 3D model toggler
         var panel_toggle = cozy.control.widget.toggle({
           region: 'top.toolbar.left',
@@ -327,26 +307,69 @@ webgl = FactoryService.webgl_unity(webgl_id)
         })
         panel_toggle.addTo(reader);
 
-        // Accessibility mode toggler
-        var a11y_toggle = cozy.control.widget.toggle({
-          region: 'top.header.right',
-          template: '<a target="_top" class="toggle-a11y" data-toggle="button" aria-disabled="true">Accessibility Mode</a>',
-          states: [{
-            stateName: 'a11y-on',
-            onClick: function(btn, reader) {
-              a11y_on();
-              btn.state('a11y-off');
-            }
-          },
+        // accessibility mode functions
+        var a11y_on = function() {
+          $('body').addClass('a11y');
+          $('.toggle-a11y').addClass('on');
+          $('.toggle-a11y').attr('aria-disabled', 'false');
+          console.log('a11y-on');
+          close_panel();
+          //$('.webgl-content').detach();
+          // do something different with links to unity
+          // go to database in new window
+        }
+
+        var a11y_off = function() {
+          $('body').removeClass('a11y');
+          $('.toggle-a11y').removeClass('on');
+          $('.toggle-a11y').attr('aria-disabled', 'true');
+          console.log('a11y-off');
+          open_panel();
+        }
+
+        // Accessibility mode in preferences
+        cozy.control.preferences({
+          region: 'top.toolbar.right',
+          fields: [
             {
-              stateName: 'a11y-off',
-              onClick: function(btn, reader) {
-                a11y_off();
-                btn.state('a11y-on');
-              }
-            }],
-        })
-        a11y_toggle.addTo(reader);
+              label: 'Accessibility Mode',
+              name: 'accessibility-mode',
+              inputs: [
+                { value: 'off', label: 'Off' },
+                { value: 'on', label: 'On'}
+              ],
+              value: 'off',
+              callback: function(value) {
+                if value == 'on' {
+                  a11y_on();
+                } else {
+                  a11y_off();
+                }
+                //alert("Accessibility Mode changed to " + value);
+              },
+              hint: 'Read the publication without the 3D model. Links to stratigraphic units point to database records.'
+            }
+          ]
+        }).addTo(reader);
+        //var a11y_toggle = cozy.control.widget.toggle({
+        //  region: 'top.header.right',
+        //  template: '<a target="_top" class="toggle-a11y" data-toggle="button" aria-disabled="true">Accessibility Mode</a>',
+        //  states: [{
+        //    stateName: 'a11y-on',
+        //    onClick: function(btn, reader) {
+        //      a11y_on();
+        //      btn.state('a11y-off');
+        //    }
+        //  },
+        //    {
+        //      stateName: 'a11y-off',
+        //      onClick: function(btn, reader) {
+        //        a11y_off();
+        //        btn.state('a11y-on');
+        //      }
+        //    }],
+        // })
+        // a11y_toggle.addTo(reader);
         <% else %>
         // no-op for epubs without a webgl (so... almost all of them)
         var fetch_poi = function() { }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -398,8 +398,8 @@ webgl = FactoryService.webgl_unity(webgl_id)
               label: 'Accessibility Mode',
               name: 'accessibility-mode',
               inputs: [
-                { value: 'off', label: 'Accessibility Mode Off' },
-                { value: 'on', label: 'Accessibility Mode On'}
+                { value: 'off', label: 'Off' },
+                { value: 'on', label: 'On'}
               ],
               value: 'off',
               callback: function(value) {
@@ -408,7 +408,6 @@ webgl = FactoryService.webgl_unity(webgl_id)
                 } else {
                   a11y_off();
                 }
-                //alert("Accessibility Mode changed to " + value);
               },
               hint: 'When Accessibility Mode is "On", the publication is read without the 3D model. All links to stratigraphic units point to external database records.'
             }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -95,13 +95,13 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
           if (! $panel.length) {
 
-            var mobileUserMessage = '';
+            var $mobileUserMessage = "";
             if(heliotropeMobileUser === true) {
-              mobileUserMessage = '<div id="epub-webgl-mobile-message">Sorry, mobile devices are not compatible with WebGL.</div>';
+              $mobileUserMessage = '<div id="epub-webgl-mobile-message">Sorry, mobile devices are not compatible with WebGL.</div>';
             }
 
             var $panelContent =
-              '<div class="special-panel">' +
+              '<div class="special-panel" aria-hidden="false">' +
                 '<div class="panel-control">' +
                   '<button class="button--sm webgl-close" data-toggle="button" data-slot="label" aria-label="Close 3-D Model" onclick="close_panel();">' +
                     '<i class="icon-x oi" data-glyph="x" aria-hidden="true"></i>' +
@@ -109,7 +109,7 @@ webgl = FactoryService.webgl_unity(webgl_id)
                 '</div>' +
                 '<div class="webgl-content">' +
                   '<div id="gameContainer" tabindex="0">' +
-                    mobileUserMessage +
+                    $mobileUserMessage +
                   '</div>' +
                 '</div>' +
                 '<div class="panel-info">' +
@@ -122,6 +122,8 @@ webgl = FactoryService.webgl_unity(webgl_id)
             $panel = $($panelContent).appendTo($main);
           } else {
             $panel.show();
+            $('.special-panel').prop('hidden', false);
+            $('.special-panel').attr('aria-hidden', 'false');
           }
 
           // mobile users won't be loading the 3D content so this stuff isn't required
@@ -158,6 +160,8 @@ webgl = FactoryService.webgl_unity(webgl_id)
             $('.special-panel').hide();
             $('body').removeClass('panel-open');
             $('body').removeClass('panel-right');
+            $('.special-panel').prop('hidden', true);
+            $('.special-panel').attr('aria-hidden', 'true');
             setTimeout(function() {
               window.dispatchEvent(new Event('resize'));
             }, 0);
@@ -183,8 +187,9 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
         // dynamic WebGL canvas resizing
         reader.on('resized', function() {
-          // mobile users shouldn't have a canvas to resize
-          if (gameReady && heliotropeMobileUser === false) {
+          // again, these folks won't have a canvas to resize
+          //if (heliotropeMobileUser === false)
+          if (gameReady) {
             resize_webgl();
           }
         })
@@ -263,8 +268,6 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
         }, true);
 
-
-
         // POI to CFI webgl -> epub mapping stuff
         var poiToCfiMap = {};
 
@@ -307,69 +310,22 @@ webgl = FactoryService.webgl_unity(webgl_id)
         })
         panel_toggle.addTo(reader);
 
-        // accessibility mode functions
+        // accessibility mode on/off
         var a11y_on = function() {
           $('body').addClass('a11y');
-          $('.toggle-a11y').addClass('on');
-          $('.toggle-a11y').attr('aria-disabled', 'false');
-          console.log('a11y-on');
+          $('#webgl').attr('aria-disabled', 'true');
+          $('#webgl').prop('disabled', true);
           close_panel();
-          //$('.webgl-content').detach();
-          // do something different with links to unity
-          // go to database in new window
         }
 
         var a11y_off = function() {
           $('body').removeClass('a11y');
           $('.toggle-a11y').removeClass('on');
-          $('.toggle-a11y').attr('aria-disabled', 'true');
-          console.log('a11y-off');
+          $('#webgl').attr('aria-disabled', 'false');
+          $('#webgl').prop('disabled', false);
           open_panel();
         }
 
-        // Accessibility mode in preferences
-        cozy.control.preferences({
-          region: 'top.toolbar.right',
-          fields: [
-            {
-              label: 'Accessibility Mode',
-              name: 'accessibility-mode',
-              inputs: [
-                { value: 'off', label: 'Off' },
-                { value: 'on', label: 'On'}
-              ],
-              value: 'off',
-              callback: function(value) {
-                if value == 'on' {
-                  a11y_on();
-                } else {
-                  a11y_off();
-                }
-                //alert("Accessibility Mode changed to " + value);
-              },
-              hint: 'Read the publication without the 3D model. Links to stratigraphic units point to database records.'
-            }
-          ]
-        }).addTo(reader);
-        //var a11y_toggle = cozy.control.widget.toggle({
-        //  region: 'top.header.right',
-        //  template: '<a target="_top" class="toggle-a11y" data-toggle="button" aria-disabled="true">Accessibility Mode</a>',
-        //  states: [{
-        //    stateName: 'a11y-on',
-        //    onClick: function(btn, reader) {
-        //      a11y_on();
-        //      btn.state('a11y-off');
-        //    }
-        //  },
-        //    {
-        //      stateName: 'a11y-off',
-        //      onClick: function(btn, reader) {
-        //        a11y_off();
-        //        btn.state('a11y-on');
-        //      }
-        //    }],
-        // })
-        // a11y_toggle.addTo(reader);
         <% else %>
         // no-op for epubs without a webgl (so... almost all of them)
         var fetch_poi = function() { }
@@ -415,6 +371,7 @@ webgl = FactoryService.webgl_unity(webgl_id)
 
         // Bib info widget
         cozy.control.bibliographicInformation({ region: 'top.toolbar.left' }).addTo(reader)
+
         // Fullscreen widget
         cozy.control.widget.button({
           region: 'top.toolbar.right',
@@ -430,8 +387,37 @@ webgl = FactoryService.webgl_unity(webgl_id)
             }
           }
         }).addTo(reader);
-        // Reading preferences widget
+
+        // Reading preferences widget - webgl gets custom preferences
+        <% if @monograph_presenter.webgl? %>
+        // Add accessibility mode to preferences
+        cozy.control.preferences({
+          region: 'top.toolbar.right',
+          fields: [
+            {
+              label: 'Accessibility Mode',
+              name: 'accessibility-mode',
+              inputs: [
+                { value: 'off', label: 'Accessibility Mode Off' },
+                { value: 'on', label: 'Accessibility Mode On'}
+              ],
+              value: 'off',
+              callback: function(value) {
+                if (value == 'on') {
+                  a11y_on();
+                } else {
+                  a11y_off();
+                }
+                //alert("Accessibility Mode changed to " + value);
+              },
+              hint: 'When Accessibility Mode is "On", the publication is read without the 3D model. All links to stratigraphic units point to external database records.'
+            }
+          ]
+        }).addTo(reader);
+        <% else %>
         cozy.control.preferences({ region: 'top.toolbar.right' }).addTo(reader);
+        <% end %>
+
         // Paging widgets
         // cozy.control.pageFirst({ region: 'left.sidebar' }).addTo(reader);
         cozy.control.pagePrevious({ region: 'left.sidebar' }).addTo(reader);


### PR DESCRIPTION
Resolves #1442 

Adds an Accessibility Mode on/off toggle in preferences pane for EPUBs that have WebGL assets. If "on": closes WebGL panel, marks the `.special-panel` as hidden, disables 3D model button, and publication links that go to SU panels in WebGL model are replaced with links that go to corresponding SU database records.

(Also, updates cozy-sun-bear)

![screen shot 2018-03-22 at 2 11 30 pm](https://user-images.githubusercontent.com/1686111/37789788-2b947744-2ddb-11e8-8e43-dc2806ea22a0.png)

![screen shot 2018-03-22 at 2 11 45 pm](https://user-images.githubusercontent.com/1686111/37789793-30ebac62-2ddb-11e8-80c8-b934f431aa2e.png)

