### PR TITLE
Update CSB with Safari bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '6067e96ca8c23f51cd02ac8f3354c6cb49cb9365'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '94cc6cea0a6e8c49cf1da83327290b45efe46b57'
 
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '9139d358e3cd6b3cca7d71e3ff8352269d6c218d'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '6067e96ca8c23f51cd02ac8f3354c6cb49cb9365'
 
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 6067e96ca8c23f51cd02ac8f3354c6cb49cb9365
-  ref: 6067e96ca8c23f51cd02ac8f3354c6cb49cb9365
+  revision: 94cc6cea0a6e8c49cf1da83327290b45efe46b57
+  ref: 94cc6cea0a6e8c49cf1da83327290b45efe46b57
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 9139d358e3cd6b3cca7d71e3ff8352269d6c218d
-  ref: 9139d358e3cd6b3cca7d71e3ff8352269d6c218d
+  revision: 6067e96ca8c23f51cd02ac8f3354c6cb49cb9365
+  ref: 6067e96ca8c23f51cd02ac8f3354c6cb49cb9365
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -640,12 +640,12 @@ footer.press {
 }
 
 .cozy-control button.button--sm.cozy-close {
-	padding: .71em 1em;
+	padding: .83em 1em !important;
 }
 
 .cozy-control .btn-group {
   display: flex;
-  height: 100%;
+  flex: 1 1 auto;
 
   .dropdown-menu {
     border-radius: 0px;


### PR DESCRIPTION
Includes updated version of CSB with fixes for [CSB#78](https://github.com/mlibrary/cozy-sun-bear/issues/78) as well as local changes to heliotrope e-reader CSS to account for the share button and close reader button.