### PR TITLE
Add subjects, pub date; rework metadata display for monographs

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -270,7 +270,7 @@ footer.press {
       }
 
       input#permalink {
-        max-width: 70%;
+        max-width: 82%;
       }
     }
   }
@@ -280,7 +280,13 @@ footer.press {
       padding-top: 4em;
     }
     .chapter {
-      margin-left: 4em;
+      padding-left: 1em;
+    }
+
+    .download {
+      display: block;
+      padding-left: 2em;
+      padding-top: .4em;
     }
   }
 

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -207,10 +207,39 @@ footer.press {
     }
 
     .monograph-metadata {
+      .copyright {
+        font-size: .85em;
+      }
+
       .description {
+        padding-top: 1.2em;
         padding-bottom: 2em;
       }
 
+      .additional-metadata {
+        padding-top: 2em;
+        dt, dd {
+          display: inline-block;
+          float: left;
+        }
+        dt {
+          clear: both;
+          width: 8em;
+        }
+
+        dd {
+          padding-left: 3em;
+        }
+
+        dd > form {
+          width: 200%;
+          label {}
+        }
+
+        ul {
+          padding-left: 0;
+        }
+      }
     .webgl.alert {
       margin-left: 0;
       margin-right: 0;
@@ -241,7 +270,7 @@ footer.press {
       }
 
       input#permalink {
-        max-width: 50%;
+        max-width: 70%;
       }
     }
   }

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -70,6 +70,18 @@ module Hyrax
       solr_document.creator_display.present?
     end
 
+    def copyright_holder?
+      solr_document.copyright_holder.present?
+    end
+
+    def holding_contact?
+      solr_document.holding_contact.present?
+    end
+
+    def date_created?
+      solr_document.date_created.present?
+    end
+
     def unreverse_names(comma_separated_names)
       forward_names = []
       comma_separated_names.each { |n| forward_names << unreverse_name(n) }

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hyrax
   module PresentsAttributes
     ##
@@ -40,7 +42,7 @@ module Hyrax
     def microdata_type_to_html
       return "" unless display_microdata?
       value = Microdata.fetch(microdata_type_key, default: Hyrax.config.microdata_default_type)
-      " itemscope itemtype=\"#{value}\"".html_safe
+      " itemscope itemtype=\"#{value}\"".html_safe # rubocop:disable Rails/OutputSafety
     end
 
     private

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -1,0 +1,75 @@
+module Hyrax
+  module PresentsAttributes
+    ##
+    # Present the attribute as an HTML table row or dl row.
+    #
+    # @param [Hash] options
+    # @option options [Symbol] :render_as use an alternate renderer
+    #   (e.g., :linked or :linked_attribute to use LinkedAttributeRenderer)
+    # @option options [String] :search_field If the method_name of the attribute is different than
+    #   how the attribute name should appear on the search URL,
+    #   you can explicitly set the URL's search field name
+    # @option options [String] :label The default label for the field if no translation is found
+    # @option options [TrueClass, FalseClass] :include_empty should we display a row if there are no values?
+    # @option options [String] :work_type name of work type class (e.g., "GenericWork")
+    def attribute_to_html(field, options = {})
+      unless respond_to?(field)
+        Rails.logger.warn("#{self.class} attempted to render #{field}, but no method exists with that name.")
+        return
+      end
+
+      if options[:html_dl]
+        renderer_for(field, options).new(field, send(field), options).render_dl_row
+      else
+        renderer_for(field, options).new(field, send(field), options).render
+      end
+    end
+
+    def permission_badge
+      permission_badge_class.new(solr_document.visibility).render
+    end
+
+    def permission_badge_class
+      PermissionBadge
+    end
+
+    def display_microdata?
+      Hyrax.config.display_microdata?
+    end
+
+    def microdata_type_to_html
+      return "" unless display_microdata?
+      value = Microdata.fetch(microdata_type_key, default: Hyrax.config.microdata_default_type)
+      " itemscope itemtype=\"#{value}\"".html_safe
+    end
+
+    private
+
+      def find_renderer_class(name)
+        renderer = nil
+        ['Renderer', 'AttributeRenderer'].each do |suffix|
+          const_name = "#{name.to_s.camelize}#{suffix}".to_sym
+          renderer = begin
+            Renderers.const_get(const_name)
+          rescue NameError
+            nil
+          end
+          break unless renderer.nil?
+        end
+        raise NameError, "unknown renderer type `#{name}`" if renderer.nil?
+        renderer
+      end
+
+      def renderer_for(_field, options)
+        if options[:render_as]
+          find_renderer_class(options[:render_as])
+        else
+          Renderers::AttributeRenderer
+        end
+      end
+
+      def microdata_type_key
+        "resource_type.#{human_readable_type}"
+      end
+  end
+end

--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -40,6 +40,20 @@ module Hyrax
         markup.html_safe
       end
 
+      # Draw the dl row for the attribute
+      def render_dl_row
+        markup = ''
+
+        return markup if values.blank? && !options[:include_empty]
+        markup << %(<dt>#{label}</dt>\n<dd><ul class='tabular'>)
+        attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
+        Array(values).each do |value|
+          markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
+        end
+        markup << %(</ul></dd>)
+        markup.html_safe
+      end
+
       def maybe_sort_values
         # options[:sort_by] is an array showing values' items in their intended order
         return if options[:sort_by].blank? || !values.is_a?(Array) || values.count < 1

--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -4,14 +4,12 @@
 <% @monograph_presenter.epub_presenter.chapters.each do |chapter| %>
   <div class="row chapter">
     <div class="col-sm-12">
-      <h3>
-        <% if chapter.downloadable? %>
-        <a href="<%= epub_download_chapter_path(id: @monograph_presenter.epub_id, cfi: chapter.cfi) %>" data-turbolinks="false">
-          <i id="download" class="oi" data-glyph="data-transfer-download" title="Download chapter" aria-hidden="true"></i>
-        </a>
-        <% end %>
-        <a href="<%= epub_url %>#<%= chapter.cfi %>4/1:0"><%= chapter.title %></a>
-      </h3>
+      <h3><a href="<%= epub_url %>#<%= chapter.cfi %>4/1:0"><%= chapter.title %></a></h3>
+      <% if chapter.downloadable? %>
+      <span class="download"><a class="btn btn-default btn-sm" href="<%= epub_download_chapter_path(id: @monograph_presenter.epub_id, cfi: chapter.cfi) %>" data-turbolinks="false">
+        <i id="download" class="oi" data-glyph="data-transfer-download" title="Download chapter" aria-hidden="true"></i>
+      Download</a></span>
+      <% end %>
       <hr>
     </div>
   </div>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -18,6 +18,16 @@
     <% if @monograph_presenter.authors? %>
         <h3><%= render_markdown @monograph_presenter.authors %></h3>
     <% end %>
+    <% if @monograph_presenter.date_created? %>
+    <span aria-label="publication date" class="pubdate"><%= @monograph_presenter.date_created.first %></span>
+    <% end %>
+    <% if @monograph_presenter.copyright_holder? %>
+       <% if @monograph_presenter.holding_contact? %>
+        <span aria-label="copyright information and contact" class="copyright">&copy; <a href="<%= @monograph_presenter.holding_contact %>"><%= @monograph_presenter.copyright_holder %></a></span>
+       <% else %>
+        <span aria-label="copyright information" class="copyright">&copy; <%= @monograph_presenter.copyright_holder %></span>
+       <% end %>
+    <% end %>
     <div class="description">
       <%= render_markdown @monograph_presenter.description.first || '' %>
     </div>
@@ -40,23 +50,20 @@
       <div id="webgl-message"></div>
     <% end %>
 
-    <table class="table monograph attributes" <%= @monograph_presenter.microdata_type_to_html %>>
-      <tbody>
-      <%= @monograph_presenter.attribute_to_html(:series, label: t('series')) %>
-      <%= @monograph_presenter.attribute_to_html(:copyright_holder, label: t('copyright_holder')) %>
-      <%= @monograph_presenter.attribute_to_html(:holding_contact, render_as: :markdown, label: t('holding_contact')) %>
-      <%= @monograph_presenter.attribute_to_html(:isbn, label: t('isbn')) %>
-      <tr>
-        <th><%= t('citable_link') %></th>
-        <td>
-          <form>
-            <label for="permalink" style="display: none;"><%= t('citable_link') %></label>
-            <input type="text" class="form-control" id="permalink" aria-label="citable link" value="<%= @monograph_presenter.citable_link %>" readonly="readonly" onclick="this.select(); document.execCommand('copy');" />
-          </form>
-        </td>
-      </tr>
-      </tbody>
-    </table>
+  <div class="additional-metadata">
+    <dl>
+      <%= @monograph_presenter.attribute_to_html(:series, html_dl: true) %>
+      <%= @monograph_presenter.attribute_to_html(:isbn, label: t('isbn'), html_dl: true) %>
+      <%= @monograph_presenter.attribute_to_html(:subject, html_dl: true) %>
+      <dt><%= t('citable_link') %></dt>
+      <dd>
+        <form>
+          <label for="permalink" style="display: none;"><%= t('citable_link') %></label>
+          <input type="text" class="form-control" id="permalink" aria-label="citable link" value="<%= @monograph_presenter.citable_link %>" readonly="readonly" onclick="this.select(); document.execCommand('copy');" />
+        </form>
+      </dd>
+    </dl>
+  </div>
 
   </div><!-- /.monograph-metadata -->
 </div><!-- /.monograph-info-epub -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,7 @@ en:
     search:
       form:
         q:
-          label: "Search within %{monograph_name}"
+          label: "Search for assets within %{monograph_name}"
           placeholder: "Search assets"
   monograph_manifests:
     notice:
@@ -170,7 +170,7 @@ en:
     search:
       form:
         q:
-          label: "Search within %{press_name}"
+          label: "Search for works within %{press_name}"
           placeholder: "Search works"
   publisher: "Publisher"
   redirect_to: "Redirect to"

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -87,7 +87,9 @@ feature 'Create a monograph' do
       expect(page).to have_content 'The Second Series'
       # copyright stuff
       expect(page).to have_content 'Blahdy Blah Copyright Holder'
-      expect(page).to have_content 'http://www.blahpresscompany.com/'
+      expect(page).to have_link("Blahdy Blah Copyright Holder", href: "http://www.blahpresscompany.com/")
+      # Subject
+      expect(page).to have_content 'red stuff'
       # ISBN
       expect(page).to have_content '123-456-7890'
       expect(page).to have_content '123-456-7891'
@@ -117,7 +119,6 @@ feature 'Create a monograph' do
       expect(page).to have_content 'Blahdy Blah Copyright Holder'
       # holding_contact
       expect(page).to have_content 'http://www.blahpresscompany.com/'
-
       # Citation Metadata
       # publisher
       expect(page).to have_content 'Blah Press, Co.'


### PR DESCRIPTION
Resolves [HELIO-1865](https://tools.lib.umich.edu/jira/browse/HELIO-1865)

For the monograph catalog page, this work: 

- Changes metadata display from table to definition list for better use of HTML semantics
- Adds monograph subjects to the metadata list
- Adds publication year
- Modifies display of copyright information and holding contact
- Styles chapter download button
- Fixes discrepancies between placeholder and label search text on monograph and publisher pages.
