### PR TITLE
Hotfix/gabii fulcrum home

### DIFF
--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -25,7 +25,7 @@
         <div class="btn-toolbar" role="toolbar" aria-label="">
           <div class="btn-group" role="group" aria-label="">
             <% if @monograph_presenter.epub? %>
-                <a id="monograph-read-btn" href="<%= epub_path(@monograph_presenter.epub) %>" title="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %>" role="button" class="btn btn-default btn-small"><%= t('monograph_catalog.index.read_book') %></a>
+                <a id="monograph-read-btn" href="<%= epub_path(@monograph_presenter.epub) %>" title="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %>" role="button" class="btn btn-default btn-small" data-turbolinks="false"><%= t('monograph_catalog.index.read_book') %></a>
             <% end %>
             <% if @monograph_presenter.buy_url? %>
                 <a id="monograph-buy-btn" href="<%= @monograph_presenter.buy_url %>" target="_blank" title="<%= t('monograph_catalog.index.buy', title: @monograph_presenter.title) %>" role="button" class="btn btn-default btn-small"><%= t('monograph_catalog.index.buy_book') %></a>

--- a/fulcrum/index.html
+++ b/fulcrum/index.html
@@ -82,6 +82,31 @@ layout: default
     <div class="section case-study">
       <div class="row">
         <div class="col s12 m4 project-cover">
+          <a href="https://www.fulcrum.org/concern/monographs/n009w229r"><img class="responsive-img" src="//fulcrum.org/image-service/m900nt438/full/300,/0/default.jpg" alt="Cover for A Mid-Republican House from Gabii" /></a>
+        </div>
+        <div class="col s12 m8 project-info">
+          <h3><a href="https://www.fulcrum.org/concern/monographs/n009w229r">A Mid-Republican House from Gabii</a></h3>
+          <h4>Rachel Opitz, Marcello Mogetta, and Nicola Terrenato, Editors</h4>
+          <h5>University of Michigan Press, 2016</h5>
+          <p class="light">Since 2009 the Gabii Project, an international archaeological initiative led by Nicola Terrenato and the University of Michigan, has been investigating the ancient Latin town of Gabii, which was both a neighbor of, and a rival to, Rome in the first millennium BCE. The trajectory of Gabii, from an Iron Age settlement to a flourishing mid-Republican town to an Imperial agglomeration widely thought to be in decline, provides a new perspective on the dynamics of settlement in central Italy. A Mid-Republican House from Gabii focuses on the construction, inhabitation, and repurposing of a private home at Gabii, built in the mid-Republican period. Published in digital form as a website backed up by a detailed database, the publication provides a synthesis of excavation results linked to the relevant spatial, descriptive, and quantitative data. Fulcrum brings together the database, narrative, and interactive 3D model of the reconstructed ancient site to give the user a seamless reading experience, presenting the narrative and 3D model side by side and including comprehensive linking throughout all components enabling the reader to move through the project in a number of ways.
+          </p>
+          <a href="https://www.fulcrum.org/concern/monographs/n009w229r" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col s12 m4 project-cover">
+          <a href="https://www.fulcrum.org/concern/monographs/w0892995q"><img class="responsive-img" src="//fulcrum.org/image-service/j098zb110/full/300,/0/default.jpg" alt="Cover for Show Sold Separately: Promos, Spoilers, and Other Media Paratexts" /></a>
+        </div>
+        <div class="col s12 m8 project-info">
+          <h3><a href="https://www.fulcrum.org/concern/monographs/w0892995q">Show Sold Separately: Promos, Spoilers, and Other Media Paratexts</a></h3>
+          <h4>Jonathan Gray</h4>
+          <h5>NYU Press, 2017</h5>
+          <p class="light"><em>Show Sold Separately</em> gives critical attention to the ubiquitous but often overlooked phenomenon of audiences approaching movies and TV shows with preconceived notions about them, shaped by the onslaught of information and hype that surround them. This book examines a wide range of materials from DVD bonus materials to action figures that reveal the world of film and television that exists before and after the show. New York University Press used Fulcrum to host the book’s impressive array of video clips and images that are embedded in the EPUB, which is available for reading in the <a href="http://openaccessbooks.nyupress.org/details/9780814731956/">New York University Press Open Access Books portal</a>. The videos are presented using AblePlayer, a fully-accessible cross-browser media player. Users are able to pan and zoom the images from within the e-reader, using the Leaflet viewer. Users are able to enjoy these media assets from the comfort of the e-reader environment, providing them an integrated, seamless reading experience.</p>
+          <a href="https://www.fulcrum.org/concern/monographs/w0892995q" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col s12 m4 project-cover">
           <a href="https://www.fulcrum.org/concern/monographs/bz60cw269"><img class="responsive-img" src="//fulcrum.org/image-service/z029p4736/full/300,/0/default.jpg" alt="Cover for Director's Prism: E.T.A. Hoffman and the Russian Theatrical Avant-Garde" /></a>
         </div>
         <div class="col s12 m8 project-info">
@@ -140,18 +165,7 @@ layout: default
           <a href="https://www.fulcrum.org/concern/monographs/rr171x24p" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
         </div>
       </div>
-      <div class="row">
-        <div class="col s12 m4 project-cover">
-          <a href="https://www.fulcrum.org/concern/monographs/w0892995q"><img class="responsive-img" src="//fulcrum.org/image-service/j098zb110/full/300,/0/default.jpg" alt="Cover for Show Sold Separately: Promos, Spoilers, and Other Media Paratexts" /></a>
-        </div>
-        <div class="col s12 m8 project-info">
-          <h3><a href="https://www.fulcrum.org/concern/monographs/w0892995q">Show Sold Separately: Promos, Spoilers, and Other Media Paratexts</a></h3>
-          <h4>Jonathan Gray</h4>
-          <h5>NYU Press, 2017</h5>
-          <p class="light"><em>Show Sold Separately</em> gives critical attention to the ubiquitous but often overlooked phenomenon of audiences approaching movies and TV shows with preconceived notions about them, shaped by the onslaught of information and hype that surround them. This book examines a wide range of materials from DVD bonus materials to action figures that reveal the world of film and television that exists before and after the show. New York University Press used Fulcrum to host the book’s impressive array of video clips and images that are embedded in the EPUB, which is available for reading in the <a href="http://openaccessbooks.nyupress.org/details/9780814731956/">New York University Press Open Access Books portal</a>. The videos are presented using AblePlayer, a fully-accessible cross-browser media player. Users are able to pan and zoom the images from within the e-reader, using the Leaflet viewer. Users are able to enjoy these media assets from the comfort of the e-reader environment, providing them an integrated, seamless reading experience.</p>
-          <a href="https://www.fulcrum.org/concern/monographs/w0892995q" class="btn-large button--lg waves-effect waves-light lighten-1">View Project</a>
-        </div>
-      </div>
+
       <div class="row">
         <div class="col s12 m4 project-cover">
           <a href="https://www.fulcrum.org/concern/monographs/fj2362114"><img class="responsive-img" src="//fulcrum.org/image-service/4x51hj03c/full/300,/0/default.jpg" alt="Cover for Selma and the Liuzzo Murder Trials: The First Modern Civil Rights Convictions" /></a>


### PR DESCRIPTION
Resolves #1704 
Resolves #1706 

Adds Gabii to Fulcrum homepage and fixes bug when navigating from monograph catalog page to e-reader after clicking on the 3D model tab.