### PR TITLE
Add free trial messaging for gabii/webgl titles

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -929,6 +929,17 @@ $gabii-link-hover:    #1e5667;
       }
     }
 
+    .message {
+      @include lato;
+      font-size: .8em;
+      padding-left: 1em;
+      vertical-align: sub;
+
+      a {
+        text-decoration: underline;
+      }
+    }
+
     .nav-tabs {
       @include lato;
     }
@@ -1019,7 +1030,30 @@ $gabii-link-hover:    #1e5667;
     .hint {
       padding: 1em 2em;
     }
-    
+
+    .cozy-panel-header > .cozy-panel-right {
+
+      justify-content: flex-end;
+
+      .alert {
+        padding: 12.5px;
+        margin: 0;
+        font-size: .9em;
+
+        a {
+          text-decoration: underline;
+        }
+      }
+
+      .alert-dismissable .close {
+        top: -10px;
+        right: -5px;
+      }
+
+    }
+
+
+
     .cozy-control .cozy-h1 {
       font-size: 1.5em;
     }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -68,6 +68,13 @@ webgl = FactoryService.webgl_unity(webgl_id)
         // Book/chapter title widget
         cozy.control.title({ region: 'top.header.left' }).addTo(reader);
 
+        <% if @monograph_presenter.webgl? %>
+        cozy.control.widget.panel({
+          region: 'top.header.right',
+          template: `<div class="alert alert-info alert-dismissable" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><span class="message"><strong>Access to the full publication is free through June 2018.</strong> Afterwards, you can purchase access <a href="https://www.press.umich.edu/9231782/mid_republican_house_from_gabii">here</a>.</span></div>`
+        }).addTo(reader);
+        <% end %>
+
         // Table of contents widget
         cozy.control.contents({ region: 'top.toolbar.left' }).addTo(reader);
 

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -31,6 +31,9 @@
                 <a id="monograph-buy-btn" href="<%= @monograph_presenter.buy_url %>" target="_blank" title="<%= t('monograph_catalog.index.buy', title: @monograph_presenter.title) %>" role="button" class="btn btn-default btn-small"><%= t('monograph_catalog.index.buy_book') %></a>
             <% end %>
           </div><!-- /.btn-group -->
+          <% if @monograph_presenter.webgl? %>
+          <span class="message">Enjoy free-trial access through June 2018. Afterwards, you can purchase access <a href="https://www.press.umich.edu/9231782/mid_republican_house_from_gabii">here</a>.</span>
+          <% end %>
         </div><!-- /.btn-toolbar -->
     <% end %>
     <% if @monograph_presenter.webgl? %>


### PR DESCRIPTION
Resolves #1695 

Incorporates feedback from mockups. Adds message on monograph catalog page about free-trial access and a link to purchase (goes to press product page). Adds a dismissible message in the e-reader about free-trial access and a link to purchase (goes to press product page).

Adds some custom styles to control display. 

These messages will be removed after June 2018.