### PR TITLE
add message for HEB users that provides a link to the book on DLXS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,8 @@
 //= require cozy-sun-bear-main
 //= require_tree ./idpselect
 //= require_tree ./application
-// require application_survey
+//  require application_survey
+//= require application_message
 //= require hyrax
 // rails new <app> defaults ...
 // require rails-ujs

--- a/app/assets/javascripts/application_message.js
+++ b/app/assets/javascripts/application_message.js
@@ -1,0 +1,13 @@
+$(document).ready(function () {
+  if ($(".heb").length > 0 ) {
+    closeMessage();
+  }
+});
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+function closeMessage() {
+  $(".message button.dismiss").click(function() {
+    $("div.message").hide();
+  });
+}

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -339,7 +339,7 @@ footer.press {
       border: 4px solid #eeeeee;
     }
   }
-  
+
   .monograph-metadata {
     h1 {
       font-size: 30px;
@@ -349,6 +349,16 @@ footer.press {
       font-size: 24px;
       font-weight: 700;
       display: block;
+    }
+
+    .message {
+      display: inline-block;
+      padding-left: 2em;
+      padding-top: 1em;
+
+      a {
+        text-decoration: underline;
+      }
     }
 
   }

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -189,6 +189,52 @@ $heb-black-80: #342f2e;
     }
   }
 
+  .monograph {
+    .message {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      z-index: 5000;
+      background-color: #002C63;
+      width: 100%;
+      padding: 3em;
+      color: #FFF;
+      display: flex;
+      transition-duration: 0.5s;
+
+      .wrapper {
+        width: 85%;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: row;
+      }
+
+      .text {
+        width: 85%;
+      }
+
+      .dismiss {
+        display: flex;
+        width: 12%;
+        justify-content: flex-end;
+      }
+
+      a {
+        color: #00AFEC;
+        text-decoration: underline;
+      }
+
+      button.dismiss {
+        text-decoration: none;
+        color: #FFF;
+        background: transparent;
+        border: 0;
+        font-size: 2em;
+        padding: 0
+      }
+    }
+  }
+
   //filters on press and monograph pages
   .col-sm-3.facets-container,
   #facet-panel-collapse {
@@ -981,11 +1027,6 @@ $gabii-link-hover:    #1e5667;
       @include lato;
       font-size: .8em;
       padding-left: 1em;
-      vertical-align: sub;
-
-      a {
-        text-decoration: underline;
-      }
     }
 
     .nav-tabs {

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -16,7 +16,7 @@ module Hyrax
              :subject, :section_titles, :based_near, :publisher, :date_published, :language,
              :isbn, :copyright_holder, :holding_contact, :has_model,
              :buy_url, :embargo_release_date, :lease_expiration_date, :rights, :series,
-             :visibility,
+             :visibility, :identifier,
              to: :solr_document
 
     def creator
@@ -81,6 +81,23 @@ module Hyrax
 
     def date_created?
       solr_document.date_created.present?
+    end
+
+    def heb?
+      Array(solr_document['press_tesim']).include?('heb')
+    end
+
+    def heb_id
+      solr_document.identifier.find { |e| /^heb[0-9]/ =~ e }
+    end
+
+    def heb_id?
+      heb_id.present?
+    end
+
+    def heb_dlxs_link
+      return unless heb_id?
+      "https://quod.lib.umich.edu/cgi/t/text/text-idx?c=acls;idno=#{heb_id}"
     end
 
     def unreverse_names(comma_separated_names)

--- a/app/views/monograph_catalog/index.html.erb
+++ b/app/views/monograph_catalog/index.html.erb
@@ -2,6 +2,19 @@
 <% provide :page_class, 'search monograph' %>
 <% provide :page_header do %>
   <%# render 'shared/survey' %>
+  <!-- Temporary message to HEB Users -->
+  <% if @monograph_presenter.heb? %>
+    <% if @monograph_presenter.heb_id? %>
+      <div class="message" role="alert">
+        <div class="wrapper">
+          <div class="text">ACLS Humanities E-Book has migrated to <a href="https://fulcrum.org" target="_blank">Fulcrum</a>, a new platform for enhanced digital books. Access to the legacy ACLS Humanities E-Book platform will continue until October 1st, 2018, where you can <a href="<%= @monograph_presenter.heb_dlxs_link %>" title="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %> on the legacy platform" target="_blank">read this book</a> and others in the collection. If you are having trouble using Fulcrum, <a href="https://goo.gl/forms/mqmDGSe5ihDgWrii1">please let us know</a>.</div>
+          <div class="dismiss">
+            <button type="button" class="dismiss" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
   <!-- breadcrumbs -->
   <%= render 'shared/breadcrumbs' %>
 <% end %><!-- provide :page_header -->


### PR DESCRIPTION
Resolves HELIO-1900

Presents HEB users on the monograph page with a message and links to 1) the book on the legacy platform and 2) the accessibility/usability google form to collect information from users if they are having trouble using the new platform.

Because the links to DLXS are constructed using the HEB ID stored in the multi-value `:identifier` field (which also contains the old HEB handles) there was a little bit of work on the `monograph_presenter` needed in order to find and use the right HEB ID to construct the links.

![screen shot 2018-07-24 at 11 08 50 am](https://user-images.githubusercontent.com/1686111/43148281-fb42b0b0-8f32-11e8-8bb7-0ce8b85b8c83.png)
