### PR TITLE
HELIO-1913 heb resque errors (Hyrax::GrantReadToMembersJob heliotrope…

### DIFF
--- a/app/jobs/hyrax/grant_read_to_members_job.rb
+++ b/app/jobs/hyrax/grant_read_to_members_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Grants read access for the supplied user for the members attached to a work
+  class GrantReadToMembersJob < ApplicationJob
+    queue_as Hyrax.config.ingest_queue_name
+
+    # @param [ActiveFedora::Base] work - the work object
+    # @param [String] user_key - the user to add
+    def perform(work, user_key)
+      # Iterate over ids because reifying objects is slow.
+      file_set_ids(work).each do |file_set_id|
+        # Call this synchronously, since we're already in a job
+        # Heliotrope:
+        # Now asynch (perform_later).
+        # In the context of mediated deposit approval, this and the also
+        # synchronous RevokeEditFromMembersJob throws occasional strange
+        # errors. HELIO-1913
+        GrantReadJob.perform_later(file_set_id, user_key)
+      end
+    end
+
+    private
+
+      # Filter the member ids and return only the FileSet ids (filter out child works)
+      # @return [Array<String>] the file set ids
+      def file_set_ids(work)
+        ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
+      end
+  end
+end

--- a/app/jobs/hyrax/revoke_edit_from_members_job.rb
+++ b/app/jobs/hyrax/revoke_edit_from_members_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Revokes edit access for the supplied user for the members attached to a work
+  class RevokeEditFromMembersJob < ApplicationJob
+    queue_as Hyrax.config.ingest_queue_name
+
+    # @param [ActiveFedora::Base] work - the work object
+    # @param [String] user_key - the user to remove
+    def perform(work, user_key)
+      # Iterate over ids because reifying objects is slow.
+      file_set_ids(work).each do |file_set_id|
+        # Heliotrope:
+        # Now asynch (perform_later).
+        # In the context of mediated deposit approval, this and the also
+        # synchronous GrantReadToMembersJob throws occasional strange
+        # errors. HELIO-1913
+        RevokeEditJob.perform_later(file_set_id, user_key)
+      end
+    end
+
+    private
+
+      # Filter the member ids and return only the FileSet ids (filter out child works)
+      # @return [Array<String>] the file set ids
+      def file_set_ids(work)
+        ::FileSet.search_with_conditions(id: work.member_ids).map(&:id)
+      end
+  end
+end

--- a/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
+++ b/spec/jobs/hyrax/grant_read_to_members_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::GrantReadToMembersJob do
+  let(:depositor) { create(:user) }
+  let(:work) { build(:monograph) }
+  let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:file_set_ids).with(work).and_return(file_set_ids)
+  end
+
+  it 'loops over FileSet IDs, spawning a job for each' do
+    file_set_ids.each do |file_set_id|
+      expect(Hyrax::GrantReadJob).to receive(:perform_later).with(file_set_id, depositor.user_key).once
+    end
+    described_class.perform_now(work, depositor.user_key)
+  end
+end

--- a/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
+++ b/spec/jobs/hyrax/revoke_edit_from_members_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::RevokeEditFromMembersJob do
+  let(:depositor) { create(:user) }
+  let(:work) { build(:monograph) }
+  let(:file_set_ids) { ['xyz123abc', 'abc789zyx'] }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:file_set_ids).with(work).and_return(file_set_ids)
+  end
+
+  it 'loops over FileSet IDs, spawning a job for each' do
+    file_set_ids.each do |file_set_id|
+      expect(Hyrax::RevokeEditJob).to receive(:perform_later).with(file_set_id, depositor.user_key).once
+    end
+    described_class.perform_now(work, depositor.user_key)
+  end
+end


### PR DESCRIPTION
… overrides)

I've approved 25 monographs on preview with no resque errors. This seems to work.