### PR TITLE
Resolves #1689, replace fedora calls with solr calls

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -79,15 +79,13 @@ class EPubsController < ApplicationController
   private
 
     def set_presenter
-      @presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(params[:id]).to_solr), current_ability, request)
-      if @presenter.epub?
+      @presenter = Hyrax::PresenterFactory.build_for(ids: [params[:id]], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
+      if @presenter.present? && @presenter.epub?
         FactoryService.e_pub_publication(params[:id]) # cache epub
       else
         Rails.logger.info("EPubsController.set_presenter(#{params[:id]}) is not an EPub.")
         render 'hyrax/base/unauthorized', status: :unauthorized
       end
-    rescue Ldp::Gone # tombstone
-      raise CanCan::AccessDenied
     end
 
     def set_show

--- a/app/controllers/webgls_controller.rb
+++ b/app/controllers/webgls_controller.rb
@@ -8,8 +8,8 @@ class WebglsController < ApplicationController
     # from the monograph_catalog page instead of calling this directly through a route. However it's a good place to
     # check the WebGL outside of the EPUB or navigation tab craziness, yet inside Rails and Turbolinks craziness.
     # Eventually we could delete this (and specs), or leave it here "forever" as an example?
-    @presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(params[:id]).to_solr), current_ability, request)
-    if @presenter.webgl?
+    @presenter = Hyrax::PresenterFactory.build_for(ids: [params[:id]], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
+    if @presenter.present? && @presenter.webgl?
       webgl = FactoryService.webgl_unity(params[:id])
       @unity_progress = "#{params[:id]}/#{webgl.unity_progress}"
       @unity_loader = "#{params[:id]}/#{webgl.unity_loader}"
@@ -19,8 +19,6 @@ class WebglsController < ApplicationController
       Rails.logger.info("WebglsController.show(#{params[:id]}) is not a WebGL.")
       render 'hyrax/base/unauthorized', status: :unauthorized
     end
-  rescue Ldp::Gone # tombstone
-    raise CanCan::AccessDenied
   end
 
   def file

--- a/app/services/factory_service.rb
+++ b/app/services/factory_service.rb
@@ -193,7 +193,8 @@ module FactoryService # rubocop:disable Metrics/ModuleLength
     private_class_method :semaphore
 
     def self.e_pub_publication_from(id)
-      presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(id).to_solr), nil, nil)
+      presenter = Hyrax::PresenterFactory.build_for(ids: [id], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
+      return EPub::Publication.null_object if presenter.nil?
       return EPub::Publication.null_object unless presenter.epub?
       file = Tempfile.new(id)
       file.write(presenter.file.content.force_encoding("utf-8"))
@@ -216,7 +217,8 @@ module FactoryService # rubocop:disable Metrics/ModuleLength
     private_class_method :create_epub_webgl_bridge
 
     def self.mcvs_manifest_from(id)
-      presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(id).to_solr), nil, nil)
+      presenter = Hyrax::PresenterFactory.build_for(ids: [id], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
+      return MCSV::Manifest.null_object if presenter.nil?
       presenter.manifest? ? MCSV::Manifest.from(id: id, mcsv: presenter.file) : MCSV::Manifest.null_object
     rescue StandardError => e
       Rails.logger.info("FactoryService.mcsv_manifest_from(#{id}) raised #{e}")
@@ -225,7 +227,8 @@ module FactoryService # rubocop:disable Metrics/ModuleLength
     private_class_method :mcvs_manifest_from
 
     def self.webgl_unity_from(id)
-      presenter = Hyrax::FileSetPresenter.new(SolrDocument.new(FileSet.find(id).to_solr), nil, nil)
+      presenter = Hyrax::PresenterFactory.build_for(ids: [id], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
+      return Webgl::Unity.null_object if presenter.nil?
       return Webgl::Unity.null_object unless presenter.webgl?
       file = Tempfile.new(id)
       file.write(presenter.file.content.force_encoding("utf-8"))

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -54,24 +54,6 @@ RSpec.describe EPubsController, type: :controller do
         end
       end
     end
-
-    context 'tombstone' do
-      let(:monograph) { create(:monograph) }
-      let(:file_set) { create(:file_set, content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
-      before do
-        monograph.ordered_members << file_set
-        monograph.save!
-        file_set.save!
-        file_set.destroy!
-        get :show, params: { id: file_set.id }
-      end
-      it do
-        # The HTTP response status code 302 Found is a common way of performing URL redirection.
-        expect(response).to have_http_status(:found)
-        # raise CanCan::AccessDenied currently redirects to root_url
-        expect(response.header["Location"]).to match "http://test.host/"
-      end
-    end
   end
 
   describe "#file" do

--- a/spec/controllers/webgls_controller_spec.rb
+++ b/spec/controllers/webgls_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe WebglsController, type: :controller do
       before do
         monograph.ordered_members << file_set
         monograph.save!
+        file_set.save!
         get :show, params: { id: file_set.id }
       end
       after { FeaturedRepresentative.destroy_all }
@@ -34,6 +35,7 @@ RSpec.describe WebglsController, type: :controller do
       before do
         monograph.ordered_members << file_set
         monograph.save!
+        file_set.save!
       end
       after { FeaturedRepresentative.destroy_all }
       it "returns the UnityLoader.js file" do

--- a/spec/services/factory_service_spec.rb
+++ b/spec/services/factory_service_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe FactoryService do
   before do
     monograph.ordered_members << epub << webgl
     monograph.save!
+    epub.save!
+    webgl.save!
     FeaturedRepresentative.create(monograph_id: monograph.id, file_set_id: epub.id, kind: 'epub')
     FeaturedRepresentative.create(monograph_id: monograph.id, file_set_id: webgl.id, kind: 'webgl')
     described_class.clear_caches
@@ -21,8 +23,6 @@ RSpec.describe FactoryService do
   describe '#nop' do
     it { expect(described_class).to respond_to(:nop) }
   end
-
-  describe
 
   describe '#clear_semaphores' do
     it { expect(described_class).to respond_to(:clear_semaphores) }
@@ -157,9 +157,7 @@ RSpec.describe FactoryService do
     end
     context 'object not found' do
       let(:id) { 'validnoid' }
-      before { allow(FileSet).to receive(:find).with(id).and_raise(ActiveFedora::ObjectNotFoundError) }
       it 'returns a null object' do
-        expect(Rails.logger).to receive(:info).with("FactoryService.e_pub_publication_from(validnoid) raised ActiveFedora::ObjectNotFoundError")
         is_expected.to be_an_instance_of(EPub::PublicationNullObject)
       end
     end
@@ -190,9 +188,7 @@ RSpec.describe FactoryService do
     end
     context 'object not found' do
       let(:id) { 'validnoid' }
-      before { allow(FileSet).to receive(:find).with(id).and_raise(ActiveFedora::ObjectNotFoundError) }
       it 'returns a null object' do
-        expect(Rails.logger).to receive(:info).with("FactoryService.mcsv_manifest_from(validnoid) raised ActiveFedora::ObjectNotFoundError")
         is_expected.to be_an_instance_of(MCSV::ManifestNullObject)
       end
     end


### PR DESCRIPTION
There are still some places where we're using Fedora to display when we should be using Solr. But these places are tied into what it means to be "tombstoned" and development for that is scheduled for Summer '18 so we'll deal with those then see #994. This PR does remove some current tombstone code, but all of that will be worked out in #994.

The FactorService specs are pretty slow right now, but that area too is going to be refactored so changes are coming see #1692 