### PR TITLE
HELIO-1861 toc link to CSB is broken for multi rendition epubs

### DIFF
--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -4,7 +4,7 @@
 <% @monograph_presenter.epub_presenter.chapters.each do |chapter| %>
   <div class="row chapter">
     <div class="col-sm-12">
-      <h3><a href="<%= epub_url %>#/<%= epub_dir %>/<%= chapter.href %>"><%= chapter.title %></a></h3>
+      <h3><a href="<%= epub_url %>#<%= chapter.cfi %>4/1:0"><%= chapter.title %></a></h3>
       <%= chapter.blurb unless chapter.paragraphs.empty? %>
       <hr>
     </div>

--- a/lib/e_pub/chapter_presenter.rb
+++ b/lib/e_pub/chapter_presenter.rb
@@ -16,6 +16,10 @@ module EPub
       @chapter.chapter_href
     end
 
+    def cfi
+      @chapter.basecfi
+    end
+
     def blurb
       text = ""
       @chapter.paragraphs.each do |p|

--- a/lib/spec/e_pub/chapter_presenter_spec.rb
+++ b/lib/spec/e_pub/chapter_presenter_spec.rb
@@ -44,4 +44,11 @@ RSpec.describe EPub::ChapterPresenter do
       expect(subject).to all(be_an_instance_of(EPub::ParagraphPresenter))
     end
   end
+
+  describe "#cfi" do
+    subject { described_class.send(:new, chapter).cfi }
+    it "returns the (base) cfi" do
+      is_expected.to eq "/6/4/2[Chapter1]"
+    end
+  end
 end


### PR DESCRIPTION
Instead of using the chapter's href to link into CSB, use the
chapter's CFI. This "base" CFI should work for both renditions.