### PR TITLE
HELIO-2055 and HELIO-2056 - modify monograph meta tags

### DIFF
--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -8,15 +8,19 @@
     <% end %>
   <% end %>
 
-  <% if @monograph_presenter.date_published.present? %>
-    <meta name="citation_publication_date" content="<%= @monograph_presenter.date_published.first %>">
+  <% if @monograph_presenter.date_created.present? %>
+    <meta name="citation_publication_date" content="<%= @monograph_presenter.date_created.first %>">
   <% end %>
 
   <% if @monograph_presenter.isbn.present? %>
-    <meta name="citation_isbn" content="<%= @monograph_presenter.isbn.first %>">
+    <% @monograph_presenter.isbn.each do |isbn| %>
+      <meta name="citation_isbn" content="<%= isbn.html_safe %>">
+    <% end %>
   <% end %>
 
-  <meta name="citation_publisher" content="<%= @monograph_presenter.press %>">
+  <% if @monograph_presenter.publisher.present? %>
+    <meta name="citation_publisher" content="<%= @monograph_presenter.publisher.first %>">
+  <% end %>
 
 <% elsif @presenter.present? && @presenter.class == Hyrax::FileSetPresenter %>
 

--- a/spec/views/shared/_metadata.html.erb_spec.rb
+++ b/spec/views/shared/_metadata.html.erb_spec.rb
@@ -15,8 +15,8 @@ describe 'shared/_metadata.html.erb' do
                                            has_model_ssim: ['Monograph'],
                                            title_tesim: ['Sun Moon Dog'],
                                            creator_tesim: ['Doggie, Boutros-Boutros', 'Meow, Chairman'],
-                                           press_name_ssim: ['Seeing Eye Press'],
-                                           date_published_tesim: ['2001']) }
+                                           publisher_tesim: ['Seeing Eye Press'],
+                                           date_created_tesim: ['2001']) }
     it 'has the correct metadata' do
       @monograph_presenter = Hyrax::MonographPresenter.new(solr_document, nil)
       render
@@ -33,7 +33,7 @@ describe 'shared/_metadata.html.erb' do
                                            has_model_ssim: ['Monograph'],
                                            title_tesim: ['Sun Moon Dog'],
                                            creator_full_name_tesim: ['Boutros-Boutros Doggie'],
-                                           press_name_ssim: ['Seeing Eye Press']) }
+                                           publisher_tesim: ['Seeing Eye Press']) }
     it 'has no citation_publication_date' do
       @monograph_presenter = Hyrax::MonographPresenter.new(solr_document, nil)
       render
@@ -47,7 +47,7 @@ describe 'shared/_metadata.html.erb' do
                                            has_model_ssim: ['Monograph'],
                                            title_tesim: [%q(Bob's “Smart” Dog’s "Rött" Äpple)],
                                            creator_full_name_tesim: ['Bob'],
-                                           press_name_ssim: ['Swedish Red Apple']) }
+                                           publisher_tesim: ['Swedish Red Apple']) }
     it 'renders the characters correctly' do
       @monograph_presenter = Hyrax::MonographPresenter.new(solr_document, nil)
       render
@@ -62,7 +62,7 @@ describe 'shared/_metadata.html.erb' do
                                            title_tesim: ['More Things About Stuff'],
                                            contributor_tesim: ['Overlooked, Sir Always'],
                                            creator_tesim: ['Blug Shoeman', 'Melissa Allen'],
-                                           press_name_ssim: ['Marge INC.']) }
+                                           publisher_tesim: ['Marge INC.']) }
     it 'creators are cited but contributors are not' do
       @monograph_presenter = Hyrax::MonographPresenter.new(solr_document, nil)
       render


### PR DESCRIPTION
Resolves HELIO-2055 and HELIO-2056, adding correct publisher meta tags, listing all ISBNs, and correct publication date.