### PR TITLE
HELIO-1973 rake task and job to rebuild epub sqlite indexes

### DIFF
--- a/app/jobs/reindex_epub_job.rb
+++ b/app/jobs/reindex_epub_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ReindexEpubJob < ApplicationJob
+  def perform(id)
+    db = File.join(UnpackService.root_path_from_noid(id, 'epub'), id + ".db")
+    begin
+      FileUtils.mv(db, db + ".old") if File.exist? db
+      sqlite = EPub::SqlLite.from_directory(UnpackService.root_path_from_noid(id, 'epub'))
+      sqlite.create_table
+      sqlite.load_chapters
+      FileUtils.rm db + ".old" if File.exist? db + ".old"
+    rescue SQLite3::Exception => e
+      Rails.logger.error("EPub Index #{db} not updated")
+      Rails.logger.error(e.message)
+    end
+  end
+end

--- a/lib/tasks/reindex_epubs.rake
+++ b/lib/tasks/reindex_epubs.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+desc 'Reindex All Epubs'
+namespace :heliotrope do
+  task reindex_epubs: :environment do
+    FeaturedRepresentative.where(kind: 'epub').each do |epub|
+      ReindexEpubJob.perform_later(epub.file_set_id)
+    end
+    p "Reindexing #{FeaturedRepresentative.where(kind: 'epub').count} epubs"
+  end
+end

--- a/spec/jobs/reindex_epub_job_spec.rb
+++ b/spec/jobs/reindex_epub_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReindexEpubJob, type: :job do
+  describe "perform" do
+    let(:epub) { create(:file_set, content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
+    let(:db_file) { File.join(UnpackService.root_path_from_noid(epub.id, 'epub'), epub.id + '.db') }
+    before do
+      UnpackJob.perform_now(epub.id, 'epub')
+    end
+    it "reindexes the epub" do
+      # The only thing that will really change here is the timestamp on the
+      # .db sqlite file. So I guess test that
+      old_timestamp = File.mtime(db_file).to_f
+      old_size = File.size(db_file)
+      described_class.perform_now(epub.id)
+      expect(old_timestamp < File.mtime(db_file).to_f).to be true
+      # Make sure the contents are the same
+      expect(old_size == File.size(db_file)).to be true
+    end
+  end
+end


### PR DESCRIPTION
This has been run on staging and reindexes epubs correctly. However, don't run it in production until HELIO-1966 is done.