### PR TITLE
Use the unpacked derivatives for epubs and webgls if they exist, othe…

### DIFF
--- a/app/presenters/concerns/featured_representatives/monograph_presenter.rb
+++ b/app/presenters/concerns/featured_representatives/monograph_presenter.rb
@@ -22,7 +22,12 @@ module FeaturedRepresentatives
     end
 
     def epub_presenter
-      FactoryService.e_pub_publication(epub_id).presenter
+      epub = if Dir.exist?(UnpackService.root_path_from_noid(epub_id, 'epub'))
+               EPub::Publication.from_directory(UnpackService.root_path_from_noid(epub_id, 'epub'))
+             else
+               FactoryService.e_pub_publication(epub_id)
+             end
+      epub.presenter
     end
 
     def webgl?

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -6,7 +6,11 @@
     <%
 # load what we need to show the webgl/3-d model if needed
 webgl_id = @monograph_presenter.webgl_id
-webgl = FactoryService.webgl_unity(webgl_id)
+webgl = if Dir.exist?(UnpackService.root_path_from_noid(webgl_id, 'webgl'))
+          Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 'webgl'))
+        else
+          FactoryService.webgl_unity(webgl_id)
+        end
 @unity_loader = "/webgl/#{webgl_id}/#{webgl.unity_loader}"
 @unity_json = "/webgl/#{webgl_id}/#{webgl.unity_json}"
     %>

--- a/app/views/webgls/_tab.html.erb
+++ b/app/views/webgls/_tab.html.erb
@@ -2,7 +2,11 @@
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end
 webgl_id = @monograph_presenter.webgl_id
-webgl = FactoryService.webgl_unity(webgl_id)
+webgl = if Dir.exist?(UnpackService.root_path_from_noid(webgl_id, 'webgl'))
+          Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 'webgl'))
+        else
+          FactoryService.webgl_unity(webgl_id)
+        end
 @unity_loader = "/webgl/#{webgl_id}/#{webgl.unity_loader}"
 @unity_json = "/webgl/#{webgl_id}/#{webgl.unity_json}"
 %>

--- a/lib/e_pub/toc.rb
+++ b/lib/e_pub/toc.rb
@@ -31,7 +31,7 @@ module EPub
         title = @doc.xpath("//nav[@type='toc']/ol/li/a[@href='#{upone_href}']").text
       end
 
-      ::EPub.logger.error("Can't find chapter title for #{chapter_href}") if title.blank?
+      ::EPub.logger.info("Can't find chapter title for #{chapter_href}") if title.blank?
       title
     end
   end

--- a/lib/spec/e_pub/toc_spec.rb
+++ b/lib/spec/e_pub/toc_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe EPub::Toc do
     context "no match" do
       let(:none) { Nokogiri::XML('<item id="x" href="notevenclose.xhtml"> ') }
       it do
-        allow(EPub.logger).to receive(:error).and_return(nil)
+        allow(EPub.logger).to receive(:info).and_return(nil)
         expect(subject.chapter_title(none.children[0])).to eq ''
       end
     end

--- a/lib/spec/e_pub/validator_spec.rb
+++ b/lib/spec/e_pub/validator_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe EPub::Validator do
     subject { described_class.from(@id) }
     it "is a ValidatorNullObject" do
       is_expected.to be_an_instance_of(EPub::ValidatorNullObject)
+      expect(subject.id).to eq 'null_epub'
+      expect(subject.container).to be_an_instance_of(Nokogiri::XML::Document)
+      expect(subject.content_file).to be "empty"
+      expect(subject.content).to be_an_instance_of(Nokogiri::XML::Document)
+      expect(subject.toc).to be_an_instance_of(Nokogiri::XML::Document)
+      expect(subject.root_path).to be nil
     end
   end
 end

--- a/lib/spec/webgl/unity_spec.rb
+++ b/lib/spec/webgl/unity_spec.rb
@@ -42,4 +42,59 @@ RSpec.describe Webgl::Unity do
       expect(subject).to eq "./tmp/webgl/validnoid/Build/thing.asm.memory.unityweb"
     end
   end
+
+  context "using #from_directory with root_path" do
+    before do
+      @noid = 'validnoid'
+      @root_path = UnpackHelper.noid_to_root_path(@noid, 'webgl')
+      @file = './spec/fixtures/fake-game.zip'
+      UnpackHelper.unpack_webgl(@noid, @root_path, @file)
+      allow(Webgl.logger).to receive(:info).and_return(nil)
+    end
+
+    after do
+      FileUtils.rm_rf(Dir[File.join('./tmp', 'rspec_derivatives')])
+    end
+
+    describe "with a valid noid and unity file" do
+      subject { described_class.from_directory(@root_path) }
+
+      it "has the correct attributes" do
+        expect(subject).to be_an_instance_of(described_class)
+        expect(subject.id).to eq 'validnoid'
+        expect(subject.unity_progress).to eq 'TemplateData/UnityProgress.js'
+        expect(subject.unity_loader).to eq 'Build/UnityLoader.js'
+        expect(subject.unity_json).to eq 'Build/fake.json'
+        expect(subject.root_path).to eq @root_path
+      end
+    end
+
+    describe "with an invalid noid" do
+      subject { described_class.from_directory("/not/a/real/path") }
+      it "is a UnityNullObject" do
+        expect(subject).to be_an_instance_of(Webgl::UnityNullObject)
+        expect(subject.id).to eq nil
+        expect(subject.unity_progress).to eq nil
+        expect(subject.unity_loader).to eq nil
+        expect(subject.unity_json).to eq nil
+        expect(subject.root_path).to eq nil
+      end
+    end
+
+    describe "#read" do
+      subject { described_class.from_directory(@root_path).read(js_file) }
+      let(:js_file) { "Build/thing.asm.memory.unityweb" }
+      it "returns the file contents" do
+        expect(subject).to eq "\u001F\x8B\b\bT\xAB\xA2Z\u0000\u0003thing.asm.memory.unityweb\u0000+K,R(\xC9\xC8\xCCK/V\xB0UP\x82\xB0\x94\xAC\xB9\u0000\xD4\xDB\xCD\xFC\u0017\u0000\u0000\u0000"
+      end
+    end
+
+    describe "#file" do
+      subject { described_class.from_directory(@root_path).file(js_file) }
+      let(:js_file) { "Build/thing.asm.memory.unityweb" }
+      it "returns the file path" do
+        expect(subject).to eq "./tmp/rspec_derivatives/va/li/dn/oi/d-webgl/Build/thing.asm.memory.unityweb"
+      end
+    end
+  end
 end

--- a/lib/spec/webgl/unity_validator_spec.rb
+++ b/lib/spec/webgl/unity_validator_spec.rb
@@ -1,25 +1,104 @@
 # frozen_string_literal: true
 
 RSpec.describe Webgl::UnityValidator do
-  describe "with a valid webgl" do
-    before do
-      @id = 'validnoid'
-      @file = './spec/fixtures/fake-game.zip'
-      Webgl::Unity.from(id: @id, file: @file)
+  describe "with the #from initializer" do
+    context "and a valid webgl" do
+      before do
+        @id = 'validnoid'
+        @file = './spec/fixtures/fake-game.zip'
+        Webgl::Unity.from(id: @id, file: @file)
+      end
+
+      after do
+        Webgl::Unity.from(id: @id, file: @file).purge
+      end
+
+      subject { described_class.from(@id) }
+
+      it "has the correct attributes" do
+        expect(subject).to be_an_instance_of(described_class)
+        expect(subject.id).to eq 'validnoid'
+        expect(subject.progress).to eq 'TemplateData/UnityProgress.js'
+        expect(subject.loader).to eq 'Build/UnityLoader.js'
+        expect(subject.json).to eq 'Build/fake.json'
+      end
+    end
+  end
+
+  describe "with the #from_directory initializer" do
+    context "and a valid webgl" do
+      before do
+        @noid = 'validnoid'
+        @root_path = UnpackHelper.noid_to_root_path(@noid, 'webgl')
+        @file = './spec/fixtures/fake-game.zip'
+        UnpackHelper.unpack_webgl(@noid, @root_path, @file)
+        allow(Webgl.logger).to receive(:info).and_return(nil)
+      end
+
+      after do
+        FileUtils.rm_rf('./tmp/rspec_derivatives')
+      end
+
+      subject { described_class.from_directory(@root_path) }
+
+      it "has the correct attributes" do
+        expect(subject).to be_an_instance_of(described_class)
+        expect(subject.id).to eq 'validnoid'
+        expect(subject.progress).to eq 'TemplateData/UnityProgress.js'
+        expect(subject.loader).to eq 'Build/UnityLoader.js'
+        expect(subject.json).to eq 'Build/fake.json'
+      end
+
+      context "with a missing UnityProgress.js" do
+        it "returns the null object" do
+          allow(File).to receive(:join).and_call_original
+          allow(File).to receive(:join).with(@root_path, "TemplateData", "UnityProgress.js").and_return(nil)
+          allow(Webgl.logger).to receive(:info).and_return(nil)
+
+          expect(subject).to be_an_instance_of(Webgl::UnityValidatorNullObject)
+        end
+      end
+
+      context "with a missing UnityLoader.js" do
+        it "returns the null object" do
+          allow(File).to receive(:join).and_call_original
+          allow(File).to receive(:join).with(@root_path, "Build", "UnityLoader.js").and_return(nil)
+          allow(Webgl.logger).to receive(:info).and_return(nil)
+
+          expect(subject).to be_an_instance_of(Webgl::UnityValidatorNullObject)
+        end
+      end
+
+      context "with a missing unity json file" do
+        it "returns the null object" do
+          allow(Find).to receive(:find).and_return(nil)
+          allow(Webgl.logger).to receive(:info).and_return(nil)
+
+          expect(subject).to be_an_instance_of(Webgl::UnityValidatorNullObject)
+        end
+      end
     end
 
-    after do
-      Webgl::Unity.from(id: @id, file: @file).purge
+    context "with an invalid webgl" do
+      subject { described_class.from_directory('/not/a/real/path') }
+
+      it "is a null object" do
+        expect(subject).to be_an_instance_of(Webgl::UnityValidatorNullObject)
+      end
     end
+  end
 
-    subject { described_class.from(@id) }
-
-    it "has the correct attributes" do
-      expect(subject).to be_an_instance_of(described_class)
-      expect(subject.id).to eq 'validnoid'
-      expect(subject.progress).to eq 'TemplateData/UnityProgress.js'
-      expect(subject.loader).to eq 'Build/UnityLoader.js'
-      expect(subject.json).to eq 'Build/fake.json'
+  describe "#null_object" do
+    subject { described_class.null_object }
+    it "is a null object" do
+      expect(subject).to be_an_instance_of(Webgl::UnityValidatorNullObject)
+      # The fact that these all default to nil sort of defeats the purpose of
+      # a null object. TODO: if this becomes a problem, give these default values
+      expect(subject.id).to be nil
+      expect(subject.progress).to be nil
+      expect(subject.loader).to be nil
+      expect(subject.json).to be nil
+      expect(subject.root_path).to be nil
     end
   end
 end

--- a/lib/tasks/unpack_assets.rake
+++ b/lib/tasks/unpack_assets.rake
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
-desc 'Unpack EPUB and WEBGL assets'
+desc 'Unpack EPUB and WEBGL assets (initial migration to unpacked from cached, see #1692)'
 namespace :heliotrope do
   task unpack_assets: :environment do
     FeaturedRepresentative.where(kind: 'epub').or(FeaturedRepresentative.where(kind: 'webgl')).each do |fr|
       puts "Unpacking #{fr.kind} #{fr.file_set_id}"
       UnpackJob.perform_later(fr.file_set_id, fr.kind)
+    end
+  end
+
+  task remove_unpacked_assets: :environment do
+    # This is just for testing and will be removed later
+    FeaturedRepresentative.where(kind: 'epub').or(FeaturedRepresentative.where(kind: 'webgl')).each do |fr|
+      root_path = UnpackService.root_path_from_noid(fr.file_set_id, fr.kind)
+      if Dir.exist? root_path
+        puts "Removing #{root_path}"
+        FileUtils.remove_entry_secure(root_path)
+      end
     end
   end
 end

--- a/lib/webgl/unity.rb
+++ b/lib/webgl/unity.rb
@@ -3,7 +3,7 @@
 module Webgl
   class Unity
     private_class_method :new
-    attr_accessor :id, :unity_progress, :unity_loader, :unity_json
+    attr_accessor :id, :unity_progress, :unity_loader, :unity_json, :root_path
 
     def self.clear_cache
       Cache.clear
@@ -24,6 +24,18 @@ module Webgl
       new(valid_webgl)
     end
 
+    def self.from_directory(root_path)
+      ::Webgl.logger.info("Opening Webgl from directory #{root_path}")
+      return null_object unless Dir.exist? root_path
+      valid_webgl = UnityValidator.from_directory(root_path)
+      return null_object if valid_webgl.is_a?(UnityValidatorNullObject)
+
+      new(valid_webgl)
+    rescue StandardError => e
+      ::Webgl.logger.info("Unity.from_directory(#{root_path}) raised #{e} #{e.backtrace}")
+      null_object
+    end
+
     def self.null_object
       UnityNullObject.send(:new)
     end
@@ -33,15 +45,23 @@ module Webgl
     end
 
     def file(file_entry)
-      return Unity.null_object.file(file_entry) unless Cache.cached?(id)
-      file = ::Webgl.path_entry(id, file_entry)
+      if @root_path.present?
+        file = File.join(root_path, file_entry)
+      else
+        return Unity.null_object.file(file_entry) unless Cache.cached?(id)
+        file = ::Webgl.path_entry(id, file_entry)
+      end
       return Unity.null_object.file(file) unless File.exist?(file)
       file
     end
 
     def read(file_entry)
-      return Unity.null_object.read(file_entry) unless Cache.cached?(id)
-      file = ::Webgl.path_entry(id, file_entry)
+      if @root_path.present?
+        file = File.join(root_path, file_entry)
+      else
+        return Unity.null_object.read(file_entry) unless Cache.cached?(id)
+        file = ::Webgl.path_entry(id, file_entry)
+      end
       return Unity.null_object.read(file) unless File.exist?(file)
       File.read(file)
     end
@@ -53,12 +73,13 @@ module Webgl
         @unity_progress = webgl.progress
         @unity_loader = webgl.loader
         @unity_json = webgl.json
+        @root_path = webgl.root_path
       end
   end
 
   class UnityNullObject
     private_class_method :new
-    attr_accessor :id, :unity_progress, :unity_loader, :unity_json
+    attr_accessor :id, :unity_progress, :unity_loader, :unity_json, :root_path
 
     def read(_file_entry)
       ''
@@ -75,6 +96,7 @@ module Webgl
         @unity_progress = nil
         @unity_loader = nil
         @unity_json = nil
+        @root_path = nil
       end
   end
 end

--- a/lib/webgl/unity_validator.rb
+++ b/lib/webgl/unity_validator.rb
@@ -4,7 +4,7 @@ require 'find'
 
 module Webgl
   class UnityValidator
-    attr_reader :id, :progress, :loader, :json
+    attr_reader :id, :progress, :loader, :json, :root_path
 
     def self.from(id)
       if File.join(Webgl.path(id), "TemplateData", "UnityProgress.js").blank?
@@ -29,8 +29,38 @@ module Webgl
           json: File.join("Build", File.basename(json_file)))
     end
 
+    def self.from_directory(root_path)
+      return null_object unless Dir.exist? root_path
+
+      if File.join(root_path, "TemplateData", "UnityProgress.js").blank?
+        ::Webgl.logger.info("#{root_path} is missing UnityProgress.js")
+        return null_object
+      end
+
+      if File.join(root_path, "Build", "UnityLoader.js").blank?
+        ::Webgl.logger.info("#{root_path} is missing UnityLoader.js")
+        return null_object
+      end
+
+      json_file = Find.find(File.join(root_path, "Build"))&.map { |f| f if File.extname(f) == ".json" }&.compact&.first
+      if json_file.blank?
+        ::Webgl.logger.info("#{root_path} is missing Unity .json file")
+        return null_object
+      end
+
+      new(id: root_path_to_noid(root_path),
+          progress: File.join("TemplateData", "UnityProgress.js"),
+          loader: File.join("Build", "UnityLoader.js"),
+          json: File.join("Build", File.basename(json_file)),
+          root_path: root_path)
+    end
+
     def self.null_object
       UnityValidatorNullObject.new
+    end
+
+    def self.root_path_to_noid(root_path)
+      root_path.gsub(/-webgl/, '').split('/').slice(-5, 5).join('')
     end
 
     private
@@ -40,16 +70,18 @@ module Webgl
         @progress = opts[:progress]
         @loader   = opts[:loader]
         @json     = opts[:json]
+        @root_path = opts[:root_path]
       end
   end
 
   class UnityValidatorNullObject
-    attr_reader :id, :progress, :loader, :json
+    attr_reader :id, :progress, :loader, :json, :root_path
     def initialize
       @id = nil
       @progress = nil
       @loader = nil
       @json = nil
+      @root_path = nil
     end
   end
 end


### PR DESCRIPTION
…rwise fall back to the "cached" versions.

This is a temporary step towards removing the "cache" completely.

The intention is have both "unpack" and "cache" code paths released into production. The "unpack" code path is triggered if there's an epub or webgl derivative path (an upacked asset in `./tmp/derivatives`). All epubs and webgl derivatives can be created with the `rake heliotrope:unpack_assets` rake task which kicks off UnpackJobs. 

This is currently deployed on both __staging__ and __testing__

Then we'll work on removing the "cache" code from the code base for the next production release.

See #1692 
