### PR TITLE
Add Shibboleth support via Keycard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /yarn-error.log
 
 .byebug_history
+.rspec_status
 
 # Ignore Redis snapshots
 dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -77,8 +77,8 @@ gem 'canister', '~> 0.9.0'
 gem 'carrierwave', '~> 1.1.0'
 
 # Checkpoint provides authorization support
-# gem 'checkpoint', '~> 1.0.0'
-gem 'checkpoint', git: 'https://github.com/mlibrary/checkpoint', branch: 'master'
+gem 'checkpoint', '~> 1.0.3'
+# gem 'checkpoint', git: 'https://github.com/mlibrary/checkpoint', branch: 'master'
 
 # clamav only in production
 gem 'clamav', group: :production
@@ -110,8 +110,12 @@ gem 'jquery-turbolinks'
 # Json Web Token
 gem 'jwt'
 
+# KCV is a binding between Keycard, Checkpoint, and Vizier
+gem 'kcv', '~> 0.2.3'
+
 # Keycard provides authentication support and user/request information
-gem 'keycard', '~> 0.1.1'
+gem 'keycard', '~> 0.2.3'
+# gem 'keycard', git: 'https://github.com/mlibrary/keycard', branch: 'master'
 
 # Use MySQL as the database for Active Record
 gem 'mysql2', '~> 0.4.10'

--- a/Gemfile
+++ b/Gemfile
@@ -111,10 +111,10 @@ gem 'jquery-turbolinks'
 gem 'jwt'
 
 # KCV is a binding between Keycard, Checkpoint, and Vizier
-gem 'kcv', '~> 0.2.3'
+gem 'kcv', '~> 0.2.4'
 
 # Keycard provides authentication support and user/request information
-gem 'keycard', '~> 0.2.3'
+gem 'keycard', '~> 0.2.4'
 # gem 'keycard', git: 'https://github.com/mlibrary/keycard', branch: 'master'
 
 # Use MySQL as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,11 +452,11 @@ GEM
     kaminari-core (1.1.1)
     kaminari_route_prefix (0.1.1)
       kaminari (~> 1.0)
-    kcv (0.2.3)
+    kcv (0.2.4)
       checkpoint (~> 1.0.3)
-      keycard (~> 0.2.3)
+      keycard (~> 0.2.4)
       vizier (~> 0.1.0)
-    keycard (0.2.3)
+    keycard (0.2.4)
       sequel
     kramdown (1.15.0)
     ld-patch (0.3.2)
@@ -939,8 +939,8 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   jwt
-  kcv (~> 0.2.3)
-  keycard (~> 0.2.3)
+  kcv (~> 0.2.4)
+  keycard (~> 0.2.4)
   legato (~> 0.3)
   listen (>= 3.0.5, < 3.2)
   mysql2 (~> 0.4.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/mlibrary/checkpoint
-  revision: cd60e319a9a2ca72ce7cc9e7d226b24cc67bbb46
-  branch: master
-  specs:
-    checkpoint (1.0.0)
-      ettin (~> 1.1)
-      mysql2 (~> 0.4.10)
-      sequel (~> 5.6)
-
-GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
   revision: 1c2eec64c6ed2b44e0f7d32f5a1a0b4470811be2
   ref: 1c2eec64c6ed2b44e0f7d32f5a1a0b4470811be2
@@ -173,6 +163,9 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    checkpoint (1.0.3)
+      ettin (~> 1.1)
+      sequel (~> 5.6)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
@@ -459,8 +452,11 @@ GEM
     kaminari-core (1.1.1)
     kaminari_route_prefix (0.1.1)
       kaminari (~> 1.0)
-    keycard (0.1.1)
-      mysql2
+    kcv (0.2.3)
+      checkpoint (~> 1.0.3)
+      keycard (~> 0.2.3)
+      vizier (~> 0.1.0)
+    keycard (0.2.3)
       sequel
     kramdown (1.15.0)
     ld-patch (0.3.2)
@@ -792,7 +788,7 @@ GEM
     selenium-webdriver (3.7.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-    sequel (5.6.0)
+    sequel (5.10.0)
     shex (0.5.1)
       ebnf (~> 1.1)
       json-ld (~> 2.1)
@@ -897,6 +893,7 @@ GEM
     unicode-display_width (1.3.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    vizier (0.1.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -922,7 +919,7 @@ DEPENDENCIES
   canister (~> 0.9.0)
   capybara (~> 2.13)
   carrierwave (~> 1.1.0)
-  checkpoint!
+  checkpoint (~> 1.0.3)
   chromedriver-helper
   clamav
   coffee-rails (~> 4.2)
@@ -942,7 +939,8 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   jwt
-  keycard (~> 0.1.1)
+  kcv (~> 0.2.3)
+  keycard (~> 0.2.3)
   legato (~> 0.3)
   listen (>= 3.0.5, < 3.2)
   mysql2 (~> 0.4.10)
@@ -989,4 +987,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,10 +38,10 @@ class ApplicationController < ActionController::Base
   end
 
   def current_institutions
-    session[:identity] ||= Keycard::RequestAttributes.new(request).all
+    session[:identity] ||= Services.request_attributes.for(request).identity
     identity = session[:identity]
-    return [] if identity.blank? || identity['dlpsInstitutionId'].blank?
-    [Institution.where(identifier: [identity['dlpsInstitutionId']].flatten.map(&:to_s))].flatten
+    return [] if identity.blank? || identity[:dlpsInstitutionId].blank?
+    [Institution.where(identifier: [identity[:dlpsInstitutionId]].flatten.map(&:to_s))].flatten
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,9 +21,6 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
-  # Behavior for devise.  Use remote user field in http header for auth.
-  include Behaviors::HttpHeaderAuthenticatableBehavior
-
   rescue_from ActiveFedora::ObjectNotFoundError, with: :render_unauthorized
   # rescue_from ActiveFedora::ActiveFedoraError, with: :render_unauthorized
   rescue_from ActiveRecord::RecordNotFound, with: :render_unauthorized
@@ -64,7 +61,7 @@ class ApplicationController < ActionController::Base
     end
 
     def valid_user_signed_in?
-      user_signed_in? && valid_user?(request.headers)
+      user_signed_in? && current_user.email.present?
     end
 
     def user_sign_out

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -11,6 +11,7 @@ class AuthenticationsController < ApplicationController
   end
 
   def destroy
+    ENV['FAKE_HTTP_X_REMOTE_USER'] = nil
     redirect_to stored_location_for(:user) || root_url
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,15 +22,15 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   # devise :database_authenticatable
 
-  # Use the http header as auth.  This app will be behind a reverse proxy
-  #   that will take care of the authentication.
-  Devise.add_module(:http_header_authenticatable,
+  # Authenticate users with Keycard. The Keycard.config.access setting
+  # will determine exactly how that happens (direct, reverse proxy, Shibboleth).
+  Devise.add_module(:keycard_authenticatable,
                     strategy: true,
                     controller: :sessions,
-                    model: 'devise/models/http_header_authenticatable')
+                    model: 'devise/models/keycard_authenticatable')
 
   # Add our custom module to devise.
-  devise :rememberable, :http_header_authenticatable
+  devise :rememberable, :keycard_authenticatable
 
   def populate_attributes
     # TODO: Override this for HttpHeaderAuthenticatable

--- a/app/policies/policy_agent.rb
+++ b/app/policies/policy_agent.rb
@@ -13,4 +13,8 @@ class PolicyAgent
   def agent_id
     @agent.id
   end
+
+  def identity
+    { agent_type => agent_id }
+  end
 end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -28,6 +28,6 @@ Services = Canister.new
 #   Vizier::PresenterFactory.new(PRESENTERS, config_type: config_class)
 # }
 #
-# Services.register(:checkpoint) { Checkpoint::Authority.new(agent_resolver: AgentResolver.new) }
 
-Services.register(:checkpoint) { Checkpoint::Authority.new } # Use default implementation
+Services.register(:checkpoint) { Checkpoint::Authority.new(agent_resolver: KCV::AgentResolver.new) }
+Services.register(:request_attributes) { Keycard::Request::AttributesFactory.new }

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -21,6 +21,7 @@ if Settings.keycard&.database
 end
 
 Keycard::DB.config.readonly = true if Settings.keycard&.readonly
+Keycard.config.access = Settings.keycard&.access || :direct
 
 Services = Canister.new
 

--- a/lib/devise/behaviors/http_header_authenticatable_behavior.rb
+++ b/lib/devise/behaviors/http_header_authenticatable_behavior.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
 # Default strategy for signing in a user, based on remote user attribute in headers.
-module Behaviors
-  module HttpHeaderAuthenticatableBehavior
-    # Called if the user doesn't already have a rails session cookie
-    # Remote user needs to be present and not null
-    def valid_user?(headers)
-      remote_user = remote_user(headers)
-      remote_user.present? && remote_user != '(null)@umich.edu'
-    end
-
-    protected
-
-      # Remote user is coming back from cosign as uniquename.
-      # Append @umich.edu to this value to satisfy user model validations
-      def remote_user(headers)
-        user_key = headers['HTTP_X_REMOTE_USER']
-        return nil if user_key.blank?
-        if user_key.include?('@')
-          user_key
-        else
-          user_key + '@umich.edu'
-        end
+module Devise
+  module Behaviors
+    module HttpHeaderAuthenticatableBehavior
+      # Called if the user doesn't already have a rails session cookie
+      # Remote user needs to be present and not null
+      def valid_user?(headers)
+        remote_user = remote_user(headers)
+        remote_user.present? && remote_user != '(null)@umich.edu'
       end
+
+      protected
+
+        # Remote user is coming back from cosign as uniquename.
+        # Append @umich.edu to this value to satisfy user model validations
+        def remote_user(headers)
+          user_key = headers['HTTP_X_REMOTE_USER']
+          return nil if user_key.blank?
+          if user_key.include?('@')
+            user_key
+          else
+            user_key + '@umich.edu'
+          end
+        end
+    end
   end
 end

--- a/lib/devise/fake_auth_header.rb
+++ b/lib/devise/fake_auth_header.rb
@@ -28,6 +28,7 @@ class FakeAuthHeader
   # consideration for threads. different threads can have their own object
   # (a duped copy) and carry on their merry way.
   def _call(env)
+    env['REMOTE_USER'] = ENV['FAKE_HTTP_X_REMOTE_USER']
     env['HTTP_X_REMOTE_USER'] = ENV['FAKE_HTTP_X_REMOTE_USER']
     @app.call(env)
   end

--- a/lib/devise/models/keycard_authenticatable.rb
+++ b/lib/devise/models/keycard_authenticatable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/keycard_authenticatable'
+module Devise
+  module Models
+    # Mix-in to expose the Keycard identity attributes on the model object.
+    # They are set by the strategy once the request attributes are resolved,
+    # meaning that an authenticated user will carry its identification with it.
+    # This avoids having to resolve the request attributes again somewhere in
+    # the controller context.
+    module KeycardAuthenticatable
+      extend ActiveSupport::Concern
+
+      included do
+        attr_writer :identity
+      end
+
+      def identity
+        @identity ||= {}
+      end
+    end
+  end
+end

--- a/lib/devise/strategies/http_header_authenticatable.rb
+++ b/lib/devise/strategies/http_header_authenticatable.rb
@@ -3,7 +3,7 @@
 module Devise
   module Strategies
     class HttpHeaderAuthenticatable < ::Devise::Strategies::Base
-      include Behaviors::HttpHeaderAuthenticatableBehavior
+      include Devise::Behaviors::HttpHeaderAuthenticatableBehavior
 
       # Called if the user doesn't already have a rails session cookie.
       def valid?

--- a/lib/devise/strategies/keycard_authenticatable.rb
+++ b/lib/devise/strategies/keycard_authenticatable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Devise
+  module Strategies
+    # Devise strategy for authenticating _individual_ users who are logging in
+    # to the application, not just authenticating for reading purposes. This
+    # uses Keycard to resolve the user EID.
+    class KeycardAuthenticatable < ::Devise::Strategies::Base
+      # Look up and set the "current user" based on EID. This may be an
+      # existing (persisted), new (unsaved, but saveable by the app), or guest
+      # (unsaved, but will raise if save is attempted) User object.
+      def authenticate!
+        if user_eid.present?
+          set_user!
+        else
+          debug_log "Passing (no user_eid present)"
+          pass
+        end
+      end
+
+      # Override and set to false for things like OmniAuth that technically
+      # run through Authentication (user_set) very often, which would normally
+      # reset CSRF data in the session
+      def clean_up_csrf?
+        false
+      end
+
+      private
+
+        def set_user!
+          user = existing_user || new_user || guest_user
+          if user
+            user.identity = identity
+            success!(user)
+          else
+            debug_log "Failed (no existing user and did not make a new/guest)"
+            fail!
+          end
+        end
+
+        def user_eid
+          identity[:user_eid]
+        end
+
+        def identity
+          @identity ||= Services.request_attributes.for(request).identity
+        end
+
+        def existing_user
+          User.find_by(user_key: user_eid).tap do |user|
+            debug_log "Found user: '#{user_eid}'" if user
+          end
+        end
+
+        def new_user
+          return unless Rails.configuration.create_user_on_login
+          User.new(user_key: user_eid).tap do |user|
+            debug_log "New user: '#{user_eid}'"
+            user.populate_attributes
+          end
+        end
+
+        def guest_user
+          User.guest(user_key: user_eid).tap do |user|
+            debug_log "Guest user: '#{user_eid}'"
+            user.populate_attributes
+          end
+        end
+
+        def debug_log(msg)
+          Rails.logger.debug "[AUTHN] KeycardAuthenticatable -- #{msg}"
+        end
+    end
+  end
+end
+
+Warden::Strategies.add(:keycard_authenticatable, Devise::Strategies::KeycardAuthenticatable)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -41,7 +41,7 @@ describe ApplicationController do
     let(:institution) { double('institution', identifier: 'identifier') }
 
     before do
-      allow_any_instance_of(Keycard::RequestAttributes).to receive(:all).and_return(keycard)
+      allow_any_instance_of(Keycard::Request::Attributes).to receive(:identity).and_return(keycard)
       allow(Institution).to receive(:where).with(identifier: ['identifier']).and_return(institution)
       request.env["HTTP_ACCEPT"] = 'application/json'
       routes.draw { get "trigger" => "anonymous#trigger" }
@@ -52,7 +52,7 @@ describe ApplicationController do
     it { expect(controller.current_institutions).to be_empty }
 
     context 'institution' do
-      let(:keycard) { { "dlpsInstitutionId" => institution.identifier } }
+      let(:keycard) { { dlpsInstitutionId: institution.identifier } }
       let(:institution) { double('institution', identifier: 'identifier') }
 
       it { expect(controller.current_institutions?).to be true }

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe EPubsController, type: :controller do
         let(:monograph) { create(:monograph) }
         let(:file_set) { create(:file_set, content: File.open(File.join(fixture_path, 'moby-dick.epub'))) }
         let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
-        let(:keycard) { { "dlpsInstitutionId" => institution.identifier } }
+        let(:keycard) { { dlpsInstitutionId: institution.identifier } }
         let(:institution) { double('institution', identifier: '9999') }
         before do
           monograph.ordered_members << file_set
           monograph.save!
           file_set.save!
-          allow_any_instance_of(Keycard::RequestAttributes).to receive(:all).and_return(keycard)
+          allow_any_instance_of(Keycard::Request::Attributes).to receive(:identity).and_return(keycard)
           allow(Institution).to receive(:where).with(identifier: ['9999']).and_return(institution)
 
           get :show, params: { id: file_set.id }
@@ -257,10 +257,10 @@ RSpec.describe EPubsController, type: :controller do
       after { FeaturedRepresentative.destroy_all }
 
       context 'institution subscription' do
-        let(:keycard) { { "dlpsInstitutionId" => dlpsInstitutionId } }
+        let(:keycard) { { dlpsInstitutionId: dlpsInstitutionId } }
         let(:dlpsInstitutionId) { 'institute' }
 
-        before { allow_any_instance_of(Keycard::RequestAttributes).to receive(:all).and_return(keycard) }
+        before { allow_any_instance_of(Keycard::Request::Attributes).to receive(:identity).and_return(keycard) }
 
         context 'institution' do
           it "Open Access" do

--- a/spec/features/sign_in_out_spec.rb
+++ b/spec/features/sign_in_out_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 feature 'Log In and Out' do
+  # FIXME: There is a side effect between requests and tests where the
+  # Authentications controller modifies ENV directly.
+  before do
+    ENV['FAKE_HTTP_X_REMOTE_USER'] = nil
+  end
+
   context "from /" do
     let!(:user) { create(:platform_admin, email: "wolverine@umich.edu") }
 
@@ -53,7 +59,7 @@ feature 'Log In and Out' do
       file_set.update_index
     end
 
-    scenario "logging in goes to that asset page" do
+    scenario "logging in returns to that asset page" do
       visit hyrax_file_set_path(file_set)
 
       click_link "Log In"
@@ -63,7 +69,7 @@ feature 'Log In and Out' do
       expect(page).to have_current_path(hyrax_file_set_path(file_set))
     end
 
-    scenario "logging out goes to that asset page" do
+    scenario "logging out returns to that asset page" do
       cosign_login_as user
       visit hyrax_file_set_path(file_set)
 

--- a/spec/lib/devise/fake_auth_header_spec.rb
+++ b/spec/lib/devise/fake_auth_header_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe FakeAuthHeader do
     before do
       allow(ENV).to receive(:[]).with("FAKE_HTTP_X_REMOTE_USER").and_return(remote_user)
       allow(env).to receive(:[]=).with("HTTP_X_REMOTE_USER", remote_user)
+      allow(env).to receive(:[]=).with("REMOTE_USER", remote_user)
       allow(app).to receive(:call).with(env)
     end
 

--- a/spec/lib/devise/keycard_authenticatable_spec.rb
+++ b/spec/lib/devise/keycard_authenticatable_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/ExpectInHook
+RSpec.describe Devise::Strategies::KeycardAuthenticatable do
+  let(:strategy) { described_class.new(nil) }
+
+  before do
+    allow(strategy).to receive(:identity).and_return(identity)
+  end
+
+  context "with a user_eid" do
+    let(:user_eid) { 'user@domain' }
+    let(:identity) { { user_eid: user_eid } }
+
+    context "for an existing user" do
+      let(:user) { double('User') }
+
+      before do
+        allow(User).to receive(:find_by).and_return(user)
+        allow(user).to receive(:identity=).with(identity)
+      end
+
+      it "authenticates succesfully" do
+        expect(strategy.authenticate!).to eq(:success)
+      end
+
+      it "sets the current user" do
+        strategy.authenticate!
+        expect(strategy.user).to eq(user)
+      end
+    end
+
+    context "for an unknown user" do
+      context "when create_user_on_login is enabled" do
+        let(:new_user) { User.new(user_key: user_eid) }
+
+        before do
+          allow(Rails.configuration).to receive(:create_user_on_login).and_return(true)
+          allow(User).to receive(:find_by).and_return(nil)
+          expect(User).to receive(:new).with(user_key: user_eid).and_return(new_user)
+          expect(new_user).to receive(:populate_attributes).once
+          expect(Guest).to receive(:new).never
+        end
+
+        it "authenticates succesfully" do
+          expect(strategy.authenticate!).to eq(:success)
+        end
+
+        it "allocates a new user with the EID and sets it as current" do
+          strategy.authenticate!
+          expect(strategy.user).to eq(new_user)
+        end
+      end
+
+      context "when create_user_on_login is disabled" do
+        let(:guest) { User.guest(user_key: user_eid) }
+
+        before do
+          allow(Rails.configuration).to receive(:create_user_on_login).and_return(false)
+          allow(User).to receive(:find_by).and_return(nil)
+          expect(Guest).to receive(:new).with(user_key: user_eid).and_return(guest)
+          expect(guest).to receive(:populate_attributes).once
+          expect(User).to receive(:new).never
+        end
+
+        it "authenticates succesfully" do
+          expect(strategy.authenticate!).to eq(:success)
+        end
+
+        it "allocates a guest user with the EID and sets it as current" do
+          strategy.authenticate!
+          expect(strategy.user).to eq(guest)
+        end
+      end
+    end
+  end
+
+  context "without a user_eid" do
+    let(:identity) { {} }
+
+    it "passes on authenticating" do
+      expect(strategy).to receive(:pass)
+      strategy.authenticate!
+    end
+  end
+end
+# rubocop:enable RSpec/ExpectInHook

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe User do
     it { is_expected.to eq 'foo@example.com' }
   end
 
+  describe '#identity' do
+    let(:user) { described_class.new }
+
+    context 'for a new user' do
+      it 'is an empty hash' do
+        expect(user.identity).to eq({})
+      end
+    end
+
+    it 'allows read and write' do
+      attrs = { user_eid: 'user@domain' }
+      user.identity = attrs
+      expect(user.identity).to eq attrs
+    end
+  end
+
   describe "#total_file_views" do
     subject { user.total_file_views }
     let(:user) { create(:user) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,12 +53,10 @@ RSpec.configure do |config|
 end
 
 def cosign_sign_in(user)
-  allow_any_instance_of(ApplicationController).to receive(:valid_user?).and_return(true)
   sign_in user
 end
 
 def cosign_login_as(user)
-  allow_any_instance_of(ApplicationController).to receive(:valid_user?).and_return(true)
   login_as user
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,9 @@ end
 require 'active_fedora/cleaner'
 
 RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
   config.before do
     ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count > 0
   end


### PR DESCRIPTION
This PR brings an in an update to Keycard and adjusts the Devise binding to use it rather than resolving the HTTP headers itself. There are detailed comments on the commits.

To switch modes, config/settings/*.yml should have a keycard.access property. The default is direct, which assumes no proxy. See Keycard for more details on the changes from RequestAttributes to the family of classes.

Note that this PR only uses the user_eid, which may or may not be present for all users. However, the user_pid is certainly not fit for display, so heliotrope will need to consider the relationship between id/user_key/email on the model and user_eid/user_pid/mail from Keycard for login, identification, and display purposes.

This PR does not address institutional affiliation by way of Shibboleth login. That will have to happen by way of some treatment of the supplement attributes of eduPersonScopedAffiliation and/or identity_provider.