### PR TITLE
Resolves HELIO-2031 - swap out webfonts to use google instead of typekit

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -61,8 +61,10 @@ $heb-white: #fff;
 $heb-black-80: #342f2e;
 
 // typography
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,600i,700');
+
 @mixin open-sans {
-  font-family: "open-sans", Helvetica, sans-serif;
+  font-family: 'Open Sans', Helvetica, sans-serif;
 }
 
 .heb {
@@ -120,7 +122,7 @@ $heb-black-80: #342f2e;
 
     .navbar-brand {
       color: $heb-red;
-      font-weight: 900;
+      font-weight: 800;
     }
 
     .navbar-nav {


### PR DESCRIPTION
Puts an `@include` into `themes.scss`, allowing webfonts to be served over Google Fonts. Once in production will require the removal of the Typekit ID from HEB's publisher configuration (in dashboard).