### PR TITLE
HELIO-1478 Use a role based mediated deposit workflow for heb ingest

### DIFF
--- a/app/search_builders/hyrax/my/search_builder.rb
+++ b/app/search_builders/hyrax/my/search_builder.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module My
+    # Search builder for things that the current user has edit access to
+    # Heliotrope Hyrax override
+    # @abstract
+    class SearchBuilder < ::SearchBuilder
+      # Check for edit access
+      include Hyrax::My::SearchBuilderBehavior
+      self.default_processor_chain += [:show_all_edit_access]
+      self.default_processor_chain -= [:only_active_works]
+
+      def show_all_edit_access(solr_parameters)
+        roles = current_user.groups.join(",")
+        solr_parameters[:fq] ||= []
+        solr_parameters[:fq] << "{!terms f=edit_access_group_ssim}#{roles}"
+      end
+    end
+  end
+end

--- a/app/views/hyrax/monographs/show.html.erb
+++ b/app/views/hyrax/monographs/show.html.erb
@@ -29,8 +29,10 @@
   <div class="col-sm-12">
     <%= render 'csb_hyrax_citations', presenter: @presenter %>
     <%= render 'items', presenter: @presenter %>
+    <% if @presenter.workflow.state != "deposited" %>
+      <%= render 'workflow_actions_widget', presenter: @presenter %>
+    <% end %>
     <%# TODO: we may consider adding these partials in the future %>
-    <%#= render 'workflow_actions_widget', presenter: @presenter %>
     <%#= render 'sharing_with', presenter: @presenter %>
     <%#= render 'user_activity', presenter: @presenter %>
   </div>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -9,6 +9,8 @@
     <% if can? :edit, @monograph_presenter %>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.monograph_show_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.show_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.show_page_button') %></a>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.edit_hyrax_monograph_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.edit_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.edit_page_button') %></a>
+      <p><%= @monograph_presenter.permission_badge %>
+      <%= @monograph_presenter.workflow.badge %></p>
     <% end %>
   </div><!-- /.monograph-cover -->
   <div class="col-sm-9 monograph-metadata">

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -15,3 +15,47 @@
     }
   </script>
 <% end %>
+
+<% if @monograph_presenter.workflow.state != "deposited" && @monograph_presenter.workflow.actions.present? %>
+  <div class="workflow-actions">
+    <div id="workflow_controls"class="panel panel-default workflow-affix">
+      <div class="panel-heading">
+        <a data-toggle="collapse" href="#workflow_controls_collapse">
+          <h2 class="panel-title">Review and Approval</h2>
+        </a>
+      </div>
+      <div id="workflow_controls_collapse" class="row panel-body panel-collapse collapse">
+        <%= form_tag hyrax_workflow_action_path(@monograph_presenter), method: :put do %>
+          <div class="col-sm-3 workflow-actions">
+            <h3>Actions</h3>
+
+            <% @monograph_presenter.workflow.actions.each do |key, label| %>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="workflow_action[name]" id="workflow_action_name_<%= key %>" value="<%= key %>">
+                  <%= label %>
+                </label>
+              </div>
+            <% end %>
+          </div>
+          <div class="col-sm-9 workflow-comments">
+            <div class="form-group">
+              <label for="workflow_action_comment">Review comment:</label>
+              <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+            </div>
+
+            <input class="btn btn-primary" type="submit" value="Submit">
+
+            <h4>Previous Comments</h4>
+            <dl>
+              <% @monograph_presenter.workflow.comments.each do |comment| %>
+                <dt><%= comment.name_of_commentor %></dt>
+                <dd><%= comment.comment %></dd>
+              <% end %>
+            </dl>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/workflows/heb_mediated_deposit_workflow.json
+++ b/config/workflows/heb_mediated_deposit_workflow.json
@@ -1,0 +1,75 @@
+{
+    "workflows": [
+        {
+            "name": "heb_one_step_mediated_deposit",
+            "label": "One-step mediated deposit workflow for ACLS",
+            "description": "A single-step workflow for mediated deposit very similiar to the Hyrax default but in where heb_admin/heb_editors have BOTH the approving AND depositing roles",
+            "allows_access_grant": false,
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::DeactivateObject"
+                    ]
+                }, {
+                    "name": "request_changes",
+                    "from_states": [{"names": ["deposited", "pending_review"], "roles": ["approving", "depositing"]}],
+                    "transition_to": "changes_required",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::ChangesRequiredNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::DeactivateObject",
+                        "Hyrax::Workflow::GrantEditToDepositor"
+                    ]
+                }, {
+                    "name": "approve",
+                    "from_states": [{"names": ["pending_review"], "roles": ["approving", "depositing"]}],
+                    "transition_to": "deposited",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DepositedNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::GrantReadToDepositor",
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
+                    "name": "request_review",
+                    "from_states": [{"names": ["changes_required"], "roles": ["approving", "depositing"]}],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
+                    ]
+                }, {
+                    "name": "comment_only",
+                    "from_states": [
+                        { "names": ["pending_review", "deposited"], "roles": ["approving", "depositing"] },
+                        { "names": ["changes_required"], "roles": ["depositing"] }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/script/import
+++ b/script/import
@@ -49,6 +49,10 @@ def parse_inputs(args)
     inputs[:test] = true
   end
 
+  opts.on('-w [WORKFLOW NAME]', '--workflow', 'Specify a Workflow') do |workflow|
+    inputs[:workflow] = workflow
+  end
+
   opts.on('-h', '--help', 'Print this help message') do
     puts opts
     exit 0
@@ -60,8 +64,8 @@ def parse_inputs(args)
 
   opts.parse!(args)
 
-  if inputs[:monograph_id] && (inputs[:press] || inputs[:visibility] || inputs[:monograph_title])
-    raise "Error: using -m or --monograph_id (i.e. reimporting) excludes -p, -v and -n"
+  if inputs[:monograph_id] && (inputs[:press] || inputs[:visibility] || inputs[:monograph_title] || inputs[:workflow])
+    raise "Error: using -m or --monograph_id (i.e. reimporting) excludes -p, -v, -n and -w"
   end
   raise "Error: The CSV directory is required" unless inputs[:root_dir]
   raise "Error: Username (email) is required" unless inputs[:user_email]
@@ -84,6 +88,8 @@ importer = Import::Importer.new({ root_dir: options[:root_dir],
                                   monograph_title: options[:monograph_title],
                                   monograph_id: options[:monograph_id],
                                   quiet: options[:quiet]})
+                                  workflow: options[:workflow]})
+
 importer.run(options[:test])
 
 puts "Import finished"

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin_set do
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    # Given the relationship between permission template and admin set, when
+    # an admin set is created via a factory, I believe it is appropriate to go ahead and
+    # create the corresponding permission template
+    #
+    # This way, we can go ahead
+    after(:create) do |admin_set, evaluator|
+      if evaluator.with_permission_template
+        attributes = { admin_set_id: admin_set.id }
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        # There is a unique constraint on permission_templates.admin_set_id; I don't want to
+        # create a permission template if one already exists for this admin_set
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set.id)
+      end
+    end
+
+    transient do
+      # false, true, or Hash with keys for permission_template
+      with_permission_template false
+    end
+  end
+end

--- a/spec/features/monograph_dashboard_role_visibility_spec.rb
+++ b/spec/features/monograph_dashboard_role_visibility_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'A monograph deposited by one user' do
+  let(:depositor) { create(:platform_admin) }
+  let(:press) { create(:press, subdomain: 'umich') }
+  let(:press_admin) { create(:press_admin, press: press) }
+  let(:monograph) { create(:monograph, title: ['My New Book'],
+                                       press: press.subdomain,
+                                       user: depositor,
+                                       edit_groups: ['umich_admin']) }
+
+  before { monograph.save! }
+
+  scenario "can be seen in the dashboard by other users who have edit access" do
+    # This is mostly testing app/search_builders/hyrax/my/search_builder.rb which
+    # is modified from what was in hyrax
+    cosign_login_as press_admin
+    visit '/dashboard/my/works'
+    # In vanilla hyrax users can only see works they've deposited
+    # In heliotrope they can see monographs they have edit access to as well
+    expect(page).to have_content("My New Book")
+  end
+end

--- a/spec/lib/import/importer_spec.rb
+++ b/spec/lib/import/importer_spec.rb
@@ -16,8 +16,9 @@ describe Import::Importer do
                                        user_email: user.email,
                                        press: press.subdomain,
                                        visibility: public_vis,
+                                       monograph_id: monograph_id,
                                        quiet: true,
-                                       monograph_id: monograph_id) }
+                                       workflow: 'my_workflow') }
   let(:monograph_id) { '' }
   let(:visibility) { public_vis }
 
@@ -106,8 +107,38 @@ describe Import::Importer do
   end
 
   describe '#run' do
+    let(:workflow_name) { 'my_workflow' }
+    let(:admin_set) { create(:admin_set, edit_users: [user.user_key]) }
+    let(:one_step_workflow) do
+      {
+        workflows: [
+          {
+            name: workflow_name,
+            label: "One-step mediated deposit workflow",
+            description: "A single-step workflow for mediated deposit",
+            actions: [
+              {
+                name: "deposit", from_states: [], transition_to: "pending_review"
+              }, {
+                name: "approve", from_states: [{ names: ["pending_review"], roles: ["approving"] }],
+                transition_to: "deposited",
+                methods: ["Hyrax::Workflow::ActivateObject"]
+              }, {
+                name: "leave_a_comment", from_states: [{ names: ["pending_review"], roles: ["approving"] }]
+              }
+            ]
+          }
+        ]
+      }
+    end
+    let(:workflow) { Sipity::Workflow.find_by!(name: workflow_name, permission_template: permission_template) }
+    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+
     before do
       stub_out_redis
+      Hyrax::Workflow::WorkflowImporter.generate_from_hash(data: one_step_workflow, permission_template: permission_template)
+      permission_template.available_workflows.first.update!(active: true)
+      Hyrax::Workflow::PermissionGenerator.call(roles: 'approving', workflow: workflow, agents: user)
     end
 
     context 'when the importer runs successfully' do
@@ -125,6 +156,7 @@ describe Import::Importer do
         expect(monograph.id.length).to eq 9 # NOID
 
         expect(monograph.depositor).to eq user.email
+        expect(monograph.admin_set_id).to eq admin_set.id
 
         expect(monograph.visibility).to eq public_vis
         file_sets = monograph.ordered_members.to_a
@@ -239,6 +271,18 @@ describe Import::Importer do
 
       it 'raises an exception' do
         expect { importer.run }.to raise_error(/No press found with subdomain: 'incorrect press'/)
+      end
+    end
+
+    context "when the workflow doesn't have an admin_set" do
+      let(:importer) { described_class.new(root_dir: root_dir,
+                                           user_email: user.email,
+                                           press: press.subdomain,
+                                           visibility: public_vis,
+                                           monograph_id: monograph_id,
+                                           workflow: 'not_a_real_workflow') }
+      it 'raises an exception' do
+        expect { importer.run }.to raise_error(/a corresponding AdminSet was not found. Make sure you've registered this workflow./)
       end
     end
   end

--- a/spec/views/monograph_catalog/index.html.erb_spec.rb
+++ b/spec/views/monograph_catalog/index.html.erb_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "monograph_catalog/index.html.erb", type: :view do
   end
 
   let(:debug) { false }
-  let(:monograph_presenter) { build(:monograph_presenter) }
+  let(:current_ability) { double("ability") }
+  let(:monograph_presenter) { Hyrax::MonographPresenter.new(SolrDocument.new(id: 'mono_id', title: ["Untitled"], has_model_ssim: ['Monograph']), current_ability) }
 
   before do
     stub_template "catalog/_search_sidebar" => "<!-- render-template-catalog/_search_sidebar -->"


### PR DESCRIPTION
This is safe to merge as-is. Until we register the new workflow and then associate an admin_set/permissions template, nothing will need to change in staging/testing/preview/production.

After the merge, I'll update, I don't know maybe testing and register the workflow/make an admin set. I'll document the process in confluence and then when we release to production we'll duplicate it.

