### PR TITLE
add share widget button to heliotrope e-reader

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -643,6 +643,16 @@ footer.press {
 	padding: .71em 1em;
 }
 
+.cozy-control .btn-group {
+  display: initial;
+
+  .dropdown-menu {
+    border-radius: 0px;
+    top: 125%;
+  }
+
+}
+
 .cozy-modal {
   padding: 0 !important;
 }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -388,6 +388,12 @@ webgl = FactoryService.webgl_unity(webgl_id)
         // Bib info widget
         cozy.control.bibliographicInformation({ region: 'top.toolbar.left' }).addTo(reader)
 
+        // Share widget
+        cozy.control.widget.button({
+          region: 'top.toolbar.left',
+          template: `<div class="btn-group"><button class="button--sm dropdown-toggle" data-toggle="dropdown" aria-label="Share book" aria-haspopup="true" aria-expanded="false"><i id="share" class="icon-share-boxed oi" data-glyph="share-boxed" title="Share book" aria-hidden="true"></i></button><ul class="dropdown-menu"><li><a href="http://twitter.com/intent/tweet?text=<%= @monograph_presenter.page_title %>&amp;url=<%= @citable_link %>" target="_blank">Twitter</a></li><li><a href="http://www.facebook.com/sharer.php?u=<%= @citable_link %>&amp;t=<%= @monograph_presenter.page_title %>" target="_blank">Facebook</a></li><li><a href="https://plus.google.com/share?url=<%= @citable_link %>" target="_blank">Google+</a></li><li><a href="http://www.reddit.com/submit?url=<%= @citable_link %>" target="_blank">Reddit</a></li><li><a href="http://www.mendeley.com/import/?url=<%= @citable_link %>" target="_blank">Mendeley</a></li><li><a href="http://www.citeulike.org/posturl?url=<%= @citable_link %>&amp;title=<%= @monograph_presenter.page_title %>" target="_blank">Cite U Like</a></li></ul></div>`
+        }).addTo(reader);
+
         // Fullscreen widget
         cozy.control.widget.button({
           region: 'top.toolbar.right',


### PR DESCRIPTION
Resolves [CSB#43](https://github.com/mlibrary/cozy-sun-bear/issues/43)

Adds a share widget button that shares title and citable link to social sites.

![screen shot 2018-04-12 at 4 14 00 pm](https://user-images.githubusercontent.com/1686111/38701858-013290ec-3e6d-11e8-8f64-fcbaa35c8bc9.png)

Clicking the share button activates a (bootstrap) dropdown menu with a list of social sites.

![screen shot 2018-04-12 at 4 14 11 pm](https://user-images.githubusercontent.com/1686111/38701869-0a142e28-3e6d-11e8-9603-7f6cd33843a8.png)

Clicking a social site opens that site in a new window with title and citable link pre-populated.

![screen shot 2018-04-12 at 4 21 33 pm](https://user-images.githubusercontent.com/1686111/38702061-997fedfe-3e6d-11e8-935f-d566ab6f094d.png)

Is using the same share sites we use for assets.
