### PR TITLE
Resolve HELIO-2019: Login Options page redirects Friend accounts to d…

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,9 +52,10 @@ class SessionsController < ApplicationController
   private
 
     def shib_target
-      url_for Rails.application.routes.recognize_path(params[:resource])
-    rescue
-      hyrax.dashboard_path
+      target = params[:resource] || root_path
+      target = CGI.unescape(target)
+      target = target.gsub(/(^\/*)(.*)/, '/\2')
+      target
     end
 
     def sp_login_url(entity_id = params[:entityID], target = params[:resource])

--- a/spec/features/sign_in_out_spec.rb
+++ b/spec/features/sign_in_out_spec.rb
@@ -66,7 +66,7 @@ feature 'Log In and Out' do
       fill_in 'Email', with: 'wolverine@umich.edu'
       click_button 'Save'
 
-      expect(page).to have_current_path(hyrax_file_set_path(file_set, locale: 'en'))
+      expect(page).to have_current_path(hyrax_file_set_path(file_set))
     end
 
     scenario "logging out returns to that asset page" do


### PR DESCRIPTION
…ashboard

url_for Rails.application.routes.recognize_path(params[:resource]) threw when :resource => 'press'  e.g. :resource => 'heliotrope'

probably because the route is unconventional /:subdomain(.:format)

solution was to use a regex to ensure params[:resource] is a relative path but still could be an invalid route which would only happen if under attack by script kiddies, so no great loss and security is maintained. 







