### PR TITLE
Add filters to publisher catalog page; begin other enhancements to publisher catalog

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -156,6 +156,17 @@ footer.press {
       border-bottom: none;
       padding-top: 2em;
 
+      h3 {
+        font-size: 24px;
+      }
+
+      .authors {
+        display: block;
+        font-size: 18px;
+        font-weight: 700;
+        padding-bottom: 1.5em;
+      }
+
       .epub {
         padding-bottom: 1em;
       }
@@ -207,6 +218,20 @@ footer.press {
   #appliedParams.constraints-container {
     margin-bottom: 20px;
   }
+
+  .monograph-metadata {
+    h1 {
+      font-size: 30px;
+    }
+
+    .authors {
+      font-size: 24px;
+      font-weight: 700;
+      display: block;
+    }
+
+  }
+
 
   // EPUB - MONOGRAPH INFORMATION
   .monograph-info-epub {

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -171,10 +171,6 @@ $heb-black-80: #342f2e;
 
   .press {
 
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
-
     .document,
     .documentHeader {
       margin-bottom: 2em;
@@ -410,10 +406,6 @@ $iu-midnight: #006298;
 
   .press {
 
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
-
     .document,
     .documentHeader {
       margin-bottom: 2em;
@@ -626,10 +618,6 @@ $um-black-80: #342f2e;
   }
 
   .press {
-
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {
@@ -888,10 +876,6 @@ $gabii-link-hover:    #1e5667;
   }
 
   .press {
-
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {
@@ -1250,9 +1234,6 @@ $umn-white: #fff;
 
   .press {
 
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {
@@ -1473,10 +1454,6 @@ $fulcrum-light-2: #bec4cc;
   }
 
   .press {
-
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {
@@ -1718,10 +1695,6 @@ $nyu-gray-2: #342f2e;
   }
 
   .press {
-
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {
@@ -2006,10 +1979,6 @@ $psu-gray-1: #3F4550;
   }
 
   .press {
-
-    h2:first-child {
-      margin-bottom: 1.5em;
-    }
 
     .document,
     .documentHeader {

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -9,7 +9,35 @@ class PressCatalogController < ::CatalogController
   configure_blacklight do |config|
     config.search_builder_class = PressSearchBuilder
     config.index.partials = %i[thumbnail index_header]
-    config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} asc"
+    config.view.gallery.partials = %i[index_header index]
+
+    config.default_per_page = 15
+    # leaving the #{uploaded_field} desc in these for section sort when all else is equal
+    config.add_sort_field 'date_uploaded desc', sort: "#{solr_name('date_uploaded', :sortable)} desc", label: "Date Added (Newest First)"
+    config.add_sort_field 'author asc', sort: "#{solr_name('creator_full_name', :sortable)} asc", label: "Author (A-Z)"
+    config.add_sort_field 'author desc', sort: "#{solr_name('creator_full_name', :sortable)} desc", label: "Author (Z-A)"
+    config.add_sort_field 'year asc', sort: "#{solr_name('date_created', :sortable)} asc", label: "Publication Date (Newest First)"
+    config.add_sort_field 'year desc', sort: "#{solr_name('date_created', :sortable)} desc", label: "Publication Date (Oldest First)"
+    config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
+    config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} desc", label: "Title (Z-A)"
+
+    config.facet_fields.tap do
+      # solr facet fields not to be displayed in the index (search results) view
+      config.facet_fields.delete('human_readable_type_sim')
+      config.facet_fields.delete('language_sim')
+      config.facet_fields.delete('press_name_ssim')
+      config.facet_fields.delete('subject_sim')
+      config.facet_fields.delete('creator_full_name_sim')
+    end
+
+    config.add_facet_field solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper
+    config.add_facet_field solr_name('creator_full_name', :facetable), label: "Author", limit: 5, url_method: :facet_url_helper
+    config.add_facet_field solr_name('publisher', :facetable), label: "Publisher", limit: 5, url_method: :facet_url_helper
+    config.add_facet_field solr_name('series', :facetable), label: "Series", limit: 5, url_method: :facet_url_helper
+    config.add_facet_fields_to_solr_request!
+
+    config.index.partials = %i[thumbnail index_header]
+    config.view.gallery.partials = %i[index_header index]
   end
 
   def show_site_search?

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -13,12 +13,12 @@ class PressCatalogController < ::CatalogController
 
     config.default_per_page = 15
     # leaving the #{uploaded_field} desc in these for section sort when all else is equal
+    config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
     config.add_sort_field 'date_uploaded desc', sort: "#{solr_name('date_uploaded', :sortable)} desc", label: "Date Added (Newest First)"
     config.add_sort_field 'author asc', sort: "#{solr_name('creator_full_name', :sortable)} asc", label: "Author (A-Z)"
     config.add_sort_field 'author desc', sort: "#{solr_name('creator_full_name', :sortable)} desc", label: "Author (Z-A)"
     config.add_sort_field 'year asc', sort: "#{solr_name('date_created', :sortable)} asc", label: "Publication Date (Newest First)"
     config.add_sort_field 'year desc', sort: "#{solr_name('date_created', :sortable)} desc", label: "Publication Date (Oldest First)"
-    config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
     config.add_sort_field "#{Solrizer.solr_name('title', :sortable)} desc", label: "Title (Z-A)"
 
     config.facet_fields.tap do

--- a/app/indexers/monograph_indexer.rb
+++ b/app/indexers/monograph_indexer.rb
@@ -23,7 +23,11 @@ class MonographIndexer < Hyrax::WorkIndexer
       solr_doc[Solrizer.solr_name('creator', :stored_searchable)] = roleless_creators
       solr_doc[Solrizer.solr_name('creator_full_name', :stored_searchable)] = roleless_creators&.first
       solr_doc[Solrizer.solr_name('creator_full_name', :facetable)] = roleless_creators&.first
+      solr_doc[Solrizer.solr_name('creator_full_name', :sortable)] = roleless_creators&.first
       solr_doc[Solrizer.solr_name('contributor', :stored_searchable)] = roleless_contributors
+      solr_doc[Solrizer.solr_name('date_created', :sortable)] = roleless_date_created
+      solr_doc[Solrizer.solr_name('contributor', :stored_searchable)] = roleless_contributors
+      solr_doc[Solrizer.solr_name('date_uploaded', :stored_searchable)] = roleless_date_uploaded
 
       # grab previous file set order here from Solr (before they are reindexed)
       existing_fileset_order = existing_filesets

--- a/app/indexers/monograph_indexer.rb
+++ b/app/indexers/monograph_indexer.rb
@@ -23,11 +23,7 @@ class MonographIndexer < Hyrax::WorkIndexer
       solr_doc[Solrizer.solr_name('creator', :stored_searchable)] = roleless_creators
       solr_doc[Solrizer.solr_name('creator_full_name', :stored_searchable)] = roleless_creators&.first
       solr_doc[Solrizer.solr_name('creator_full_name', :facetable)] = roleless_creators&.first
-      solr_doc[Solrizer.solr_name('creator_full_name', :sortable)] = roleless_creators&.first
       solr_doc[Solrizer.solr_name('contributor', :stored_searchable)] = roleless_contributors
-      solr_doc[Solrizer.solr_name('date_created', :sortable)] = roleless_date_created
-      solr_doc[Solrizer.solr_name('contributor', :stored_searchable)] = roleless_contributors
-      solr_doc[Solrizer.solr_name('date_uploaded', :stored_searchable)] = roleless_date_uploaded
 
       # grab previous file set order here from Solr (before they are reindexed)
       existing_fileset_order = existing_filesets

--- a/app/models/monograph.rb
+++ b/app/models/monograph.rb
@@ -29,7 +29,7 @@ class Monograph < ActiveFedora::Base
   end
 
   property :series, predicate: ::RDF::Vocab::DCMIType.Collection do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   include HeliotropeUniversalMetadata

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
 <% # container for a single doc -%>
-<div class="row document <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
+<article class="row document <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
   <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter %>
-</div>
+</article>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <div class="col-sm-3 monograph-cover">
     <img class="img-responsive" src="/image-service/<%= @monograph_presenter.representative_id %>/full/225,/0/default.jpg"
-         alt="<%= @monograph_presenter.representative_alt_text %>">
+         alt="Cover for <%= @monograph_presenter.representative_alt_text %>">
     <% if can? :edit, @monograph_presenter %>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.monograph_show_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.show_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.show_page_button') %></a>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.edit_hyrax_monograph_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.edit_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.edit_page_button') %></a>
@@ -14,9 +14,9 @@
     <% end %>
   </div><!-- /.monograph-cover -->
   <div class="col-sm-9 monograph-metadata">
-    <h2><%= @monograph_presenter.title %></h2>
+    <h1><%= @monograph_presenter.title %></h1>
     <% if @monograph_presenter.authors? %>
-        <h3><%= render_markdown @monograph_presenter.authors %></h3>
+        <span class="authors"><%= render_markdown @monograph_presenter.authors %></span>
     <% end %>
     <% if @monograph_presenter.date_created? %>
     <span aria-label="publication date" class="pubdate"><%= @monograph_presenter.date_created.first %></span>

--- a/app/views/press_catalog/_document_gallery.html.erb
+++ b/app/views/press_catalog/_document_gallery.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index list view -%>
+<div id="documents" class="row gallery">
+  <%= render_gallery_collection documents %>
+</div>

--- a/app/views/press_catalog/_facets.html.erb
+++ b/app/views/press_catalog/_facets.html.erb
@@ -1,0 +1,19 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values?  %>
+<div id="facets" class="facets sidenav">
+
+  <div class="top-panel-heading panel-heading">
+    <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+      <span class="sr-only">Toggle facets</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+
+  </div>
+
+  <div id="facet-panel-collapse" class="collapse panel-group">
+    <%= render_facet_partials %>
+  </div>
+</div>
+<% end %>

--- a/app/views/press_catalog/_index_header_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_list_monograph.html.erb
@@ -3,25 +3,14 @@
 <div class="col-sm-9">
   <div class="row documentHeader">
     <div class="col-sm-12">
-      <h2 class="index_title">
+      <h3 class="index_title">
         <% counter = document_counter_with_offset(document_counter) %>
         <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
-      </h2>
+      </h3>
       <% if presenter.authors? %>
-        <h3><%= render_markdown presenter.authors %></h3>
+        <span class="authors"><%= render_markdown presenter.authors %></span>
       <% end %>
       <p><%= render_markdown document.description.first || '' %></p>
-    </div>
-  </div>
-
-  <div class="row featured-assets">
-    <div class="col-sm-3">
-    </div>
-    <div class="col-sm-3">
-    </div>
-    <div class="col-sm-3">
-    </div>
-    <div class="col-sm-3">
     </div>
   </div>
 

--- a/app/views/press_catalog/_press_results.html.erb
+++ b/app/views/press_catalog/_press_results.html.erb
@@ -1,5 +1,3 @@
-<h2>Books</h2>
-
 <% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
 
 <% content_for(:head) do -%>
@@ -7,8 +5,6 @@
   <%= rss_feed_link_tag %>
   <%= atom_feed_link_tag %>
 <% end %>
-
-<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
 
 <%- if @response.empty? %>
   <%= render "zero_results" %>

--- a/app/views/press_catalog/_thumbnail_list_monograph.html.erb
+++ b/app/views/press_catalog/_thumbnail_list_monograph.html.erb
@@ -3,7 +3,7 @@
   <% presenter = Hyrax::MonographPresenter.new(document, current_ability) %>
   <a href="<%= polymorphic_path(url_for_document(document)) %>" >
     <img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/225,/0/default.jpg"
-         alt="<%= presenter.representative_alt_text %>">
+         alt="Cover image for <%= presenter.representative_alt_text %>">
   </a>
 </div>
 <%- end %>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -1,6 +1,11 @@
 <% provide :page_title, @press.name %>
 <% provide :page_class, 'press' %>
-
 <div id="maincontent">
-  <%= render 'press_catalog/press_results' %>
+  <h2>Books</h2>
+  <div class="col-sm-3">
+    <%= render 'catalog/search_sidebar' %>
+  </div>
+  <div class="col-sm-9">
+    <%= render 'press_catalog/press_results' %>
+  </div>
 </div>

--- a/app/views/shared/_brand_press_jumbotron.html.erb
+++ b/app/views/shared/_brand_press_jumbotron.html.erb
@@ -1,5 +1,6 @@
 <!-- Main jumbotron for a primary heading image -->
     <div class="jumbotron">
+      <h1 class="sr-only"><%= @press.name %></h1>
       <div class="container">
         <% if @press.logo_path && !@press.new_record? %>
           <div class="logo pull-left">

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -61,13 +61,13 @@ feature 'Press Catalog' do
 
         expect(page).to have_link("View book materials", href: monograph_catalog_path(red, locale: 'en'))
         # thumbnail link
-        expect(page).to have_selector("img[alt='#{red.title[0]}']")
+        expect(page).to have_selector("img[alt='Cover image for #{red.title[0]}']")
         expect(page).to have_link('', href: monograph_catalog_path(red, locale: 'en'))
 
         # Selectors needed for assets/javascripts/ga_event_tracking.js
         # If these change, fix here then update ga_event_tracking.js
         expect(page).to have_selector('a.navbar-brand')
-        expect(page).to have_selector('#documents .document h2.index_title a')
+        expect(page).to have_selector('#documents .document h3.index_title a')
         expect(page).to have_selector('#documents .document a.btn.btn-default')
         expect(page).to have_selector('footer.press a')
         expect(page).to have_selector('#keyword-search-submit')


### PR DESCRIPTION
Resolves HELIO-1926

Adds filters to publisher catalog page.
Begins adding sort configs for publisher catalog page.
Fixes accessibility issues on monograph and publisher catalogs detailed in HELIO-1751 and modifies styles to maintain current display.