### PR TITLE
HELIO-1953 don't show filters when a publisher has < 15 books

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,6 +164,7 @@ group :development, :test do
   gem 'coveralls', require: false
   gem 'factory_bot_rails'
   gem "fakefs", require: "fakefs/safe"
+  gem "faker"
   gem 'fcrepo_wrapper', '0.5.2'
   gem 'rails-controller-testing'
   gem 'rspec-context-private'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     fakefs (0.11.3)
+    faker (1.9.1)
+      i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
@@ -931,6 +933,7 @@ DEPENDENCIES
   devise-guests (~> 0.3)
   factory_bot_rails
   fakefs
+  faker
   fcrepo_wrapper (= 0.5.2)
   httparty
   hyrax (= 2.0.0)

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -2,6 +2,7 @@
 
 class PressCatalogController < ::CatalogController
   before_action :load_press
+  before_action :conditional_blacklight_configuration
 
   self.theme = 'curation_concerns'
   with_themed_layout 'catalog'
@@ -10,17 +11,6 @@ class PressCatalogController < ::CatalogController
     config.search_builder_class = PressSearchBuilder
     config.index.partials = %i[thumbnail index_header]
     config.view.gallery.partials = %i[index_header index]
-
-    config.default_per_page = 15
-    config.per_page = [10, 15, 50, 100]
-
-    config.add_sort_field 'relevance', sort: "score desc, #{solr_name('date_uploaded', :stored_sortable, type: :date)} desc", label: "Relevance"
-    config.add_sort_field 'author asc', sort: "#{solr_name('creator_full_name', :sortable)} asc", label: "Author (A-Z)"
-    config.add_sort_field 'author desc', sort: "#{solr_name('creator_full_name', :sortable)} desc", label: "Author (Z-A)"
-    config.add_sort_field 'year desc', sort: "#{solr_name('date_created', :sortable)} desc", label: "Publication Date (Newest First)"
-    config.add_sort_field 'year asc', sort: "#{solr_name('date_created', :sortable)} asc", label: "Publication Date (Oldest First)"
-    config.add_sort_field 'title asc', sort: "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
-    config.add_sort_field 'title desc', sort: "#{Solrizer.solr_name('title', :sortable)} desc", label: "Title (Z-A)"
 
     config.facet_fields.tap do
       # solr facet fields not to be displayed in the index (search results) view
@@ -31,12 +21,6 @@ class PressCatalogController < ::CatalogController
       config.facet_fields.delete('creator_full_name_sim')
       config.facet_fields.delete('based_near_sim')
     end
-
-    config.add_facet_field solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper
-    config.add_facet_field solr_name('creator_full_name', :facetable), label: "Author", limit: 5, url_method: :facet_url_helper
-    config.add_facet_field solr_name('publisher', :facetable), label: "Publisher", limit: 5, url_method: :facet_url_helper
-    config.add_facet_field solr_name('series', :facetable), label: "Series", limit: 5, url_method: :facet_url_helper
-    config.add_facet_fields_to_solr_request!
 
     config.index.partials = %i[thumbnail index_header]
     config.view.gallery.partials = %i[index_header index]
@@ -65,5 +49,44 @@ class PressCatalogController < ::CatalogController
 
       flash[:error] = "The press \"#{params['subdomain']}\" doesn't exist!"
       redirect_to presses_path
+    end
+
+    def open_monographs
+      children = @press.children.pluck(:subdomain)
+      presses = children.push(@press.subdomain).uniq
+      docs = ActiveFedora::SolrService.query("{!terms f=press_sim}#{presses.map(&:downcase).join(',')}", rows: 100_000)
+      docs.select { |doc| doc["suppressed_bsi"] == false && doc["visibility_ssi"] == "open" }.count
+    end
+
+    def conditional_blacklight_configuration
+      if open_monographs >= 15
+        # per page
+        blacklight_config.default_per_page = 15
+        blacklight_config.per_page = [10, 15, 50, 100]
+
+        # facets
+        blacklight_config.add_facet_field Solrizer.solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper
+        blacklight_config.add_facet_field Solrizer.solr_name('creator_full_name', :facetable), label: "Author", limit: 5, url_method: :facet_url_helper
+        if @press.subdomain == 'heb'
+          blacklight_config.add_facet_field Solrizer.solr_name('publisher', :facetable), label: "Publisher", limit: 5, url_method: :facet_url_helper
+        end
+        blacklight_config.add_facet_field Solrizer.solr_name('series', :facetable), label: "Series", limit: 5, url_method: :facet_url_helper
+        blacklight_config.add_facet_fields_to_solr_request!
+      end
+
+      # sort fields
+      if params[:q].present?
+        # if this is a search, relevance/score is default
+        blacklight_config.add_sort_field 'relevance', sort: "score desc, #{Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)} desc", label: "Relevance"
+      else
+        # if it's a "browse", then it's date_uploaded
+        blacklight_config.add_sort_field 'date_uploaded desc', sort: "#{Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)} desc", label: "Date Added (Newest First)"
+      end
+      blacklight_config.add_sort_field 'author asc', sort: "#{Solrizer.solr_name('creator_full_name', :sortable)} asc", label: "Author (A-Z)"
+      blacklight_config.add_sort_field 'author desc', sort: "#{Solrizer.solr_name('creator_full_name', :sortable)} desc", label: "Author (Z-A)"
+      blacklight_config.add_sort_field 'year desc', sort: "#{Solrizer.solr_name('date_created', :sortable)} desc", label: "Publication Date (Newest First)"
+      blacklight_config.add_sort_field 'year asc', sort: "#{Solrizer.solr_name('date_created', :sortable)} asc", label: "Publication Date (Oldest First)"
+      blacklight_config.add_sort_field 'title asc', sort: "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
+      blacklight_config.add_sort_field 'title desc', sort: "#{Solrizer.solr_name('title', :sortable)} desc", label: "Title (Z-A)"
     end
 end

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -16,6 +16,7 @@ module Hyrax
              :subject, :section_titles, :based_near, :publisher, :date_published, :language,
              :isbn, :copyright_holder, :holding_contact, :has_model,
              :buy_url, :embargo_release_date, :lease_expiration_date, :rights, :series,
+             :visibility,
              to: :solr_document
 
     def creator

--- a/app/views/press_catalog/index.html.erb
+++ b/app/views/press_catalog/index.html.erb
@@ -2,10 +2,22 @@
 <% provide :page_class, 'press' %>
 <div id="maincontent">
   <h2>Books</h2>
-  <div class="col-sm-3 facets-container">
-    <%= render 'catalog/search_sidebar' %>
+  <% if has_facet_values?  %>
+  <div class="row">
+    <div class="col-sm-3 facets-container">
+      <%= render 'catalog/search_sidebar' %>
+    </div>
+    <div class="col-sm-9 results-container">
+      <%= render 'catalog/search_results' %>
+    </div>
   </div>
-  <div class="col-sm-9 results-container">
-    <%= render 'catalog/search_results' %>
+  <% else %>
+  <div class="row">
+    <div class="col-sm-1"></div>
+    <div class="col-sm-11 results-container">
+      <%= render 'catalog/search_results' %>
+    </div>
   </div>
+  <% end %>
+
 </div>


### PR DESCRIPTION
HELIO-1954 only show the "publisher" filter for HEB

Also changed the default sort to be different in "search" vs. "browse"