### PR TITLE
Addresses HELIO-1991 Citation tool capitalization inconsistencies.

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/title_behavior.rb
+++ b/app/helpers/hyrax/citations_behaviors/title_behavior.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: false
+
+module Hyrax
+  module CitationsBehaviors
+    module TitleBehavior
+      include Hyrax::CitationsBehaviors::CommonBehavior
+
+      TITLE_NOCAPS = ["a", "an", "and", "but", "by", "for", "it", "of", "the", "to", "with"].freeze
+      EXPANDED_NOCAPS = TITLE_NOCAPS + ["about", "across", "before", "without"]
+
+      def chicago_citation_title(title_text)
+        process_title_parts(title_text) do |w, index|
+          if (index.zero? && w.casecmp(w).zero?) || (w.length > 1 && w.casecmp(w).zero? && !EXPANDED_NOCAPS.include?(w))
+            # the split("-") will handle the capitalization of hyphenated words
+            w.split("-").map! { |x| ucfirst(x) }.join("-")
+          else
+            w
+          end
+        end
+      end
+
+      def mla_citation_title(title_text)
+        process_title_parts(title_text) do |w|
+          if TITLE_NOCAPS.include? w
+            w
+          else
+            w.split("-").map! { |x| ucfirst(x) }.join("-")
+          end
+        end
+      end
+
+      def process_title_parts(title_text, &block)
+        if block_given?
+          title_text.split(" ").collect.with_index(&block).join(" ")
+        else
+          title_text
+        end
+      end
+
+      def setup_title_info(work)
+        text = ''
+        title = work.to_s
+        if title.present?
+          title = CGI.escapeHTML(title)
+          title_info = clean_end_punctuation(title.strip)
+          text << title_info
+        end
+
+        return nil if text.strip.blank?
+        clean_end_punctuation(text.strip) + "."
+      end
+
+      def ucfirst(word)
+        word.slice(0, 1).capitalize + word.slice(1..-1)
+      end
+    end
+  end
+end

--- a/spec/helpers/hyrax/citations_behaviors/title_behavior_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/title_behavior_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::CitationsBehaviors::TitleBehavior do
+  let(:title_behavior) { described_class.new }
+
+  it 'gets World War II right for Chicago' do
+    expect(chicago_citation_title('World War II')).to eq 'World War II'
+  end
+
+  it 'gets Circum-Caribbean right for Chicago' do
+    expect(chicago_citation_title('Circum-Caribbean adventure')).to eq 'Circum-Caribbean Adventure'
+  end
+
+  it 'gets quotes right for Chicago' do
+    expect(chicago_citation_title('The Name "Haydn" In Quotes')).to eq 'The Name "Haydn" In Quotes'
+  end
+
+  it 'gets World War II right for MLA' do
+    expect(mla_citation_title('World War II')).to eq 'World War II'
+  end
+
+  it 'gets Circum-Caribbean right for MLA' do
+    expect(mla_citation_title('Circum-Caribbean adventure')).to eq 'Circum-Caribbean Adventure'
+  end
+
+  it 'gets quotes right for MLA' do
+    expect(mla_citation_title('The Name &quot;Haydn&quot; In Quotes')).to eq 'The Name &quot;Haydn&quot; In Quotes'
+  end
+end


### PR DESCRIPTION
Hyrax built-in functionality copied and minimally patched to correct some brain-dead behavior.