### PR TITLE
modify jumbotron for HEB theme, reducing font size

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -152,6 +152,17 @@ $heb-black-80: #342f2e;
   .jumbotron {
     background-color: $heb-grey-4;
     font-weight: 200;
+    padding-top: 2em;
+    padding-bottom: 2em;
+
+    p {
+      font-size: 16px;
+      margin-bottom: 0;
+    }
+    
+    .container {
+      margin-top: 0;
+    }
 
     .logo {
 


### PR DESCRIPTION
Resolves #1727 

Reduce font size for jumbotron on the publisher page for HEB theme, and reduce some of the margins as well to decrease the amount of screen space the publisher description takes up.

![screen shot 2018-04-13 at 11 14 54 am](https://user-images.githubusercontent.com/1686111/38743519-44113e2c-3f0d-11e8-8b01-42007d1d8c10.png)

