### PR TITLE
Addresses #1725 file manager changes visibility.

### DIFF
--- a/app/actors/hyrax/actors/monograph_actor.rb
+++ b/app/actors/hyrax/actors/monograph_actor.rb
@@ -19,13 +19,15 @@ module Hyrax
 
         # Add some default read and edit groups for that Press, for that Role
         def apply_default_group_permissions(env)
-          admin = "#{env.attributes['press']}_admin"
-          editor = "#{env.attributes['press']}_editor"
+          press = env.attributes['press'] || env.curation_concern.press
+          admin = "#{press}_admin"
+          editor = "#{press}_editor"
 
           (env.attributes["read_groups"] ||= []).push(admin).push(editor)
           (env.attributes["edit_groups"] ||= []).push(admin).push(editor)
 
-          if env.attributes["visibility"] == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          if env.attributes["visibility"] == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC ||
+             env.curation_concern.public?
             env.attributes["read_groups"].push("public")
           end
           env


### PR DESCRIPTION
In cases where the actor environment lacks permissions information, extract them from the `curation_concern`.