### PR TITLE
Accessibility fixes for monograph and asset tabs

### DIFF
--- a/app/assets/javascripts/application/tabs.js
+++ b/app/assets/javascripts/application/tabs.js
@@ -1,0 +1,137 @@
+$(document).on('turbolinks:load', function() {
+  // Store the tab last used on the monograph catalog page and amend it to URL
+  // if it exists.
+  storeTab();
+  accessibleTabs();
+  keyboardTabs();
+  //Improve accessibility of tabs on monograph and asset pages
+
+function storeTab() {
+  // If monograph page, store the last used tab
+  if ($('#main.monograph').length > 0) {
+    // https://stackoverflow.com/a/10524697
+    var monograph_id = '<%= @monograph_presenter.id %>';
+    var previous_monograph_id = localStorage.getItem('monograph_id');
+    localStorage.setItem('monograph_id', monograph_id);
+
+    if (monograph_id !== previous_monograph_id) {
+      localStorage.removeItem('lastTab');
+    }
+
+    // for bootstrap 3 use 'shown.bs.tab', for bootstrap 2 use 'shown' in the next line
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+      // save the latest tab; use cookies if you like 'em better:
+      localStorage.setItem('lastTab', $(e.target).attr('href'));
+    });
+
+    // go to the latest tab, apply aria semantics, if it exists in localStorage
+    // if not the first tab, unset aria semantics for first tab
+    var lastTab = localStorage.getItem('lastTab');
+    var firstTab = $('ul[role="tablist"]').children().first().children('a[role="tab"]').attr('href');
+    //.attr('href');
+    console.log(firstTab);
+    if (lastTab) {
+      $('a[href="' + lastTab + '"]').tab('show');
+      $(lastTab).attr("aria-hidden", false);
+      $('a[href="' + lastTab + '"]').attr("aria-selected", true);
+      if (lastTab !== firstTab) {
+        $(firstTab).attr("aria-hidden", true);
+        $('a[href="' + firstTab + '"]').attr("aria-selected", false);
+      }
+    }
+  }
+}
+
+function accessibleTabs() {
+  // a11y toggles for tab list items, fire on bootstrap tab events
+  // https://getbootstrap.com/docs/3.3/javascript/#tabs-events
+  // https://codepen.io/jwmcglone/pen/pVNLGB?editors=1010
+  $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+    var newTabList = $(e.target);
+    var oldTabList = $(e.relatedTarget);
+    var newTabPanel = $(e.target).attr('href');
+    var oldTabPanel = $(e.relatedTarget).attr('href');
+    // modify previously active tab list item and tab panel
+    // 1) change the old tabs values to aria-selected = false and aria-hidden = true
+    $(oldTabList).attr('aria-selected', false);
+    $(oldTabList).attr('tabindex', '-1');
+    $(oldTabPanel).attr('aria-hidden', true);
+
+    // modify newly active tab list item and tab panel
+    // 2) change the new tab values to aria-selected = true and aria-hidden = false
+    // 3) set the focus on the newly selected tab content .attr("tabindex", -1) and .focus();
+    $(newTabList).attr("aria-selected", true);
+    $(newTabList).attr('tabindex', '0');
+    $(newTabPanel).attr("aria-hidden", false);
+  });
+}
+
+function keyboardTabs() {
+  var tabbed = document.querySelector('#tabs');
+  var tablist = tabbed.querySelector('ul');
+  var tabs = tablist.querySelectorAll('a');
+  var panels = tabbed.querySelectorAll('.tab-pane');
+
+  // The tab switching function
+  var switchTab = function switchTab(oldTab, newTab) {
+    $(newTab).tab('show');
+    newTab.focus();
+    // Make the active tab focusable by the user (Tab key)
+    newTab.removeAttribute('tabindex');
+    // Set the selected state
+    newTab.setAttribute('aria-selected', 'true');
+    newTab.parentNode.setAttribute('class', 'active');
+    oldTab.setAttribute('aria-selected', 'false');
+    oldTab.parentNode.removeAttribute('class', 'active');
+    oldTab.setAttribute('tabindex', '-1');
+    // Get the indices of the new and old tabs to find the correct
+    // tab panels to show and hide
+    var index = Array.prototype.indexOf.call(tabs, newTab);
+    var oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
+    //panels[oldIndex].setAttribute('class', 'active');
+    $(panels[index]).tab('show');
+    //('class', 'active');
+  };
+
+  // Add the tablist role to the first <ul> in the .tabbed container
+  tablist.setAttribute('role', 'tablist');
+
+  // Add semantics are remove user focusability for each tab
+  Array.prototype.forEach.call(tabs, function (tab, i) {
+    tab.setAttribute('role', 'tab');
+    //tab.setAttribute('id', 'tab' + (i + 1));
+    tab.setAttribute('tabindex', '-1');
+    tab.parentNode.setAttribute('role', 'presentation');
+
+    // Handle clicking of tabs for mouse users
+    tab.addEventListener('click', function (e) {
+      e.preventDefault();
+      var currentTab = tablist.querySelector('[aria-selected]');
+      if (e.currentTarget !== currentTab) {
+        switchTab(currentTab, e.currentTarget);
+      }
+    });
+
+    // Handle keydown events for keyboard users
+    tab.addEventListener('keydown', function (e) {
+      // Get the index of the current tab in the tabs node list
+      var index = Array.prototype.indexOf.call(tabs, e.currentTarget);
+      // Work out which key the user is pressing and
+      // Calculate the new tab's index where appropriate
+      var dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
+      if (dir !== null) {
+        e.preventDefault();
+        // If the down key is pressed, move focus to the open panel,
+        // otherwise switch to the adjacent tab
+        dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
+      }
+    });
+  });
+
+  // Initially activate the first tab and reveal the first tab panel
+  tabs[0].removeAttribute('tabindex');
+  //tabs[0].setAttribute('aria-selected', 'true');
+  //panels[0].hidden = false;
+}
+
+});

--- a/app/assets/javascripts/application/tabs.js
+++ b/app/assets/javascripts/application/tabs.js
@@ -1,16 +1,19 @@
 $(document).on('turbolinks:load', function() {
-  // Store the tab last used on the monograph catalog page and amend it to URL
-  // if it exists.
+  // Store the monograph ID and tab ID last used on the monograph catalog page
+  // Amend the tab ID to URL if it exists.
   storeTab();
+  // Improve accessibility and keyboard functionality of tabs
+  // For monograph and asset pages
   accessibleTabs();
-  keyboardTabs();
-  //Improve accessibility of tabs on monograph and asset pages
 
 function storeTab() {
   // If monograph page, store the last used tab
   if ($('#main.monograph').length > 0) {
     // https://stackoverflow.com/a/10524697
-    var monograph_id = '<%= @monograph_presenter.id %>';
+    var page_url = window.location.pathname.split( '/' );
+    // getting the monograph id from the URL path is not as reliable as using the
+    // monograph presenter
+    var monograph_id = page_url[3];
     var previous_monograph_id = localStorage.getItem('monograph_id');
     localStorage.setItem('monograph_id', monograph_id);
 
@@ -28,8 +31,6 @@ function storeTab() {
     // if not the first tab, unset aria semantics for first tab
     var lastTab = localStorage.getItem('lastTab');
     var firstTab = $('ul[role="tablist"]').children().first().children('a[role="tab"]').attr('href');
-    //.attr('href');
-    console.log(firstTab);
     if (lastTab) {
       $('a[href="' + lastTab + '"]').tab('show');
       $(lastTab).attr("aria-hidden", false);
@@ -43,95 +44,73 @@ function storeTab() {
 }
 
 function accessibleTabs() {
-  // a11y toggles for tab list items, fire on bootstrap tab events
-  // https://getbootstrap.com/docs/3.3/javascript/#tabs-events
-  // https://codepen.io/jwmcglone/pen/pVNLGB?editors=1010
-  $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-    var newTabList = $(e.target);
-    var oldTabList = $(e.relatedTarget);
-    var newTabPanel = $(e.target).attr('href');
-    var oldTabPanel = $(e.relatedTarget).attr('href');
-    // modify previously active tab list item and tab panel
-    // 1) change the old tabs values to aria-selected = false and aria-hidden = true
-    $(oldTabList).attr('aria-selected', false);
-    $(oldTabList).attr('tabindex', '-1');
-    $(oldTabPanel).attr('aria-hidden', true);
+  if ($('#tabs').length > 0) {
+    // Adapted from https://codepen.io/heydon/pen/veeaEa
+    var tabbed = document.querySelector('#tabs');
+    var tablist = tabbed.querySelector('ul');
+    var tabs = tablist.querySelectorAll('a');
+    var panels = tabbed.querySelectorAll('.tab-pane');
 
-    // modify newly active tab list item and tab panel
-    // 2) change the new tab values to aria-selected = true and aria-hidden = false
-    // 3) set the focus on the newly selected tab content .attr("tabindex", -1) and .focus();
-    $(newTabList).attr("aria-selected", true);
-    $(newTabList).attr('tabindex', '0');
-    $(newTabPanel).attr("aria-hidden", false);
-  });
-}
+    // The tab switching function
+    var switchTab = function switchTab(oldTab, newTab) {
+      $(newTab).tab('show');
+      newTab.focus();
+      // Make the active tab focusable by the user (Tab key)
+      newTab.removeAttribute('tabindex');
+      // Set the selected state
+      newTab.setAttribute('aria-selected', 'true');
+      newTab.parentNode.setAttribute('class', 'active');
+      oldTab.setAttribute('aria-selected', 'false');
+      oldTab.parentNode.removeAttribute('class', 'active');
+      oldTab.setAttribute('tabindex', '-1');
+      // Get the indices of the new and old tabs to find the correct
+      // tab panels to show and hide
+      var index = Array.prototype.indexOf.call(tabs, newTab);
+      var oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
+      panels[oldIndex].setAttribute('aria-hidden', 'true');
+      $(panels[index]).tab('show');
+      panels[index].setAttribute('aria-hidden', 'false');
+      //('class', 'active');
+    };
 
-function keyboardTabs() {
-  var tabbed = document.querySelector('#tabs');
-  var tablist = tabbed.querySelector('ul');
-  var tabs = tablist.querySelectorAll('a');
-  var panels = tabbed.querySelectorAll('.tab-pane');
+    // Add the tablist role to the first <ul> in the .tabbed container
+    tablist.setAttribute('role', 'tablist');
 
-  // The tab switching function
-  var switchTab = function switchTab(oldTab, newTab) {
-    $(newTab).tab('show');
-    newTab.focus();
-    // Make the active tab focusable by the user (Tab key)
-    newTab.removeAttribute('tabindex');
-    // Set the selected state
-    newTab.setAttribute('aria-selected', 'true');
-    newTab.parentNode.setAttribute('class', 'active');
-    oldTab.setAttribute('aria-selected', 'false');
-    oldTab.parentNode.removeAttribute('class', 'active');
-    oldTab.setAttribute('tabindex', '-1');
-    // Get the indices of the new and old tabs to find the correct
-    // tab panels to show and hide
-    var index = Array.prototype.indexOf.call(tabs, newTab);
-    var oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
-    //panels[oldIndex].setAttribute('class', 'active');
-    $(panels[index]).tab('show');
-    //('class', 'active');
-  };
+    // Add aria semantics - remove user focusability for each tab
+    Array.prototype.forEach.call(tabs, function (tab, i) {
+      tab.setAttribute('role', 'tab');
+      //tab.setAttribute('id', 'tab' + (i + 1));
+      tab.setAttribute('tabindex', '-1');
+      tab.parentNode.setAttribute('role', 'presentation');
 
-  // Add the tablist role to the first <ul> in the .tabbed container
-  tablist.setAttribute('role', 'tablist');
-
-  // Add semantics are remove user focusability for each tab
-  Array.prototype.forEach.call(tabs, function (tab, i) {
-    tab.setAttribute('role', 'tab');
-    //tab.setAttribute('id', 'tab' + (i + 1));
-    tab.setAttribute('tabindex', '-1');
-    tab.parentNode.setAttribute('role', 'presentation');
-
-    // Handle clicking of tabs for mouse users
-    tab.addEventListener('click', function (e) {
-      e.preventDefault();
-      var currentTab = tablist.querySelector('[aria-selected]');
-      if (e.currentTarget !== currentTab) {
-        switchTab(currentTab, e.currentTarget);
-      }
-    });
-
-    // Handle keydown events for keyboard users
-    tab.addEventListener('keydown', function (e) {
-      // Get the index of the current tab in the tabs node list
-      var index = Array.prototype.indexOf.call(tabs, e.currentTarget);
-      // Work out which key the user is pressing and
-      // Calculate the new tab's index where appropriate
-      var dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
-      if (dir !== null) {
+      // Handle clicking of tabs for mouse users
+      tab.addEventListener('click', function (e) {
         e.preventDefault();
-        // If the down key is pressed, move focus to the open panel,
-        // otherwise switch to the adjacent tab
-        dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
-      }
-    });
-  });
+        var currentTab = tablist.querySelector('[aria-selected]');
+        if (e.currentTarget !== currentTab) {
+          switchTab(currentTab, e.currentTarget);
+        }
+      });
 
-  // Initially activate the first tab and reveal the first tab panel
-  tabs[0].removeAttribute('tabindex');
-  //tabs[0].setAttribute('aria-selected', 'true');
-  //panels[0].hidden = false;
+      // Handle keydown events for keyboard users
+      tab.addEventListener('keydown', function (e) {
+        // Get the index of the current tab in the tabs node list
+        var index = Array.prototype.indexOf.call(tabs, e.currentTarget);
+        // Work out which key the user is pressing and
+        // Calculate the new tab's index where appropriate
+        var dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
+        if (dir !== null) {
+          e.preventDefault();
+          // If the down key is pressed, move focus to the open panel,
+          // otherwise switch to the adjacent tab
+          dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
+        }
+      });
+    });
+
+    // Initially activate the first tab and reveal the first tab panel
+    tabs[0].removeAttribute('tabindex');
+  }
 }
 
 });

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -3,7 +3,19 @@
 // Place standard styling of app here
 // Press related overrides go in themes.scss
 ///////////////////////////////////////////
-
+///////////////////////////////////
+// UTILITY
+///////////////////////////////////
+.u-screenreader {
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+}
+.u-screenreader--ignore {
+  speak: none;
+}
 ///////////////////////////////////
 // COLORS
 ///////////////////////////////////

--- a/app/views/hyrax/file_sets/_attributes.html.erb
+++ b/app/views/hyrax/file_sets/_attributes.html.erb
@@ -1,52 +1,56 @@
-<ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active"><a href="#info" aria-controls="info" role="tab" data-toggle="tab">Info</a></li>
-  <li role="presentation"><a href="#permissions" aria-controls="permissions" role="tab" data-toggle="tab">Permissions</a></li>
-  <li id="stats-tab" role="presentation"><a href="#stats" aria-controls="stats-tab" role="tab" data-toggle="tab">Stats</a></li>
-  <% unless presenter.external_resource? %>
-  <li role="presentation"><a href="#technical-info" aria-controls="technical-info" role="tab" data-toggle="tab">Technical Info</a></li>
-  <% end %>
-</ul>
+<div id="tabs">
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a id="tab-info" href="#info" data-toggle="tab" role="tab" aria-controls="info" aria-selected="true" tabindex="0">Info</a></li>
+    <li role="presentation"><a id="tab-permissions" href="#permissions" data-toggle="tab" role="tab" aria-controls="permissions" aria-selected="false"   tabindex="-1">Permissions</a></li>
+    <li id="stats-tab" role="presentation"><a id="tab-stats" href="#stats" data-toggle="tab" role="tab" aria-controls="stats" aria-selected="false" tabindex="-1">Stats</a></li>
+    <% unless presenter.external_resource? %>
+    <li role="presentation"><a id="tab-technical-info" href="#technical-info" data-toggle="tab" role="tab" aria-controls="technical-info" aria-selected="false"   tabindex="-1">Technical Info</a></li>
+    <% end %>
+  </ul>
 
-<div class="tab-content">
-  <div role="tabpanel" class="tab-pane fade in active" id="info">
-    <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
-      <tbody>
-        <%= render 'attribute_rows_info', presenter: presenter %>
-        <tr>
-          <th><%= t('citable_link') %></th>
-          <td>
-            <form>
-              <label for="permalink" style="display: none;"><%= t('citable_link') %></label>
-              <input type="text" class="form-control" id="permalink" value="<%= presenter.citable_link %>" readonly="readonly" onclick="this.select(); document.execCommand('copy');" />
-            </form>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div> <!-- /.info panel -->
-  <div role="tabpanel" class="tab-pane fade" id="permissions">
-    <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
-      <tbody>
-        <%= render 'attribute_rows_permissions', presenter: presenter %>
-      </tbody>
-    </table>
-  </div> <!-- /.permissions panel -->
+  <div id="tabs-content" class="tab-content" aria-live="polite">
+    <section id="info" class="tab-pane fade in active" role="tabpanel" aria-hidden="false" aria-labelledby="tab-info" tabindex="0">
+      <h4 class="sr-only">Info</h4>
+      <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+        <tbody>
+          <%= render 'attribute_rows_info', presenter: presenter %>
+          <tr>
+            <th><%= t('citable_link') %></th>
+            <td>
+              <form>
+                <label id="citable_link" for="permalink" style="display: none;"><%= t('citable_link') %></label>
+                <input type="text" class="form-control" aria-labelledby="citable_link" id="permalink" value="<%= presenter.citable_link %>" readonly="readonly" onclick="this.select(); document.execCommand('copy');" />
+              </form>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section> <!-- /.info panel -->
+    <section id="permissions" class="tab-pane fade" role="tabpanel" aria-hidden="true" aria-labelledby="tab-permissions" tabindex="0">
+      <h4 class="sr-only">Permissions</h4>
+      <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+        <tbody>
+          <%= render 'attribute_rows_permissions', presenter: presenter %>
+        </tbody>
+      </table>
+    </section> <!-- /.permissions panel -->
 
-  <div role="tabpanel" class="tab-pane fade" id="stats">
-    <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
-      <tbody>
-        <%= render 'attribute_rows_stats', presenter: presenter %>
-      </tbody>
-    </table>
-  </div>  <!-- /.stats panel -->
+    <section id="stats" class="tab-pane fade" role="tabpanel" aria-hidden="true" aria-labelledby="tab-stats" tabindex="0">
+      <h4 class="sr-only">Stats</h4>
+      <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+        <tbody>
+          <%= render 'attribute_rows_stats', presenter: presenter %>
+        </tbody>
+      </table>
+    </section>  <!-- /.stats panel -->
 
-
-  <div role="tabpanel" class="tab-pane fade" id="technical-info">
-    <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
-      <tbody>
-       <%= render 'attribute_rows_technical', presenter: presenter %>
-      </tbody>
-    </table>
-   </div> <!-- /.technical-info panel -->
-
-</div> <!-- /.tab-content Tab panes -->
+    <section id="technical-info" class="tab-pane fade" role="tabpanel" aria-hidden="true" aria-labelledby="tab-technical-info" tabindex="0">
+      <h4 class="sr-only">Technical Info</h4>
+      <table class="table <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+        <tbody>
+         <%= render 'attribute_rows_technical', presenter: presenter %>
+        </tbody>
+      </table>
+    </section> <!-- /.technical-info panel -->
+  </div> <!-- /.tab-content Tab panes -->
+</div>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -57,71 +57,49 @@
       </tbody>
     </table>
 
-
   </div><!-- /.monograph-metadata -->
 </div><!-- /.monograph-info-epub -->
-<script>
-$(document).ready(function() {
-  // https://stackoverflow.com/a/10524697
-   var monograph_id = '<%= @monograph_presenter.id %>';
-   var previous_monograph_id = localStorage.getItem('monograph_id');
-   localStorage.setItem('monograph_id', monograph_id);
 
-   if (monograph_id !== previous_monograph_id) {
-     localStorage.removeItem('lastTab');
-   }
-
-  // for bootstrap 3 use 'shown.bs.tab', for bootstrap 2 use 'shown' in the next line
-  $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-    // save the latest tab; use cookies if you like 'em better:
-    localStorage.setItem('lastTab', $(this).attr('href'));
-  });
-
-  // go to the latest tab, if it exists:
-  var lastTab = localStorage.getItem('lastTab');
-  if (lastTab) {
-    $('[href="' + lastTab + '"]').tab('show');
-  }
-});
-</script>
 <div class="row monograph-assets-toc-epub">
-  <div class="col-sm-12">
+  <div class="col-sm-12" id="tabs">
     <ul class="nav nav-tabs" role="tablist">
       <% if @monograph_presenter.epub? %>
-        <li role="presentation" class="active"><a href="#toc" aria-controls="toc" role="tab" data-toggle="tab">Table of Contents</a></li>
+        <li role="presentation" class="active"><a id="tab-toc" role="tab" href="#toc" aria-controls="toc" aria-selected="true" data-toggle="tab" tabindex="0">Table of Contents</a></li>
       <% end %>
       <% if @monograph_presenter.assets? %>
         <% if @monograph_presenter.epub? %>
-          <li role="presentation"><a href="#media" aria-controls="media" role="tab" data-toggle="tab">Media</a></li>
+          <li role="presentation"><a id="tab-media" role="tab" href="#media" aria-controls="media" aria-selected="false" data-toggle="tab" tabindex="-1">Media</a></li>
         <% else %>
-          <li role="presentation" class="active"><a href="#media" aria-controls="media" role="tab" data-toggle="tab">Media</a></li>
+          <li role="presentation" class="active"><a id="tab-media" role="tab" href="#media" aria-controls="media" aria-selected="true" data-toggle="tab" tabindex="0">Media</a></li>
         <% end %>
       <% end %>
       <% if @monograph_presenter.webgl? %>
-        <li id="webgl-tab" role="presentation"><a href="#webgl" aria-controls="webgl" role="tab" data-toggle="tab">3-D Model</a></li>
+        <li role="presentation"><a id="tab-webgl" role="tab" href="#webgl" aria-controls="webgl" aria-selected="false" data-toggle="tab" tabindex="-1">3-D Model</a></li>
       <% end %>
       <% if @monograph_presenter.database? %>
-        <li role="presentation"><a href="<%= @monograph_presenter.database['ext_url_doi_or_handle_ssim'].first %>" aria-controls="database" role="tab" target="_blank">Database <span class="glyphicon glyphicon-share" aria-hidden="true"></span></a></li>
+        <li role="presentation"><a id="tab-database" role="tab" href="<%= @monograph_presenter.database['ext_url_doi_or_handle_ssim'].first %>" aria-controls="database" aria-selected="false" target="_blank" tabindex="-1">Database <span class="glyphicon glyphicon-share" aria-hidden="true" aria-label="Link to external database"></span></a></li>
       <% end %>
       <% if @monograph_presenter.aboutware? %>
-        <li role="presentation"><a href="#aboutware" aria-controls="aboutware" role="tab" data-toggle="tab">About</a></li>
+        <li role="presentation"><a id="tab-aboutware" role="tab" href="#aboutware" aria-controls="aboutware" aria-selected="false" data-toggle="tab" tabindex="-1">About</a></li>
       <% end %>
-      <li id="stats-tab" role="presentation"><a href="#stats" aria-controls="stats-tab" role="tab" data-toggle="tab">Stats</a></li>
+      <li role="presentation"><a id="tab-stats" role="tab" href="#stats" aria-controls="stats-tab" aria-selected="false" data-toggle="tab" tabindex="-1">Stats</a></li>
     </ul>
-    <div class="tab-content monograph-assets-toc-epub-content">
+    <div id="tabs-content" class="tab-content monograph-assets-toc-epub-content" aria-live="polite">
       <% if @monograph_presenter.epub? %>
-        <div role="tabpanel" class="tab-pane active toc row" id="toc">
+        <section id="toc" aria-hidden="false" aria-labelledby="tab-toc" class="tab-pane active toc row" tabindex="0">
           <div class="col-sm-12">
+            <h2 class="sr-only">Table of Contents</h2>
             <%= render 'index_epub_toc' %>
           </div>
-        </div>
+        </section>
       <% end %>
       <% if @monograph_presenter.assets? %>
         <% if @monograph_presenter.epub? %>
-          <div role="tabpanel" class="tab-pane media row" id="media">
+        <section id="media" aria-hidden="true" aria-labelledby="tab-media" class="tab-pane media row" tabindex="0">
         <% else %>
-          <div role="tabpanel" class="tab-pane active media row" id="media">
+        <section id="media" aria-hidden="false" aria-labelledby="tab-media" class="tab-pane active media row" tabindex="0">
         <% end %>
+          <h2 class="sr-only">Media</h2>
           <div class="col-sm-3 fulcrum_sidebar">
             <%= render 'catalog/search_sidebar' %>
           </div>
@@ -130,26 +108,29 @@ $(document).ready(function() {
               <%= render 'catalog/search_results' %>
             </div><!-- /.content -->
           </div>
-        </div>
+        </section>
       <% end %>
       <% if @monograph_presenter.webgl? %>
-        <div role="tabpanel" class="tab-pane webgl row" id="webgl">
+        <section id="webgl" aria-hidden="true" aria-labelledby="tab-webgl" class="tab-pane webgl row" tabindex="0">
           <div class="col-sm-12">
+            <h2 class="sr-only">3D Model</h2>
             <%= render 'webgls/tab' %>
           </div>
-        </div>
+        </section>
       <% end %>
       <% if @monograph_presenter.aboutware? %>
-        <div role="tabpanel" class="tab-pane aboutware row" id="aboutware">
+        <section id="aboutware" aria-hidden="true" aria-labelledby="tab-aboutware" class="tab-pane aboutware row" tabindex="0">
           <div class="col-sm-12">
+            <h2 class="sr-only">About</h2>
             <!-- this assumes that the "aboutware" FileSet is an html doc -->
             <%= @monograph_presenter.aboutware.file.content.force_encoding("UTF-8").html_safe %>
           </div>
-        </div>
+        </section>
       <% end %>
-      <div role="tabpanel" class="tab-pane stats row" id="stats">
+      <section id="stats" aria-hidden="true" aria-labelledby="tab-stats" class="tab-pane stats row" tabindex="0">
+        <h2 class="sr-only">Stats</h2>
         <%= render 'stats' %>
-      </div>
+      </section>
     </div>
   </div>
 </div><!-- /.monograph-assets-toc-epub -->

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -64,29 +64,29 @@
   <div class="col-sm-12" id="tabs">
     <ul class="nav nav-tabs" role="tablist">
       <% if @monograph_presenter.epub? %>
-        <li role="presentation" class="active"><a id="tab-toc" role="tab" href="#toc" aria-controls="toc" aria-selected="true" data-toggle="tab" tabindex="0">Table of Contents</a></li>
+        <li role="presentation" class="active"><a id="tab-toc" href="#toc" data-toggle="tab" role="tab" aria-controls="toc" aria-selected="true" tabindex="0">Table of Contents</a></li>
       <% end %>
       <% if @monograph_presenter.assets? %>
         <% if @monograph_presenter.epub? %>
-          <li role="presentation"><a id="tab-media" role="tab" href="#media" aria-controls="media" aria-selected="false" data-toggle="tab" tabindex="-1">Media</a></li>
+          <li role="presentation"><a id="tab-media" href="#media" role="tab" data-toggle="tab" aria-controls="media" aria-selected="false" tabindex="-1">Media</a></li>
         <% else %>
-          <li role="presentation" class="active"><a id="tab-media" role="tab" href="#media" aria-controls="media" aria-selected="true" data-toggle="tab" tabindex="0">Media</a></li>
+          <li role="presentation" class="active"><a id="tab-media" href="#media" data-toggle="tab" role="tab" aria-controls="media" aria-selected="true"  tabindex="0">Media</a></li>
         <% end %>
       <% end %>
       <% if @monograph_presenter.webgl? %>
-        <li role="presentation"><a id="tab-webgl" role="tab" href="#webgl" aria-controls="webgl" aria-selected="false" data-toggle="tab" tabindex="-1">3-D Model</a></li>
+        <li role="presentation"><a id="tab-webgl" href="#webgl" role="tab" data-toggle="tab" aria-controls="webgl" aria-selected="false" tabindex="-1">3-D Model</a></li>
       <% end %>
       <% if @monograph_presenter.database? %>
-        <li role="presentation"><a id="tab-database" role="tab" href="<%= @monograph_presenter.database['ext_url_doi_or_handle_ssim'].first %>" aria-controls="database" aria-selected="false" target="_blank" tabindex="-1">Database <span class="glyphicon glyphicon-share" aria-hidden="true" aria-label="Link to external database"></span></a></li>
+        <li role="presentation"><a id="tab-database" href="<%= @monograph_presenter.database['ext_url_doi_or_handle_ssim'].first %>" target="_blank" role="tab" aria-controls="database" aria-selected="false" tabindex="-1">Database <span class="glyphicon glyphicon-share" aria-hidden="true" aria-label="Link to external database"></span></a></li>
       <% end %>
       <% if @monograph_presenter.aboutware? %>
-        <li role="presentation"><a id="tab-aboutware" role="tab" href="#aboutware" aria-controls="aboutware" aria-selected="false" data-toggle="tab" tabindex="-1">About</a></li>
+        <li role="presentation"><a id="tab-aboutware" href="#aboutware" role="tab" data-toggle="tab" aria-controls="aboutware" aria-selected="false" tabindex="-1">About</a></li>
       <% end %>
-      <li role="presentation"><a id="tab-stats" role="tab" href="#stats" aria-controls="stats-tab" aria-selected="false" data-toggle="tab" tabindex="-1">Stats</a></li>
+      <li role="presentation"><a id="tab-stats" href="#stats" role="tab" data-toggle="tab" aria-controls="stats" aria-selected="false" tabindex="-1">Stats</a></li>
     </ul>
     <div id="tabs-content" class="tab-content monograph-assets-toc-epub-content" aria-live="polite">
       <% if @monograph_presenter.epub? %>
-        <section id="toc" aria-hidden="false" aria-labelledby="tab-toc" class="tab-pane active toc row" tabindex="0">
+        <section id="toc" class="tab-pane active fade in toc row" role="tabpanel" aria-hidden="false" aria-labelledby="tab-toc" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Table of Contents</h2>
             <%= render 'index_epub_toc' %>
@@ -95,9 +95,9 @@
       <% end %>
       <% if @monograph_presenter.assets? %>
         <% if @monograph_presenter.epub? %>
-        <section id="media" aria-hidden="true" aria-labelledby="tab-media" class="tab-pane media row" tabindex="0">
+        <section id="media" class="tab-pane fade in media row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-media" tabindex="0">
         <% else %>
-        <section id="media" aria-hidden="false" aria-labelledby="tab-media" class="tab-pane active media row" tabindex="0">
+        <section id="media" class="tab-pane fade in active media row" role="tabpanel" aria-hidden="false" aria-labelledby="tab-media" tabindex="0">
         <% end %>
           <h2 class="sr-only">Media</h2>
           <div class="col-sm-3 fulcrum_sidebar">
@@ -111,7 +111,7 @@
         </section>
       <% end %>
       <% if @monograph_presenter.webgl? %>
-        <section id="webgl" aria-hidden="true" aria-labelledby="tab-webgl" class="tab-pane webgl row" tabindex="0">
+        <section id="webgl" class="tab-pane fade in webgl row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-webgl" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">3D Model</h2>
             <%= render 'webgls/tab' %>
@@ -119,7 +119,7 @@
         </section>
       <% end %>
       <% if @monograph_presenter.aboutware? %>
-        <section id="aboutware" aria-hidden="true" aria-labelledby="tab-aboutware" class="tab-pane aboutware row" tabindex="0">
+        <section id="aboutware" class="tab-pane fade in aboutware row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-aboutware" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">About</h2>
             <!-- this assumes that the "aboutware" FileSet is an html doc -->
@@ -127,7 +127,7 @@
           </div>
         </section>
       <% end %>
-      <section id="stats" aria-hidden="true" aria-labelledby="tab-stats" class="tab-pane stats row" tabindex="0">
+      <section id="stats" class="tab-pane fade in stats row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-stats" tabindex="0">
         <h2 class="sr-only">Stats</h2>
         <%= render 'stats' %>
       </section>


### PR DESCRIPTION
Resolves #1753 

Corrects ARIA semantics to correctly announce tabs and tab panel activation; Toggles ARIA semantics on tab switching; captures keydown events to allow for navigation between tabs; sets focus to tab panel upon selecting a tab; adds headings to tab panels to ensure tab panels are discovered in document outline; Moves inline JS to tab.js to be included in asset pipeline.