### PR TITLE
Addresses HELIO-1825 -- don't use form actions as links.

### DIFF
--- a/app/views/e_pubs/access.html.erb
+++ b/app/views/e_pubs/access.html.erb
@@ -22,17 +22,13 @@
             <p>Not you? <%= current_user.email %></p>
             <p>If you have purchased individual access you may try logging in again.</p>
             <p class="text-center">
-              <form action="<%= main_app.destroy_user_session_path %>">
-                <button type="submit" class="btn btn-default">Sign Out</button>
-              </form>
+              <a class="btn btn-default" href="<%= main_app.destroy_user_session_path %>">Sign Out</a>
             </p>
             <p>Or speak with an customer service representative.</p>
           <% else %>
             <p>If you have purchased individual access log in.</p>
             <p class="text-center">
-              <form action="<%= main_app.default_login_path %>">
-                <button type="submit" class="btn btn-default">Sign In</button>
-              </form>
+              <a class="btn btn-default" href="<%= main_app.default_login_path %>">Sign In</a>
             </p>
           <% end %>
         </div>

--- a/app/views/hyrax/file_sets/_media.html.erb
+++ b/app/views/hyrax/file_sets/_media.html.erb
@@ -3,13 +3,13 @@
     <figcaption<%= ' class="text-center"'.html_safe if @presenter.center_caption? %>><%= @presenter.attribute_to_html(:caption, render_as: :markdown, label: '') %></figcaption>
     <% if @presenter.allow_download?  %>
         <div class="text-center">
-          <form action="<%= hyrax.download_path(@presenter) %>">
-            <button type="submit" formtarget="_blank" class="btn btn-default btn-lg btn-heliotrope-download"><%= @presenter.download_button_label %></button>
-          </form>
+          <a class="btn btn-default btn-lg btn-heliotrope-download" href="<%= hyrax.download_path(@presenter) %>" target="_blank">
+            <%= @presenter.download_button_label %>
+          </a>
           <% if @presenter.extracted_text? %>
-            <form action="<%= hyrax.download_path(@presenter, file: 'extracted_text', filename: @presenter.extracted_text_download_filename) %>">
-              <button type="submit" formtarget="_blank" class="btn btn-default btn-lg btn-heliotrope-download"><%= @presenter.extracted_text_download_button_label %></button>
-            </form>
+            <a class="btn btn-default btn-lg btn-heliotrope-download" href="<%= hyrax.download_path(@presenter, file: 'extracted_text', filename: @presenter.extracted_text_download_filename) %>" target="_blank">
+              <%= @presenter.extracted_text_download_button_label %>
+            </a>
           <% end %>
         </div>
     <% end %>

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,12 +1,10 @@
 <div class="form-actions">
   <% if can?(:edit, presenter) %>
-    <form action="<%= edit_polymorphic_path([main_app, presenter]) %>">
-      <button type="submit" class="btn btn-default btn-lg">Edit</button>
-    </form>
+    <a class="btn btn-default btn-lg" href="<%= edit_polymorphic_path([main_app, presenter]) %>">Edit</a>
     <!-- TODO: remove the following button, it will be replaced by breadcrumbs -->
-    <form action="<%= parent_path(parent) %>">
-      <button type="submit" class="btn btn-default btn-lg"><%= "Back to #{parent.human_readable_type}" %></button>
-    </form>
+    <a class="btn btn-default btn-lg" href="<%= parent_path(parent) %>">
+      <%= "Back to #{parent.human_readable_type}" %>
+    </a>
   <% end %>
   <% if can?(:edit, presenter) || presenter.allow_embed? %>
     <form action="#" onsubmit="CopyToClipboard()" style="display:inline;">

--- a/spec/features/edit_file_set_spec.rb
+++ b/spec/features/edit_file_set_spec.rb
@@ -82,7 +82,7 @@ feature 'Edit a file set' do
       click_button 'Update Attached File'
 
       # Go to Monograph catalog page
-      click_button 'Back to Monograph'
+      click_link 'Back to Monograph'
       expect(page).to have_current_path(hyrax_monograph_path(monograph, locale: 'en'))
       # Order in FileSet's section_title has been taken from Monograph's section_titles
       expect(page).to have_content 'From C 1 and Test section with Italicized Title therein'

--- a/spec/views/hyrax/file_sets/_media.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_media.html.erb_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe 'hyrax/file_sets/_media', type: :view do
     end
     context 'has a download link when allow_download? returns true' do
       let(:allow_download) { true }
-      it { expect(rendered).to have_button('Download') }
+      it { expect(rendered).to have_link('Download') }
     end
     context 'has no download link when allow_download? returns false' do
       let(:allow_download) { false }
-      it { expect(rendered).to_not have_button('Download') }
+      it { expect(rendered).to_not have_link('Download') }
     end
   end
 end


### PR DESCRIPTION
Leaving site/monograph search form alone. This should help retain locale param in the other locations addressed here.