### PR TITLE
Part One #1812: Metadata Download/Upload/Update Cycle

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class ManifestsController < ApplicationController
+  before_action :redirect_cancel, only: %i[create update]
+
+  def create
+    csv = manifest_params[:csv] if params[:manifest].present?
+    @manifest = Manifest.new(params[:id], csv)
+    if csv.present?
+      notice = "Error" unless @manifest.create(current_user)
+      redirect_to monograph_manifests_path, notice: notice
+    else
+      flash[:notice] = "No file chosen"
+      render :new
+    end
+  end
+
+  def destroy
+    @manifest = Manifest.new(params[:id])
+    @manifest.destroy(current_user)
+    redirect_to monograph_manifests_path
+  end
+
+  def edit
+    @manifest = Manifest.new(params[:id])
+    render
+  end
+
+  def new
+    @manifest = Manifest.new(params[:id])
+    render
+  end
+
+  def update
+    csv = manifest_params[:csv] if params[:manifest].present?
+    @manifest = Manifest.new(params[:id], csv)
+    if csv.present?
+      notice = "Error" unless @manifest.create(current_user)
+      redirect_to monograph_manifests_path, notice: notice
+    else
+      flash[:notice] = "No file chosen"
+      render :edit
+    end
+  end
+
+  private
+
+    def manifest_params
+      params.require(:manifest).permit(:csv)
+    end
+
+    def redirect_cancel
+      redirect_to main_app.monograph_manifests_path(params[:id]) if params[:cancel]
+    end
+end

--- a/app/controllers/monograph_manifests_controller.rb
+++ b/app/controllers/monograph_manifests_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MonographManifestsController < ApplicationController
+  before_action :redirect_cancel, only: [:import]
+
+  def export
+    exporter = Export::Exporter.new(params[:id])
+    send_data exporter.export.force_encoding("utf-8"), filename: "#{params[:id]}.csv"
+  end
+
+  def import
+    @monograph_manifest = MonographManifest.new(params[:id])
+    if @monograph_manifest.explicit.persisted?
+      notice = "TODO: Import"
+      Manifest.new(params[:id]).destroy(current_user)
+    else
+      notice = t('monograph_manifests.import.no_manifest')
+    end
+    redirect_to main_app.monograph_manifests_path, notice: notice
+  end
+
+  def preview
+    @monograph_manifest = MonographManifest.new(params[:id])
+    if @monograph_manifest.explicit.persisted?
+      @presenter = MonographManifestPresenter.new(current_user, @monograph_manifest)
+    else
+      notice = t('monograph_manifests.import.no_manifest')
+      redirect_to main_app.monograph_manifests_path, notice: notice
+    end
+  end
+
+  def show
+    @presenter = MonographManifestPresenter.new(current_user, MonographManifest.new(params[:id]))
+  end
+
+  private
+
+    def monograph_manifest_params
+      params.require(:monograph_manifest).permit
+    end
+
+    def redirect_cancel
+      redirect_to main_app.monograph_manifests_path(params[:id]) if params[:cancel]
+    end
+end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_dependency 'export'
+require_dependency 'import'
+
+# WARNING! DO NOT USE OUT OF CONTEXT!!!
+#
+# Specialized implementation model to be used only by MonographManifest model.
+#
+# Class factory methods:
+#   from_monograph - manifest of monograph stored in Fedora
+#   from_monograph_manifest - manifest of monograph stored on filesystem (a.k.a. Carrierwave)
+#
+# Instance methods:
+#   create - upload csv file using Carrierwave
+#   destroy - rm csv file
+#   filename - csv filename with extension if csv file exists?
+#   persisted? - csv file exists?
+#   == - returns CSV self.table_rows == other.table_rows
+#
+# NOTE: #create is dependent on Carrierwave and was not tested.
+#
+# WARNING! DO NOT USE OUT OF CONTEXT!!!
+class Manifest
+  include ActiveModel::Model
+  extend CarrierWave::Mount
+
+  attr_reader :monograph_id
+  alias_attribute :id, :monograph_id
+
+  attr_accessor :csv
+  # attr_accessor :csv, :remote_csv_url
+  mount_uploader :csv, ManifestUploader # Tells rails to use this uploader for this model.
+
+  # validates_presence_of :csv
+
+  # extend CarrierWave::Validations::ActiveModel::HelperMethods
+  # validates_integrity_of :csv
+  # validates_processing_of :csv
+
+  # en:
+  #   errors:
+  #     messages:
+  #       carrierwave_processing_error: failed to be processed
+  #       carrierwave_integrity_error: is not an allowed file type
+
+  attr_reader :table_headers
+  attr_accessor :table_rows
+
+  def initialize(monograph_id, csv = nil)
+    @monograph_id = monograph_id
+    @csv = csv
+    @table_headers = []
+    @table_rows = []
+  end
+
+  def self.from_monograph(monograph_id)
+    manifest = new(monograph_id)
+    monograph = Monograph.find(monograph_id) if monograph_id.present?
+    return manifest if monograph.blank?
+    exporter = Export::Exporter.new(monograph_id)
+    attributes = Import::CSVParser.new(nil).attributes(exporter.export)
+    metadata = attributes.deep_dup
+    metadata.delete('files')
+    metadata.delete('files_metadata')
+    metadata.delete('row_errors')
+    manifest.table_rows << [metadata['id'], '://:MONOGRAPH://:', attributes['title']&.first, metadata]
+    files = attributes['files']
+    files_metadata = attributes['files_metadata']
+    files.each.with_index do |file, index|
+      manifest.table_rows << [files_metadata[index]['id'], file, files_metadata[index]['title']&.first, files_metadata[index]]
+    end
+    manifest
+  end
+
+  def self.from_monograph_manifest(monograph_id)
+    manifest = new(monograph_id)
+    monograph = Monograph.find(monograph_id) if monograph_id.present?
+    return manifest if monograph.blank?
+    return manifest unless manifest.persisted?
+    importer = Import::CSVParser.new(File.join(manifest.path, manifest.filename))
+    attributes = importer.attributes
+    metadata = attributes.deep_dup
+    metadata.delete('files')
+    metadata.delete('files_metadata')
+    metadata.delete('row_errors')
+    manifest.table_rows << [metadata['id'], '://:MONOGRAPH://:', attributes['title']&.first, metadata]
+    files = attributes['files']
+    files_metadata = attributes['files_metadata']
+    files.each.with_index do |file, index|
+      manifest.table_rows << [files_metadata[index]['id'], file, files_metadata[index]['title']&.first, files_metadata[index]]
+    end
+    manifest
+  end
+
+  def create(current_user)
+    return false unless Valid.noid?(@monograph_id)
+    return false if @csv.blank?
+    destroy(current_user)
+    csv.cache!(content_type: @csv.content_type, filename: @csv.original_filename, tempfile: @csv.tempfile)
+    store_csv!
+    FileUtils.rm_rf(csv.cache_dir.to_s) if Dir.exist?(csv.cache_dir.to_s)
+    true
+  end
+
+  def destroy(_current_user)
+    FileUtils.rm_rf(path) if Dir.exist?(path)
+  end
+
+  def persisted?
+    filename.present?
+  end
+
+  def path
+    csv.store_dir.to_s
+  end
+
+  def filename
+    return nil unless Dir.exist?(path)
+    Dir.entries(path).drop(2).first
+  end
+
+  def ==(other)
+    table_rows == other.table_rows
+  end
+end

--- a/app/models/monograph_manifest.rb
+++ b/app/models/monograph_manifest.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Monograph Manifest model backed by Manifest model.
+#
+# Instance Methods
+#   implicit - manifest of monograph stored in Fedora
+#   explicit - manifest of monograph stored on filesystem (a.k.a. csv)
+#
+class MonographManifest
+  include ActiveModel::Model
+
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+
+  def implicit
+    @implicit ||= Manifest.from_monograph(id)
+  end
+
+  def explicit
+    @explicit ||= Manifest.from_monograph_manifest(id)
+  end
+
+  def persisted?
+    true
+  end
+end

--- a/app/presenters/manifest_presenter.rb
+++ b/app/presenters/manifest_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ManifestPresenter < ApplicationPresenter
+  attr_reader :current_user
+
+  def initialize(current_user, manifest)
+    super(current_user)
+    @manifest = manifest
+  end
+  delegate :monograph_id, :id, :table_headers, :table_rows, :persisted?, :filename, to: :@manifest
+end

--- a/app/presenters/monograph_manifest_presenter.rb
+++ b/app/presenters/monograph_manifest_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MonographManifestPresenter < ApplicationPresenter
+  attr_reader :current_user
+
+  def initialize(current_user, monograph_manifest)
+    super(current_user)
+    @monograph_manifest = monograph_manifest
+  end
+
+  delegate :id, to: :@monograph_manifest
+
+  def explicit
+    @explicit ||= ManifestPresenter.new(current_user, @monograph_manifest.explicit)
+  end
+
+  def implicit
+    @implicit ||= ManifestPresenter.new(current_user, @monograph_manifest.implicit)
+  end
+
+  def equivalent?
+    @monograph_manifest.implicit == @monograph_manifest.explicit
+  end
+end

--- a/app/uploaders/manifest_uploader.rb
+++ b/app/uploaders/manifest_uploader.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ManifestUploader < CarrierWave::Uploader::Base
+  storage :file
+
+  def store_dir
+    Rails.root.join("tmp", "uploads", model.class.to_s.underscore, model.id)
+  end
+
+  def cache_dir
+    Rails.root.join("tmp", "uploads", "cache", model.class.to_s.underscore, model.id)
+  end
+
+  # def default_url
+  #   "manifest.csv"
+  # end
+
+  def extension_whitelist
+    %w[csv]
+  end
+
+  def content_type_whitelist
+    %w[text/csv text/comma-separated-values]
+  end
+
+  # def manifest(arg)
+  #   # processing
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :manifest do
+  #   process :validate => true
+  # end
+
+  # def filename
+  #   @original_filename
+  # end
+end

--- a/app/views/manifests/_form.html.erb
+++ b/app/views/manifests/_form.html.erb
@@ -1,0 +1,31 @@
+<div class="row">
+  <hr>
+</div>
+<% unless @manifest.errors.empty? %>
+  <div class="row alert alert-error">
+    <ul>
+    <% @manifest.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<div class="row">
+  <%= form_for @manifest, url: monograph_manifests_path do |f| %>
+    <div class="row">
+      <div class="col-md-2"><%= f.label t('manifest.form.csv') %></div>
+      <div class="col-md-10"><%= f.file_field :csv %></div>
+    </div>
+    <div class="row">
+      <hr>
+    </div>
+    <div class="row">
+      <div class="col-md-2"></div>
+      <div class="col-md-2"><%= f.submit t('manifest.form.cancel'), name: :cancel, class: "btn btn-primary" %></div>
+      <div class="col-md-8"><%= f.submit t('manifest.form.save'), class: "btn btn-primary" %></div>
+    </div>
+  <% end %>
+</div>
+<div class="row">
+  <hr>
+</div>

--- a/app/views/manifests/edit.html.erb
+++ b/app/views/manifests/edit.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <div class="col-md-12">
+    <div class="row"><h1><%= t('manifest.new.h1') %></h1></div>
+    <div class="row"><%= render 'form' %></div>
+  </div>
+</div>

--- a/app/views/manifests/new.html.erb
+++ b/app/views/manifests/new.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <div class="col-md-12">
+    <div class="row"><h1><%= t('manifest.new.h1') %></h1></div>
+    <div class="row"><%= render 'form' %></div>
+  </div>
+</div>

--- a/app/views/monograph_manifests/preview.html.erb
+++ b/app/views/monograph_manifests/preview.html.erb
@@ -1,0 +1,72 @@
+<div class="container">
+  <div class="col-md-12">
+    <div class="row">
+      <div class="row"><h1><%= t('monograph_manifests.preview.h1') %></h1></div>
+      <div class="row">
+        <div class="col-md-5">
+          <div class="row"><hr/></div>
+          <div class="row"><h2><%= t('monograph_manifests.preview.h2.monograph', noid: @presenter.id) %></h2></div>
+          <div class="row"><hr/></div>
+        </div>
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+          <div class="row"><hr/></div>
+          <div class="row"><h2><%= t('monograph_manifests.preview.h2.manifest', filename: @presenter.explicit.filename) %></h2></div>
+          <div class="row"><hr/></div>
+        </div>
+        <div class="col-md-1"></div>
+      </div>
+      <div class="row">
+        <%= form_for @monograph_manifest, url: import_monograph_manifests_path do |f| %>
+          <div class="col-md-6">&nbsp;</div>
+          <div class="col-md-2"><%= f.submit t('monograph_manifests.preview.cancel'), name: :cancel, class: "btn btn-primary" %></div>
+          <div class="col-md-4"><%= f.submit t('monograph_manifests.preview.import'), name: :import, class: "btn btn-primary", disabled: @presenter.equivalent? %></div>
+        <% end %>
+      </div>
+    </div>
+    <%
+    i = @presenter.implicit.table_rows.count
+    m = @presenter.explicit.table_rows.count
+    n = i > m ? i : m
+    (0..n-1).each do |row|
+      implicit_row = @presenter.implicit.table_rows[row] if row < i
+      explicit_row = @presenter.explicit.table_rows[row] if row < m
+    %>
+      <div class="row">
+        <div class="col-md-5">
+          <div class="row">
+            <% if row < i %>
+              <div class="row"><hr/></div>
+              <div class="row"><%= implicit_row[1] %></div>
+              <div class="row"><hr/></div>
+              <% implicit_row[3].each do |pair| %>
+                <div class="row">
+                  <div class="col-md-4"><%= pair[0] %></div>
+                  <div class="col-md-8"><%= pair[1] %></div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+          <div class="row">
+            <% if row < m %>
+              <div class="row"><hr/></div>
+              <div class="row"><%= explicit_row[1] %></div>
+              <div class="row"><hr/></div>
+              <% explicit_row[3].each do |pair| %>
+                <div class="row">
+                  <div class="col-md-4"><%= pair[0] %></div>
+                  <div class="col-md-8"><%= pair[1] %></div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-1"></div>
+      </div>
+     <% end %>
+     <div class="row"><hr></div>
+  </div>
+</div>

--- a/app/views/monograph_manifests/show.html.erb
+++ b/app/views/monograph_manifests/show.html.erb
@@ -1,0 +1,46 @@
+<div class="container">
+  <div class="col-md-12">
+    <div class="row">
+      <h1><%= t('monograph_manifests.show.h1') %></h1>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-md-12"><h2><%= t('monograph_manifests.show.h2.monograph', noid: @presenter.id) %></h2></div>
+        </div>
+        <div class="row">
+          <div class="col-md-11"><hr/></div>
+          <div class="col-md-1"></div>
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+            <%= button_to t('monograph_manifests.show.export'), main_app.export_monograph_manifests_path(@presenter.id), method: :get, class: 'btn btn-primary' %>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-md-12"><h2><%= t('monograph_manifests.show.h2.manifest', filename: @presenter.explicit.filename) %></h2></div>
+        </div>
+        <div class="row">
+          <div class="col-md-11"><hr/></div>
+          <div class="col-md-1"></div>
+        </div>
+        <div class="row">
+          <div class="col-md-2">
+            <%= button_to t('monograph_manifests.show.upload'), main_app.new_monograph_manifests_path(@presenter.id), method: :get, class: 'btn btn-primary' %>
+          </div>
+          <div class="col-md-2">
+            <%= button_to t('monograph_manifests.show.preview'), main_app.preview_monograph_manifests_path(@presenter.id), method: :get, class: 'btn btn-primary' if @presenter.explicit.persisted? %>
+          </div>
+          <div class="col-md-8">
+            <%= button_to t('monograph_manifests.show.delete'), main_app.monograph_manifests_path(@presenter.id), method: :delete, data: { confirm: t('monograph_manifests.show.confirm') }, class: 'btn btn-primary' if @presenter.explicit.persisted? %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12"><hr></div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,15 @@ en:
   manage_assets:
     monograph_link_text: "Organize Assets"
     section_link_text: "Organize Assets"
+  manifest:
+    edit:
+      h1: "Upload Manifest"
+    form:
+      cancel: "Cancel"
+      csv: "CSV"
+      save: "Save"
+    new:
+      h1: "Upload Manifest"
   mime_type: "Mime Type"
   monograph_catalog:
     index:
@@ -138,6 +147,24 @@ en:
       form:
         q:
           label: "Search within %{monograph_name}"
+  monograph_manifests:
+    preview:
+      cancel: "Cancel"
+      h1: "Preview Monograph Manifest"
+      h2:
+        monograph: "Monograph: %{noid}"
+        manifest: "Manifest: %{filename}"
+      import: "Update"
+    show:
+      h1: "Monograph Manifest"
+      h2:
+        monograph: "Monograph: %{noid}"
+        manifest: "Manifest: %{filename}"
+      confirm: "Are you sure?"
+      delete: "Delete"
+      export: "Download"
+      preview: "Preview"
+      upload: "Upload"
   original_checksum: "Original Checksum"
   pageviews_html: "<strong>%{count}</strong> views since %{date}"
   permissions_expiration_date: "Permissions Expiration Date"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,18 @@ Rails.application.routes.draw do
     end
   end
 
+  constraints platform_administrator_constraint do
+    resource :manifests, path: 'concern/monographs/:id/manifest', only: %i[new edit update create destroy], as: :monograph_manifests
+
+    resource :monograph_manifests, path: 'concern/monographs/:id/manifest', only: [:show] do
+      member do
+        get :export
+        patch :import
+        get :preview
+      end
+    end
+  end
+
   mount Qa::Engine => '/authorities'
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do

--- a/lib/import/csv_parser.rb
+++ b/lib/import/csv_parser.rb
@@ -10,7 +10,7 @@ module Import
       @file = input_file
     end
 
-    def attributes
+    def attributes(stream = nil)
       attrs = {}
 
       # a CSV can only have one monograph (probably for in-house use only)...
@@ -19,8 +19,12 @@ module Import
       attrs['files_metadata'] = []
       attrs['row_errors'] = {}
 
-      puts "Parsing file: #{file}"
-      rows = CSV.read(file, headers: true, skip_blanks: true).delete_if { |row| row.to_hash.values.all?(&:blank?) }
+      rows = if stream.present?
+               CSV.parse(stream, headers: true, skip_blanks: true).delete_if { |row| row.to_hash.values.all?(&:blank?) }
+             else
+               puts "Parsing file: #{file}"
+               CSV.read(file, headers: true, skip_blanks: true).delete_if { |row| row.to_hash.values.all?(&:blank?) }
+             end
       row_data = RowData.new
 
       # human-readable row counter (3 accounts for the top two discarded rows)

--- a/spec/lib/import/importer_spec.rb
+++ b/spec/lib/import/importer_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'import'
+require 'export'
 
 describe Import::Importer do
   let(:public_vis) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
@@ -14,7 +15,9 @@ describe Import::Importer do
   let(:importer) { described_class.new(root_dir: root_dir,
                                        user_email: user.email,
                                        press: press.subdomain,
-                                       visibility: public_vis) }
+                                       visibility: public_vis,
+                                       monograph_id: monograph_id) }
+  let(:monograph_id) { '' }
   let(:visibility) { public_vis }
 
   before do
@@ -44,6 +47,55 @@ describe Import::Importer do
 
       it 'is private' do
         expect(importer.visibility).to eq private_vis
+      end
+    end
+  end
+
+  describe '#import' do
+    subject { importer.import(manifest) }
+
+    let(:manifest) { double('manifest') }
+
+    context 'default no monograph' do
+      it { is_expected.to be false }
+    end
+
+    context 'with ldp:gone-ish or monograph not found' do
+      let(:monograph_id) { 'validnoid' }
+      it { expect { subject }.to raise_error(/No monograph found with id '#{monograph_id}'/) }
+    end
+
+    context 'with monograph' do
+      let(:monograph) { build(:monograph, representative_id: cover.id) }
+      let(:cover) { create(:file_set) }
+      let(:file1) { create(:file_set, resource_type: ['video']) }
+      let(:file2) { create(:file_set, resource_type: ['image']) }
+      let(:expected_manifest) do
+        <<~eos
+          NOID,File Name,Link,Title,Resource Type,Externally Hosted Resource,Caption,Alternative Text,Copyright Holder,Allow High-Res Display?,Allow Download?,Copyright Status,Rights Granted,Rights Granted - Creative Commons,Permissions Expiration Date,After Expiration: Allow Display?,After Expiration: Allow Download?,Credit Line,Holding Contact,Exclusive to Fulcrum,Persistent ID - Display on Platform,Persistent ID - XML for CrossRef,Persistent ID - Handle,Handle,DOI,Content Type,Primary Creator Last Name,Primary Creator First Name,Primary Creator Role,Additional Creator(s),Sort Date,Display Date,Description,Keywords,Section,Language,Transcript,Translation,Redirect to,Publisher,Subject,ISBN (hardcover),ISBN (paper),ISBN (ebook),Buy Book URL,Pub Year,Pub Location
+          instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder,instruction placeholder
+          #{cover.id},,"=HYPERLINK(""#{Rails.application.routes.url_helpers.hyrax_file_set_url(cover)}"")",#{cover.title.first},#{cover.resource_type.first},,,,,,,,,,,,,,,,,,,,,,,,,,#{cover.sort_date},,,,,,,,,,,,,,,,
+          #{file1.id},,"=HYPERLINK(""#{Rails.application.routes.url_helpers.hyrax_file_set_url(file1)}"")",#{file1.title.first},image,,,,,,,,,,,,,,,,,,,,,,,,,,#{file1.sort_date},,,,,,,,,,,,,,,,
+          #{file2.id},,"=HYPERLINK(""#{Rails.application.routes.url_helpers.hyrax_file_set_url(file2)}"")",NEW FILE TITLE,#{file2.resource_type.first},no,,,,,,,,,,,,,,,,,,,,,,,,,2000-01-01,,,,,,,,,,,,,,,,
+          #{monograph.id},://:MONOGRAPH://:,"=HYPERLINK(""#{Rails.application.routes.url_helpers.hyrax_monograph_url(monograph)}"")",NEW MONOGRAPH TITLE,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,://:MONOGRAPH://:,,,,,,,,,,,,
+        eos
+      end
+      let(:monograph_id) { monograph.id }
+      let(:manifest) { expected_manifest }
+
+      before do
+        monograph.ordered_members << cover
+        monograph.ordered_members << file1
+        monograph.ordered_members << file2
+        monograph.save!
+      end
+
+      it do
+        is_expected.to be true
+        actual_manifest = Export::Exporter.new(monograph_id).export
+        puts actual_manifest
+        puts expected_manifest
+        expect(actual_manifest).to eq expected_manifest
       end
     end
   end

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Manifest, type: :model do
+  let(:monograph) { create(:monograph) }
+  let(:current_user) { double("current user") }
+
+  # NOTE: #create is dependent on Carrierwave and was not tested.
+
+  before do
+    # Don't print status messages during specs
+    allow($stdout).to receive(:puts)
+  end
+
+  it 'no csv file' do
+    implicit = described_class.from_monograph(monograph.id)
+    expect(implicit.id).to eq monograph.id
+    expect(implicit.persisted?).to be false
+    expect(implicit.filename).to be nil
+
+    explicit = described_class.from_monograph_manifest(monograph.id)
+    expect(explicit.id).to eq monograph.id
+    expect(explicit.persisted?).to be false
+    expect(explicit.filename).to be nil
+
+    expect(implicit == explicit).to be false
+  end
+
+  it 'csv file' do
+    implicit = described_class.from_monograph(monograph.id)
+
+    file_dir = implicit.csv.store_dir
+    FileUtils.mkdir_p(file_dir) unless Dir.exist?(file_dir)
+    FileUtils.rm_rf(Dir.glob("#{file_dir}/*"))
+    file_name = "#{monograph.id}.csv"
+    file_path = File.join(file_dir, file_name)
+    file = File.new(file_path, "w")
+    exporter = Export::Exporter.new(monograph.id)
+    file.write(exporter.export)
+    file.close
+
+    expect(implicit.persisted?).to be true
+    expect(implicit.filename).to eq file_name
+
+    explicit = described_class.from_monograph_manifest(monograph.id)
+
+    expect(explicit.persisted?).to be true
+    expect(explicit.filename).to eq file_name
+
+    expect(implicit == explicit).to be true
+
+    expect(explicit.table_rows.count).to eq 1
+    expect(explicit.table_rows[0].count).to eq 4
+    expect(explicit.table_rows[0][3]["title"].first).to eq monograph.title.first
+
+    explicit.table_rows[0][3]["title"] = ["NEW TITLE"]
+
+    expect(implicit == explicit).to be false
+
+    explicit.destroy(current_user)
+
+    expect(implicit.id).to eq monograph.id
+    expect(implicit.persisted?).to be false
+    expect(implicit.filename).to be nil
+
+    expect(explicit.id).to eq monograph.id
+    expect(explicit.persisted?).to be false
+    expect(explicit.filename).to be nil
+  end
+end

--- a/spec/models/monograph_manifest_spec.rb
+++ b/spec/models/monograph_manifest_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MonographManifest, type: :model do
+  subject(:monograph_manifest) { described_class.new(monograph.id) }
+
+  let(:monograph) { double("monograph", id: noid) }
+  let(:noid) { "123456789" }
+  let(:implicit_manifest) { double("implicit_manifest") }
+  let(:explicit_manifest) { double("explicit_manifest") }
+
+  before do
+    allow(Manifest).to receive(:from_monograph).with(noid).and_return(implicit_manifest)
+    allow(Manifest).to receive(:from_monograph_manifest).with(noid).and_return(explicit_manifest)
+  end
+
+  it { expect(monograph_manifest.id).to eq noid }
+  it { expect(monograph_manifest.implicit).to be implicit_manifest }
+  it { expect(monograph_manifest.explicit).to be explicit_manifest }
+  it { expect(monograph_manifest.persisted?).to be true }
+end

--- a/spec/presenters/manifest_presenter_spec.rb
+++ b/spec/presenters/manifest_presenter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ManifestPresenter do
+  subject(:presenter) { described_class.new(current_user, manifest) }
+
+  let(:current_user) { double("current_user") }
+  let(:manifest) { double("manifest", id: "manifest") }
+
+  it do
+    expect(subject.current_user).to be current_user
+    expect(subject.id).to eq manifest.id
+  end
+end

--- a/spec/presenters/monograph_manifest_presenter_spec.rb
+++ b/spec/presenters/monograph_manifest_presenter_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MonographManifestPresenter do
+  subject(:presenter) { described_class.new(current_user, monograph_manifest) }
+
+  let(:current_user) { double("current_user") }
+  let(:monograph_manifest) { double("monograph_manifest", id: "manifest", explicit: explicit, implicit: implicit) }
+  let(:explicit) { double("explicit", id: "explicit") }
+  let(:implicit) { double("implicit", id: "implicit") }
+
+  it do
+    expect(subject.current_user).to be current_user
+    expect(subject.id).to eq monograph_manifest.id
+    expect(subject.explicit).to be_a(ManifestPresenter)
+    expect(subject.explicit.id).to eq explicit.id
+    expect(subject.implicit).to be_a(ManifestPresenter)
+    expect(subject.implicit.id).to eq implicit.id
+    expect(subject.equivalent?).to be false
+  end
+end

--- a/spec/requests/monograph_manifests_spec.rb
+++ b/spec/requests/monograph_manifests_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Monograph Manifest", type: :request do
+  let(:monograph) { create(:monograph) }
+
+  context 'anonymous' do
+    describe "GET /concern/monographs/:id/manifest" do
+      it do
+        expect { get monograph_manifests_path(monograph) }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+
+  context 'user' do
+    before { cosign_sign_in(current_user) }
+
+    context 'unauthorized' do
+      let(:current_user) { create(:user) }
+
+      describe "GET /concern/monographs/:id/manifest" do
+        it do
+          expect { get monograph_manifests_path(monograph) }.to raise_error(ActionController::RoutingError)
+        end
+      end
+    end
+
+    context 'authorized' do
+      let(:current_user) { create(:platform_admin) }
+
+      describe "GET /concern/monographs/:id/manifest" do
+        it do
+          get monograph_manifests_path(monograph)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Monograph Manifest routes restricted to platform admins.
Append "/manifest" to any monograph to begin.
Part one does everything but update (a.k.a. import) the monograph metadata.
For now selecting update is equivalent to selecting delete which removes the csv file.
