### PR TITLE
Style publisher filters and gallery view

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -188,6 +188,7 @@ footer.press {
   // Gallery View (Default)
   .results-container {
     padding-left: 3em;
+    margin-top: -2.75em;
 
     #sortAndPerPage, .pagination-search-widgets {
       border-bottom: none;
@@ -204,13 +205,14 @@ footer.press {
       border-bottom: none;
       margin-top: 0px;
       padding-top: 0px;
+      padding-bottom: 3em;
 
       .thumbnail {
         text-align: left;
         border: none;
         border-radius: 0px;
         padding: 0px;
-        margin-bottom: 1.5em;
+        margin-bottom: 0px;
 
         a > img {
           margin-left: 0;

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -16,6 +16,15 @@
 .u-screenreader--ignore {
   speak: none;
 }
+
+:focus,
+.btn-group > .btn:focus {
+  outline: 3px solid #00AFEC;
+  outline-offset: 0;
+  -webkit-transition: outline .05s ease-out;
+  -o-transition: outline .05s ease-out;
+  transition: outline .05s ease-out;
+}
 ///////////////////////////////////
 // COLORS
 ///////////////////////////////////
@@ -150,6 +159,7 @@ footer.press {
 }
 .press {
 
+  // List View
   #documents.documents-list {
 
     .document {
@@ -173,6 +183,82 @@ footer.press {
 
     }
 
+  }
+
+  // Gallery View (Default)
+  .results-container {
+    padding-left: 3em;
+
+    #sortAndPerPage, .pagination-search-widgets {
+      border-bottom: none;
+      margin-bottom: 0em;
+      padding-bottom: 4em;
+    }
+
+  }
+
+  #documents.gallery {
+
+    .document {
+      border-top: none;
+      border-bottom: none;
+      margin-top: 0px;
+      padding-top: 0px;
+
+      .thumbnail {
+        text-align: left;
+        border: none;
+        border-radius: 0px;
+        padding: 0px;
+        margin-bottom: 1.5em;
+
+        a > img {
+          margin-left: 0;
+          margin-right: 0;
+        }
+
+        .caption {
+          padding: 0px;
+
+          h3.index_title {
+            font-size: 16px;
+          }
+
+          .authors {
+            font-size: 13px;
+          }
+
+          .col-sm-12 {
+            padding: 0px;
+          }
+        }
+      }
+    }
+
+  }
+}
+///////////////////////////////////
+// PRESS AND MONOGRAPH FILTERS
+///////////////////////////////////
+.col-sm-3.facets-container,
+#facet-panel-collapse {
+  padding-left: 0px;
+}
+.facets-container {
+  .panel-group {
+    padding-left: 0px;
+  }
+
+  .panel-group .panel {
+    border-radius: 0px;
+  }
+
+  .panel-heading {
+    padding-top: 15px;
+  }
+
+  .panel-group .panel + .panel {
+    margin-top: 0px;
   }
 }
 ///////////////////////////////////

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -169,13 +169,50 @@ $heb-black-80: #342f2e;
 
   }
 
+
   .press {
 
     .document,
     .documentHeader {
       margin-bottom: 2em;
     }
+
   }
+
+  //filters on press and monograph pages
+  .col-sm-3.facets-container {
+    padding-left: 0px;
+  }
+
+  .panel-group {
+    padding-left: 0px;
+  }
+
+  .panel-group .panel {
+    border-radius: 0px;
+  }
+
+  .panel-heading {
+    padding-top: 15px;
+  }
+
+  .panel-group .panel + .panel {
+    margin-top: 0px;
+  }
+
+  h3.panel-title a, a.more_facets_link {
+    color: #333;
+  }
+
+  .panel-heading.collapse-toggle .panel-title::after {
+    color: #333;
+  }
+
+  .panel-body {
+    background-color: #fafafa;
+  }
+
+
 
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -218,8 +218,23 @@ $heb-black-80: #342f2e;
   }
 
   // sorts on press and monograph pages
-  #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
+  #sort-dropdown .dropdown-toggle,
+  #per_page-dropdown .dropdown-toggle {
     color: $heb-white;
+  }
+
+  #sort-dropdown .dropdown-toggle:hover,
+  #per_page-dropdown .dropdown-toggle:hover,
+  #sort-dropdown .dropdown-toggle:active,
+  #per_page-dropdown .dropdown-toggle:active {
+    color: $heb-brand-color;
+  }
+
+  .constraints-container {
+    padding: 10px 20px;
+    border-radius: 0px;
+    -webkit-box-shadow: none;
+    box-shadow: none;
   }
 
   // pagination
@@ -232,12 +247,33 @@ $heb-black-80: #342f2e;
        color: $heb-white;
      }
 
+     li>a:hover,
+     li>a:focus,
+     li>span:hover,
+     li>span:focus {
+       background-color: $heb-grey-4;
+       border-color: $heb-grey-4;
+       color: $heb-brand-color;
+     }
+
+
      .active>a,
      .active>a:hover,
      .active>a:focus,
      .active>span,
      .active>span:hover,
      .active>span:focus {
+       background-color: $heb-grey-4;
+       border-color: $heb-grey-4;
+       color: $heb-brand-color;
+     }
+
+     .disabled>span,
+     .disabled>span:hover,
+     .disabled>span:focus,
+     .disabled>a,
+     .disabled>a:hover,
+     .disabled>a:focus {
        background-color: $heb-grey-4;
        border-color: $heb-grey-4;
        color: $heb-brand-color;

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -97,8 +97,8 @@ $heb-black-80: #342f2e;
 
   .btn-default:hover,
   .btn-default:active {
-    @include button-hover-background-color($heb-grey-2);
-    @include button-hover-font-color($heb-link);
+    @include button-hover-background-color($heb-grey-4);
+    @include button-hover-font-color($heb-brand-color);
   }
 
   // navigation menu
@@ -169,18 +169,23 @@ $heb-black-80: #342f2e;
 
   }
 
-
   .press {
+    .results-container {
 
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
+      .documentHeader {
+        h3 {
+          font-weight: 600;
+        }
+        a {
+          color: #333;
+        }
+      }
     }
-
   }
 
   //filters on press and monograph pages
-  .col-sm-3.facets-container {
+  .col-sm-3.facets-container,
+  #facet-panel-collapse {
     padding-left: 0px;
   }
 
@@ -212,9 +217,7 @@ $heb-black-80: #342f2e;
     background-color: #fafafa;
   }
 
-
-
-  // monograph catalog
+  // sorts on press and monograph pages
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $heb-white;
   }
@@ -223,7 +226,10 @@ $heb-black-80: #342f2e;
 
   .pagination {
      li a, li span {
-       color: $heb-brand-color;
+
+       background-color: $heb-brand-color;
+       border-color: $heb-brand-color;
+       color: $heb-white;
      }
 
      .active>a,
@@ -232,9 +238,9 @@ $heb-black-80: #342f2e;
      .active>span,
      .active>span:hover,
      .active>span:focus {
-       background-color: $heb-brand-color;
-       border-color: $heb-brand-color;
-       color: $heb-white;
+       background-color: $heb-grey-4;
+       border-color: $heb-grey-4;
+       color: $heb-brand-color;
      }
   }
 
@@ -441,14 +447,6 @@ $iu-midnight: #006298;
 
   }
 
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $iu-darkmidnight;
@@ -460,6 +458,10 @@ $iu-midnight: #006298;
       p {
         @include georgia-pro;
       }
+    }
+
+    .authors, .copyright {
+      @include benton-bold;
     }
   }
 
@@ -654,14 +656,6 @@ $um-black-80: #342f2e;
 
   }
 
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $um-blue;
@@ -673,6 +667,10 @@ $um-black-80: #342f2e;
       p {
         @include meta;
       }
+    }
+
+    .authors, .copyright {
+      @include meta;
     }
   }
 
@@ -912,14 +910,6 @@ $gabii-link-hover:    #1e5667;
     font-size: 18px;
   }
 
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $gabii-white;
@@ -939,6 +929,10 @@ $gabii-link-hover:    #1e5667;
       p {
         @include garamond;
       }
+    }
+
+    .authors, .copyright {
+      @include lato;
     }
 
     .message {
@@ -1269,15 +1263,6 @@ $umn-white: #fff;
 
   }
 
-  .press {
-
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $umn-accent-link;
@@ -1289,6 +1274,10 @@ $umn-white: #fff;
       p {
         @include brandon;
       }
+    }
+
+    .authors, .copyright {
+      @include brandon;
     }
   }
 
@@ -1490,14 +1479,6 @@ $fulcrum-light-2: #bec4cc;
 
   }
 
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $nw-purple-60;
@@ -1510,6 +1491,10 @@ $fulcrum-light-2: #bec4cc;
       p {
         @include freight-sans-book;
       }
+    }
+
+    .authors, .copyright {
+      @include freight-sans-semi-bold;
     }
 
     // pagination
@@ -1729,14 +1714,6 @@ $nyu-gray-2: #342f2e;
 
     }
 
-  }
-
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
   }
 
   // monograph catalog
@@ -2015,20 +1992,16 @@ $psu-gray-1: #3F4550;
 
   }
 
-  .press {
-
-    .document,
-    .documentHeader {
-      margin-bottom: 2em;
-    }
-  }
-
   // monograph
   .monograph {
     .documentHeader {
       p {
         @include proxima-nova;
       }
+    }
+
+    .authors, .copyright {
+      @include proxima-nova;
     }
   }
 

--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -9,17 +9,15 @@ class MonographCatalogController < ::CatalogController
   configure_blacklight do |config|
     config.search_builder_class = MonographSearchBuilder
 
-    up_arrow = "\u25B2"
-    down_arrow = "\u25BC"
-
     config.default_per_page = 20
-    config.add_sort_field 'relevance', sort: "score desc, monograph_position_isi asc", label: "Relevance #{down_arrow}"
-    config.add_sort_field 'section asc', sort: "monograph_position_isi asc", label: "Section #{up_arrow}"
-    config.add_sort_field 'section desc', sort: "monograph_position_isi desc", label: "Section #{down_arrow}"
-    config.add_sort_field 'format asc', sort: "#{solr_name('resource_type', :sortable)} asc, monograph_position_isi asc", label: "Format #{up_arrow}"
-    config.add_sort_field 'format desc', sort: "#{solr_name('resource_type', :sortable)} desc, monograph_position_isi asc", label: "Format #{down_arrow}"
-    config.add_sort_field 'year asc', sort: "#{solr_name('search_year', :sortable)} asc, monograph_position_isi asc", label: "Year #{up_arrow}"
-    config.add_sort_field 'year desc', sort: "#{solr_name('search_year', :sortable)} desc, monograph_position_isi asc", label: "Year #{down_arrow}"
+    config.add_sort_field 'relevance', sort: "score desc, monograph_position_isi asc", label: "Relevance"
+    config.add_sort_field 'section asc', sort: "monograph_position_isi asc", label: "Section (Earliest First)"
+    config.add_sort_field 'section desc', sort: "monograph_position_isi desc", label: "Section (Last First)"
+    # leaving the #{uploaded_field} desc in these for section sort when all else is equal
+    config.add_sort_field 'format asc', sort: "#{solr_name('resource_type', :sortable)} asc, monograph_position_isi asc", label: "Format (A-Z)"
+    config.add_sort_field 'format desc', sort: "#{solr_name('resource_type', :sortable)} desc, monograph_position_isi asc", label: "Format (Z-A)"
+    config.add_sort_field 'year asc', sort: "#{solr_name('search_year', :sortable)} asc, monograph_position_isi asc", label: "Year (Oldest First)"
+    config.add_sort_field 'year desc', sort: "#{solr_name('search_year', :sortable)} desc, monograph_position_isi asc", label: "Year (Newest First)"
 
     config.facet_fields.tap do
       # solr facet fields not to be displayed in the index (search results) view

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -27,6 +27,7 @@ class PressCatalogController < ::CatalogController
       config.facet_fields.delete('press_name_ssim')
       config.facet_fields.delete('subject_sim')
       config.facet_fields.delete('creator_full_name_sim')
+      config.facet_fields.delete('based_near_sim')
     end
 
     config.add_facet_field solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -39,12 +39,12 @@
     <div class="col-sm-6">
       <div class="row asset-attributes">
         <div class="col-sm-12">
-          <h2 id="asset-title"><%= @presenter.title %></h2>
-          <h3>From <em><%= link_to @presenter.monograph.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
+          <h1 id="asset-title"><%= @presenter.title %></h1>
+          <span>From <em><%= link_to @presenter.monograph.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
             <% if @presenter.monograph.authors? %>
               by <%= render_markdown @presenter.monograph.authors %>
             <% end %>
-          </h3>
+          </span>
           <br />
           <%= render "attributes", presenter: @presenter %>
         </div>

--- a/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
@@ -1,7 +1,10 @@
 <% presenter = Hyrax::PresenterFactory.build_for(ids: [document.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first %>
 <div class="document col-xs-6 col-md-4">
   <div class="thumbnail">
-    <%= render_thumbnail_tag(document, {alt: presenter.representative_alt_text}, :counter => document_counter_with_offset(document_counter)) %>
+    <a href="<%= polymorphic_path(url_for_document(document)) %>" >
+      <img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/145,/0/default.jpg"
+           alt="Cover image for <%= presenter.representative_alt_text %>">
+    </a>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
       <p class="authors"><%= presenter.authors %></p>

--- a/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
@@ -1,10 +1,10 @@
 <% presenter = Hyrax::PresenterFactory.build_for(ids: [document.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first %>
-<div class="document col-xs-6 col-md-3">
+<div class="document col-xs-6 col-md-4">
   <div class="thumbnail">
     <%= render_thumbnail_tag(document, {alt: presenter.representative_alt_text}, :counter => document_counter_with_offset(document_counter)) %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
-      <p><%= presenter.authors %></p>
+      <p class="authors"><%= presenter.authors %></p>
     </div>
   </div>
 </div>

--- a/app/views/press_catalog/_index_header_gallery_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_gallery_monograph.html.erb
@@ -1,8 +1,8 @@
 <% # header bar for doc items in index view -%>
 <div class="col-sm-12">
   <div class="documentHeader">
-    <h4 class="index_title">
+    <h3 class="index_title">
       <% counter = document_counter_with_offset(document_counter) %>
       <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
-    </h4>
+    </h3>
   </div>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -5,7 +5,7 @@
   <div class="col-sm-3 facets-container">
     <%= render 'catalog/search_sidebar' %>
   </div>
-  <div class="col-sm-9">
+  <div class="col-sm-9 results-container">
     <%= render 'catalog/search_results' %>
   </div>
 </div>

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -2,7 +2,7 @@
 <% provide :page_class, 'press' %>
 <div id="maincontent">
   <h2>Books</h2>
-  <div class="col-sm-3">
+  <div class="col-sm-3 facets-container">
     <%= render 'catalog/search_sidebar' %>
   </div>
   <div class="col-sm-9">

--- a/spec/features/monograph_catalog_sort_spec.rb
+++ b/spec/features/monograph_catalog_sort_spec.rb
@@ -12,8 +12,6 @@ feature 'Monograph catalog sort' do
     let(:monograph) { create(:monograph, user: user, title: ['Polka Dots'], representative_id: cover.id) }
     let(:per_page) { 2 }
     let(:fileset_count) { per_page + 1 } # ensure pagination
-    let(:up_arrow) { "\u25B2" }
-    let(:down_arrow) { "\u25BC" }
     let(:expected_ordered_members) { monograph.ordered_members.to_ary }
 
     before do
@@ -41,32 +39,32 @@ feature 'Monograph catalog sort' do
       expect(first_fileset_link_text).to eq expected_ordered_members[1].title.first
 
       # this control is styled as a drop-down but is actually a button & list, hence click_link not select
-      click_link "Section #{down_arrow}"
+      click_link "Section (Last First)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # ordered_members go from 0 to fileset_count + 1, descending so last is shown first
       expect(first_fileset_link_text).to eq expected_ordered_members[fileset_count + 1].title.first
 
-      click_link "Section #{up_arrow}"
+      click_link "Section (Earliest First)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # essentially default sort, sans score, ascending so first is shown first
       expect(first_fileset_link_text).to eq expected_ordered_members[1].title.first
 
-      click_link "Format #{down_arrow}"
+      click_link "Format (Z-A)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # highest resource_type is the fileset_outlier, second ordered member, set to 'video' above
       expect(first_fileset_link_text).to eq expected_ordered_members[1].title.first
 
-      click_link "Format #{up_arrow}"
+      click_link "Format (A-Z)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # lowest resource_type is the 3rd ordered member (first using the audio sequence, should be set to 'audio0001')
       expect(first_fileset_link_text).to eq expected_ordered_members[2].title.first
 
-      click_link "Year #{down_arrow}"
+      click_link "Year (Newest First)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # highest year is the fileset_outlier, second ordered member [0, 1,... ], manually set to '2000' above
       expect(first_fileset_link_text).to eq expected_ordered_members[1].title.first
 
-      click_link "Year #{up_arrow}"
+      click_link "Year (Oldest First)"
       first_fileset_link_text = page.first('.documentHeader .index_title a').text
       # lowest year is the third ordered member, the first to use the factory's sequence and set to '1900'
       expect(first_fileset_link_text).to eq expected_ordered_members[2].title.first

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -71,7 +71,7 @@ feature 'Press Catalog' do
         # Selectors needed for assets/javascripts/ga_event_tracking.js
         # If these change, fix here then update ga_event_tracking.js
         expect(page).to have_selector('a.navbar-brand')
-        expect(page).to have_selector('#documents .document h4.index_title a')
+        expect(page).to have_selector('#documents .document h3.index_title a')
         expect(page).to have_selector('footer.press a')
         expect(page).to have_selector('#keyword-search-submit')
         expect(page).to have_selector('#catalog_search')

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -11,7 +11,7 @@ feature 'Press Catalog' do
 
   context 'a user who is not logged in' do
     context 'with monographs for different presses' do
-      let(:red_cover_alt_text) { ["The cover of The Red Book"] }
+      let(:red_cover_alt_text) { ["The Red Book"] }
       let(:red_cover) { create(:public_file_set, alt_text: red_cover_alt_text) }
       let!(:red) { create(:public_monograph, title: ['The Red Book'], representative_id: red_cover.id, press: umich.subdomain) }
       let!(:blue) { create(:public_monograph, title: ['The Blue Book'], press: umich.subdomain) }
@@ -65,7 +65,7 @@ feature 'Press Catalog' do
         expect(page).to_not have_link colors.title.first
 
         # thumbnail link
-        expect(page).to have_selector("img[alt='#{red_cover_alt_text.first}']")
+        expect(page).to have_selector("img[alt='Cover image for #{red_cover_alt_text.first}']")
         expect(page).to have_link('', href: monograph_catalog_path(red, locale: 'en'))
 
         # Selectors needed for assets/javascripts/ga_event_tracking.js


### PR DESCRIPTION
Resolves [HELIO-1934](https://tools.lib.umich.edu/jira/browse/HELIO-1934)

Makes style and markup changes to the publisher filters and gallery views for books; adds a few accessibility fixes that were discovered during VPAT assessment.

This branch is currently deployed to staging if you'd like to take a look:

https://heliotrope-staging.hydra.lib.umich.edu/heb
https://heliotrope-staging.hydra.lib.umich.edu/northwestern