### PR TITLE
Resolves 1905 Session Cookie Overflow

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -120,6 +120,7 @@ class EPubsController < ApplicationController
     def set_session_show
       session[:show_set] ||= []
       session[:show_set] << params[:id] unless session[:show_set].include?(params[:id])
+      session[:show_set].shift if session[:show_set].length > 10
     end
 
     def clear_session_show

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -392,4 +392,24 @@ RSpec.describe EPubsController, type: :controller do
       end
     end
   end
+
+  describe 'session[:set_show]' do
+    let(:presenter) { double('presenter', epub?: true) }
+    let(:n) { 20 }
+    let(:m) { 10 }
+
+    before do
+      allow(Hyrax::PresenterFactory).to receive(:build_for).and_return([presenter])
+    end
+
+    it 'buffers m ids' do
+      session[:show_set] = []
+      n.times do |i|
+        get :lock, params: { id: i }
+        expect(response).to redirect_to(epub_path)
+        expect(session[:show_set].include?(i.to_s)).to be true
+        expect(session[:show_set].length).to be <= m
+      end
+    end
+  end
 end


### PR DESCRIPTION
Limits session[:show_set] to a length of ten.