### PR TITLE
change the feedback link for webgl

### DIFF
--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -446,9 +446,13 @@ webgl = FactoryService.webgl_unity(webgl_id)
         // Feedback widget
         cozy.control.widget.panel({
           region: 'bottom.navigator.left',
-          className: 'cozy-panel-feedback',
-          template: '<a href="https://docs.google.com/forms/d/e/1FAIpQLSeY04WhBtHGSXONu3jGiYnOcVzZxzHi3FGbS9ELg8rJdMpgpw/viewform?usp=sf_link" target="_blank" title="Report a problem or share feedback"><i class="icon-comment-square oi" data-glyph="comment-square" aria-hidden="true"></i></a>',
-        }).addTo(reader);
+	  className: 'cozy-panel-feedback',
+	  <% if @monograph_presenter.webgl? %>
+          template: '<a href="https://docs.google.com/forms/d/e/1FAIpQLSehtWeYRAmb12pLcQV0WXDvsQgdEsI6H-gbj4HumdySrmwhZg/viewform?usp=sf_link" target="_blank" title="Report a problem or share feedback"><i class="icon-comment-square oi" data-glyph="comment-square" aria-hidden="true"></i></a>',
+  	  <% else %>
+	  template: '<a href="https://docs.google.com/forms/d/e/1FAIpQLSeY04WhBtHGSXONu3jGiYnOcVzZxzHi3FGbS9ELg8rJdMpgpw/viewform?usp=sf_link" target="_blank" title="Report a problem or share feedback"><i class="icon-comment-square oi" data-glyph="comment-square" aria-hidden="true"></i></a>',
+  	  <% end %>
+	  }).addTo(reader);
 
         // Navigator widgets
         cozy.control.navigator({ region: 'bottom.navigator' }).addTo(reader);


### PR DESCRIPTION
Resolves #1674 

If a webgl project, use a different feedback form on the e-reader so we can collect browser and OS information from users.

![screen shot 2018-03-28 at 3 38 22 pm](https://user-images.githubusercontent.com/1686111/38052154-4e48b18e-329e-11e8-8503-fff10ec5bc1d.png)
