### PR TITLE
Integrate Shibboleth Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,51 +50,29 @@ For additional details and helpful hints [read our ever growing Wiki](https://gi
   * Install mysql ([Install MySQL OS X El Capitan](https://github.com/mlibrary/heliotrope/wiki/Install-MySQL-on-OS-X-El-Capitan))
 
 ## Initial setup
-### 1. Getting a local copy, running bundler, setting up Jekyll
+### 1. Getting a local copy, bundle install gems, and execute setup script
 
 ```
 $ git clone https://github.com/mlibrary/heliotrope.git
 $ cd heliotrope
 $ bundle install
 $ ./bin/bundle exec ./bin/setup
-$ ./bin/bundle exec ./bin/rails jekyll:deploy
 ```  
-See the [Wiki](https://github.com/mlibrary/heliotrope/wiki/Static-Pages-and-Blog) for more information on [Jekyll](https://jekyllrb.com/) integration.
+See the [Wiki](https://github.com/mlibrary/heliotrope/wiki/Static-Pages-and-Blog) for information on [Jekyll](https://jekyllrb.com/) integration.
 
 ### 2. Create users
 #### Make yourself a "platform" admin
-There is a rails task you can execute to create a "platform" admin user. It will prompt you for an email address and password, and then create a user with the correct role.
+There is a rails task you can execute to create a "platform" admin user. It will prompt you for an email address and then create a user with the correct role.
 ```
 $ ./bin/bundle exec ./bin/rails admin
-```
-
-If you forget your password, execute:
-```
-$ ./bin/bundle exec ./bin/rails passwd
 ```
 
 If you need to run this when the app has been deployed, execute:
 ```
 $ RAILS_ENV=production ./bin/bundle exec ./bin/rails admin
-$ RAILS_ENV=production ./bin/bundle exec ./bin/rails passwd
 ```
 
-### 3. Give yourself an admin role
-Edit `./config/role_map.yml` and set the e-mail address you registered with as an admin.
-
-```
-$ vi ./config/role_map.yml
-```
-```
-development:
-  admin:   
-    - yourself@domain.com
-  archivist:
-    - archivist1@example.com
-...
-```
-
-### 4. Run the application
+### 3. Run the application
 
 Execute this command to start Fedora, Solr and Rails servers:
 ```
@@ -116,7 +94,7 @@ $ fcrepo_wrapper --config .wrap_conf/fcrepo_dev
 $ solr_wrapper --config .wrap_conf/solr_dev
 ```
 
-### 5. Create [default administrative set](https://github.com/samvera/hyrax#create-default-administrative-set)
+### 4. Create [default administrative set](https://github.com/samvera/hyrax#create-default-administrative-set)
 ```
 $ ./bin/bundle exec ./bin/rails hyrax:default_admin_set:create
 ```

--- a/app/assets/javascripts/idpselect/idpselect_config.js
+++ b/app/assets/javascripts/idpselect/idpselect_config.js
@@ -3,18 +3,19 @@ function IdPSelectUIParms(){
     //
     // Adjust the following to fit into your local configuration
     //
-    this.alwaysShow = true;          // If true, this will show results as soon as you start typing
-    this.dataSource = 'https://quod.lib.umich.edu/Shibboleth.sso/DiscoFeed';   // Where to get the data from
-    this.defaultLanguage = 'en';     // Language to use if the browser local doesnt have a bundle
-    this.defaultLogo = '';  // Replace with your own logo
+    this.alwaysShow = true;                     // If true, this will show results as soon as you start typing
+    this.dataSource = '/Shibboleth.sso/DiscoFeed';  // Where to get the data from
+    this.defaultLanguage = 'en';                // Language to use if the browser local doesnt have a bundle
+    this.defaultLogo = '';                      // Replace with your own logo
     this.defaultLogoWidth = 1;
     this.defaultLogoHeight = 1;
     this.defaultReturn = null;       // If non null, then the default place to send users who are not
                                      // Approaching via the Discovery Protocol for example
     //this.defaultReturn = "https://example.org/Shibboleth.sso/DS?SAMLDS=1&target=https://example.org/secure";
     this.defaultReturnIDParam = null;
-    this.helpURL = 'http://its.umich.edu/accounts-access/uniqnames-passwords/shibboleth';
-    this.ie6Hack = null;             // An array of structures to disable when drawing the pull down (needed to 
+    //this.helpURL = 'http://its.umich.edu/accounts-access/uniqnames-passwords/shibboleth';
+    this.helpURL = '/Shibboleth.sso/Help';
+    this.ie6Hack = null;             // An array of structures to disable when drawing the pull down (needed to
                                      // handle the ie6 z axis problem
     this.insertAtDiv = 'idpSelect';  // The div where we will insert the data
     this.maxResults = 10;            // How many results to show at once or the number at which to

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,9 +22,10 @@ class SessionsController < ApplicationController
 
   def destroy
     Rails.logger.debug "[AUTHN] sessions#destroy, user sign out"
+    redirect_to_url = stored_location_for(:user)
     user_sign_out
     ENV['FAKE_HTTP_X_REMOTE_USER'] = '(null)'
     sign_out_static_cookie
-    redirect_to root_url
+    redirect_to redirect_to_url || root_url
   end
 end

--- a/app/controllers/shibboleths_controller.rb
+++ b/app/controllers/shibboleths_controller.rb
@@ -2,142 +2,18 @@
 
 class ShibbolethsController < CheckpointController
   def discofeed
-    json_disco_feed = <<~eos
-      [
-        {
-         "entityID": "https://shibboleth.umich.edu/idp/shibboleth",
-         "DisplayNames": [
-          {
-          "value": "University of Michigan",
-          "lang": "en"
-          }
-         ],
-         "Descriptions": [
-          {
-          "value": "The University of Michigan",
-          "lang": "en"
-          }
-         ],
-         "InformationURLs": [
-          {
-          "value": "http://www.umich.edu/",
-          "lang": "en"
-          }
-         ],
-         "PrivacyStatementURLs": [
-          {
-          "value": "http://documentation.its.umich.edu/node/262/",
-          "lang": "en"
-          }
-         ],
-         "Logos": [
-          {
-          "value": "https://shibboleth.umich.edu/images/StackedBlockM-InC.png",
-          "height": "150",
-          "width": "300",
-          "lang": "en"
-          }
-         ]
-        },
-        {
-         "entityID": "https://sso.mtu.edu/idp/shibboleth",
-         "DisplayNames": [
-          {
-          "value": "Michigan Technological University",
-          "lang": "en"
-          }
-         ],
-         "PrivacyStatementURLs": [
-          {
-          "value": "http://www.mtu.edu/policy/policies/general/1-06/index.html",
-          "lang": "en"
-          }
-         ],
-         "Logos": [
-          {
-          "value": "https://www.mtu.edu/it/images/it-support-banner.png",
-          "height": "70",
-          "width": "332",
-          "lang": "en"
-          }
-         ]
-        },
-        {
-         "entityID": "urn:mace:incommon:msu.edu",
-         "DisplayNames": [
-          {
-          "value": "Michigan State University",
-          "lang": "en"
-          }
-         ]
-        },
-        {
-         "entityID": "https://registry.shibboleth.ox.ac.uk/idp",
-         "DisplayNames": [
-          {
-          "value": "University of Oxford",
-          "lang": "en"
-          }
-         ]
-        },
-        {
-         "entityID": "https://idp-test.shibboleth.ox.ac.uk/shibboleth-idp",
-         "DisplayNames": [
-          {
-          "value": "University of Oxford Test IdP",
-          "lang": "en"
-          }
-         ],
-         "Descriptions": [
-          {
-          "value": "University of Oxford Test IdP",
-          "lang": "en"
-          }
-         ]
-        },
-      {
-         "entityID": "https://idp.wmich.edu/idp/shibboleth",
-         "DisplayNames": [
-          {
-          "value": "Western Michigan University",
-          "lang": "en"
-          }
-         ],
-         "Descriptions": [
-          {
-          "value": "Western Michigan University",
-          "lang": "en"
-          }
-         ],
-         "InformationURLs": [
-          {
-          "value": "http://www.wmich.edu/",
-          "lang": "en"
-          }
-         ],
-         "PrivacyStatementURLs": [
-          {
-          "value": "http://www.wmich.edu/it/policies/",
-          "lang": "en"
-          }
-         ],
-         "Logos": [
-          {
-          "value": "https://idp.wmich.edu/idp/images/w_logo.png",
-          "height": "150",
-          "width": "172",
-          "lang": "en"
-          }
-         ]
-        }
-      ]
-    eos
-    obj_disco_feed = JSON.parse(json_disco_feed)
-    render json: obj_disco_feed
-    # redirect_to "#{Rails.configuration.shibboleth_service_provider_url}/DiscoFeed"
+    flag = true
+    obj_disco_feed = JSON.parse(HTTParty.get("https://heliotrope-testing.hydra.lib.umich.edu/Shibboleth.sso/DiscoFeed").body)
+    if flag
+      obj_filtered_disco_feed = obj_disco_feed
+    else
+      obj_filtered_disco_feed = []
+      obj_disco_feed.each do |entry|
+        obj_filtered_disco_feed << entry if entry["entityID"] == "https://shibboleth.umich.edu/idp/shibboleth"
+      end
+    end
+    render json: obj_filtered_disco_feed
   end
-
-  def ds; end
 
   def help; end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :registerable, :recoverable, :rememberable, :trackable, :validatable
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable
+  # devise :database_authenticatable
 
   # Use the http header as auth.  This app will be behind a reverse proxy
   #   that will take care of the authentication.
@@ -30,10 +30,11 @@ class User < ApplicationRecord
                     model: 'devise/models/http_header_authenticatable')
 
   # Add our custom module to devise.
-  devise :http_header_authenticatable
+  devise :rememberable, :http_header_authenticatable
 
   def populate_attributes
     # TODO: Override this for HttpHeaderAuthenticatable
+    # Rails.logger.info "session[:identity] = #{session[:identity]}"
   end
 
   alias_attribute :user_key, :email
@@ -93,8 +94,7 @@ class User < ApplicationRecord
   end
 
   def tokenize!
-    self.password = SecureRandom.urlsafe_base64(12)
-    self.password_confirmation = password
+    self.encrypted_password = SecureRandom.urlsafe_base64(12)
     save!
   end
 

--- a/app/views/e_pubs/access.html.erb
+++ b/app/views/e_pubs/access.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
+
 <% provide :page_title, @title || "Access Restricted to #{@monograph_presenter.title}" %>
 <div class="alert alert-danger">
   <p class="text-center"><em><%= @monograph_presenter.title %></em> is a restricted access online resource. <%= link_to 'Go back to previous page', :back %>.</p>
@@ -49,18 +53,26 @@
             </ul>
           <% end %>
           <p>You may attempt to login at the appropriate institution.</p>
-          <p class="text-center">
-            <%= form_tag(epub_shibboleth_path(@presenter.id), method: :post) do %>
-              <select id="institution_id" name="institution_id">
-                <% @institutions.each do |institution| %>
-                  <% if institution.shibboleth? %>
-                    <option value=<%= institution.id %>><%= institution.name %></option>
-                  <% end %>
-                <% end %>
-              </select>
-              <button type="submit">Login</button>
-            <% end %>
-          </p>
+          <div id="idpSelect" class="panel-body"></div>
+          <script>
+            idSelectUIParms = new IdPSelectUIParms();
+            idSelectUIParms.defaultLogo = '<%= asset_path('fulcrum-logo.png') %>';
+            idSelectUIParms.defaultLogoWidth = 8;
+            idSelectUIParms.defaultLogoHeight = 16;
+            <%
+              target = if @monograph_presenter.present?
+                         monograph_catalog_url(@monograph_presenter.id)
+                       else
+                         hyrax_file_set_url(@presenter.id)
+                       end.gsub!(/\?locale=.*/, '')
+            %>
+            idSelectUIParms.defaultReturn = '<%= URI.join(root_url, 'Shibboleth.sso/', 'Login') %>?target=<%= target %>';
+            idSelectUIParms.myEntityID = '<%= Rails.configuration.shibboleth_identity_provider_url %>';
+            idSelectUIParms.preferredIdP = ['<%= Rails.configuration.shibboleth_identity_provider_url %>'];
+            idSelectUIParms.ignoreURLParams = true; // TODO: Figure out why this is needed, or what needs to be fixed to remove it.
+            // idSelectUIParms.testGUI = true;
+            (new IdPSelectUI()).draw(idSelectUIParms);
+          </script>
           <p>For other institutions.<p>
           <ul>
             <% @institutions.each do |institution| %>
@@ -88,41 +100,5 @@
         </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-3"></div>
-    <div class="col-sm-6">
-      <div class="panel panel-danger">
-        <div class="panel-heading">
-          <h3 class="panel-title">Federation</h3>
-        </div>
-        <div id="idpSelect" class="panel-body"></div>
-        <script>
-          idSelectUIParms = new IdPSelectUIParms();
-
-          idSelectUIParms.dataSource = '/shibboleth/discofeed';
-          //idSelectUIParms.dataSource = '<%= Rails.configuration.shibboleth_service_provider_url %>/DiscoFeed';
-
-          idSelectUIParms.defaultLogo = '<%= asset_path('fulcrum-logo.png') %>';
-          idSelectUIParms.defaultLogoWidth = 8;
-          idSelectUIParms.defaultLogoHeight = 16;
-
-          //idSelectUIParms.defaultReturn = '<%= ds_shibboleth_url %>?target=<%= epub_shibboleth_path(@presenter.id) %>';
-          idSelectUIParms.defaultReturn = '<%= Rails.configuration.shibboleth_service_provider_url %>?target=<%= epub_shibboleth_path(@presenter.id) %>';
-
-          idSelectUIParms.helpURL = '<%= help_shibboleth_url %>';
-
-          //idSelectUIParms.myEntityID = 'https://shibboleth.umich.edu/idp/shibboleth';
-          idSelectUIParms.myEntityID = 'https://shib-idp-test.www.umich.edu/idp/shibboleth';
-
-          //idSelectUIParms.preferredIdP = ['https://shibboleth.umich.edu/idp/shibboleth'];
-          idSelectUIParms.preferredIdP = ['https://shib-idp-test.www.umich.edu/idp/shibboleth'];
-
-          idSelectUIParms.testGUI = true;
-          (new IdPSelectUI()).draw(idSelectUIParms);
-        </script>
-      </div>
-    </div>
-    <div class="col-sm-3"></div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module Heliotrope
     Rails.application.routes.default_url_options[:host] = config.hostname
 
     # URL for logging the user in via shibbolleth
-    config.shibboleth_service_provider_url = Settings.shibboleth_service_provider_url
+    config.shibboleth_identity_provider_url = Settings.shibboleth_identity_provider_url
 
     # Disable automatic account creation on Cosign logins unless
     # enabled in config/settings.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,14 +62,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :shibboleth, only: [] do
-    member do
-      get :discofeed
-      get :ds
-      get :help
-    end
-  end
-
   get 'epubs/:id', controller: :e_pubs, action: :show, as: :epub
   post 'epubs/:id/shibboleth', controller: :e_pubs, action: :shibboleth, as: :epub_shibboleth
   get 'epubs/:id/*file', controller: :e_pubs, action: :file, as: :epub_file
@@ -101,8 +93,16 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users, path: '', path_names: { sign_in: 'login', sign_out: 'logout' }, controllers: { sessions: 'sessions' }, skip: %i[registration password]
+  devise_for :users, path: '', controllers: { sessions: 'sessions' }
+  get 'login', controller: :sessions, action: :new, as: :new_user_session
+  get 'logout', controller: :sessions, action: :destroy, as: :destroy_user_session
   resource :authentications, only: %i[new create destroy]
+
+  unless /^production$/i.match?(Rails.env)
+    get 'Shibboleth.sso/DiscoFeed', controller: :shibboleths, action: :discofeed
+    get 'Shibboleth.sso/Help', controller: :shibboleths, action: :help
+    get 'Shibboleth.sso/Login', controller: :sessions, action: :new
+  end
 
   get 'users', controller: :users, action: :index, as: :users
   get 'users/:id', controller: :users, action: :show, as: :user

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,8 +8,7 @@ uploads_path: <%= File.join(Rails.root, 'tmp', 'uploads') %>
 minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
 resque_namespace: heliotrope-development
 host: localhost:3000
-# shibboleth_service_provider_url: "https://quod.lib.umich.edu/Shibboleth.sso"
-shibboleth_service_provider_url: "https://quod.lib.umich.edu/Shibboleth.sso"
+shibboleth_identity_provider_url: "https://shibboleth.umich.edu/idp/shibboleth"
 
 # Should we create users automatically on first login?
 # This supports convenient single sign-on account provisioning

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -8,8 +8,7 @@ uploads_path: <%= File.join(Rails.root, 'tmp', 'uploads') %>
 minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
 resque_namespace: heliotrope-testing
 host: test.host
-# shibboleth_service_provider_url: "https://quod.lib.umich.edu/Shibboleth.sso"
-shibboleth_service_provider_url: ""
+shibboleth_identity_provider_url: ""
 
 # Should we create users automatically on first login?
 # This supports convenient single sign-on account provisioning

--- a/lib/tasks/roles.rake
+++ b/lib/tasks/roles.rake
@@ -35,8 +35,8 @@ end
 
 def prompt_to_create_user
   User.find_or_create_by!(email: prompt_for_email) do |u|
-    puts 'User not found. Enter a password to create the user.'
-    u.password = prompt_for_password
+    # puts 'User not found. Enter a password to create the user.'
+    # u.password = prompt_for_password
   end
 rescue => e
   puts e

--- a/ruumba/.ruumba.yml
+++ b/ruumba/.ruumba.yml
@@ -9,13 +9,19 @@ AllCops:
 # begin unapplicable cops
 Style/FrozenStringLiteralComment:
   Enabled: false
+
 Layout/AlignHash:
   Enabled: false
 Layout/AlignParameters:
   Enabled: false
+Layout/ElseAlignment:
+  Enabled: false
 Layout/IndentationWidth:
   Enabled: false
 Layout/TrailingBlankLines:
+  Enabled: false
+
+Lint/EndAlignment:
   Enabled: false
 # end unapplicable cops
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe SessionsController, type: :controller do
     end
   end
 
-  describe '#create' do
-    subject { post :create }
-
-    it { is_expected.to have_http_status(:bad_request) }
-  end
-
   describe '#destroy' do
     subject { get :destroy }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     end
 
     sequence(:email) { |_n| "email-#{srand}@test.com" }
-    password 'a password'
-    password_confirmation 'a password'
+
+    encrypted_password { SecureRandom.urlsafe_base64(12) }
 
     factory :platform_admin do
       after(:create) do |user, _evaluator|

--- a/spec/features/sign_in_out_spec.rb
+++ b/spec/features/sign_in_out_spec.rb
@@ -63,7 +63,7 @@ feature 'Log In and Out' do
       expect(page).to have_current_path(hyrax_file_set_path(file_set))
     end
 
-    scenario "logging out goes to root page" do
+    scenario "logging out goes to that asset page" do
       cosign_login_as user
       visit hyrax_file_set_path(file_set)
 
@@ -71,7 +71,7 @@ feature 'Log In and Out' do
         click_link "Log Out"
       end
 
-      expect(page).to have_current_path(main_app.root_path(locale: 'en'))
+      expect(page).to have_current_path(hyrax_file_set_path(file_set))
     end
   end
 end


### PR DESCRIPTION
Integrated Shibboleth and removed devise :database_authenticatable and added devise :rememberable which explicit leaves only devise :http_header_authenticatable for authentication.  Rememberable should remember if a session has been authenticated.
A request was made to A&E to reconfigure heliotrope-testing to use Shibboleth only (a.k.a. remove CoSign configuration).   As it is now they both exist and CoSign is being used for login authentication.

This branch was deployed to heliotrope-testing and publisher heliotrope has a restricted EPUB.