### PR TITLE
HELIO-1965 - brand michigan e-reader

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -758,10 +758,21 @@ $um-black-80: #342f2e;
     background-color: $um-grey-1;
     @include meta-serif;
 
+    padding-top: 20px;
+    padding-bottom: 20px;
+
+    .container {
+      margin-top: 1em;
+    }
+
+    p.lead {
+      font-size: 16px;
+    }
+
     .logo {
 
       img {
-        width: 84px;
+        width: 73px;
         margin-right: 3em;
       }
 
@@ -862,6 +873,50 @@ $um-black-80: #342f2e;
     .platform {
       background-color: $um-black-80;
     }
+  }
+
+  // EPUB Reader
+  #reader {
+
+    .cozy-control .cozy-h1 {
+      font-size: 1.5em;
+    }
+
+    .button {
+      @include epub-button-background-color($um-brand-color,$um-blue,$um-white);
+    }
+
+    .button--lg {
+      @include epub-button-background-color($um-brand-color,$um-blue,$um-white);
+    }
+
+    .button--sm {
+      @include epub-button-background-color($um-brand-color,$um-blue,$um-white);
+    }
+
+    i[class^='icon-chevron-'] {
+      @include epub-prev-next-color($um-brand-color);
+      transition: 0.2s ease-in;
+    }
+
+    i[class^='icon-chevron-']:hover {
+      @include epub-hover-prev-next-color($um-brand-color);
+      transition: 0.2s ease-in;
+    }
+
+    .cozy-control .logo {
+      background: $um-grey-1;
+      height: 46.6px;
+      width: 36px;
+      overflow: hidden;
+
+      img {
+        height: 36px;
+        margin-top: 6px;
+        margin-left: 11px;
+      }
+    }
+
   }
 
 }

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -54,7 +54,7 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         // TODO: only show logo for publishers that also have CSS overrides. Currently only HEB has this.
         <% if defined? @subdomain %>
         // only include logos for heb, nyupress, and gabii at this point
-        <% if %w[heb nyupress gabii].include? @subdomain %>
+        <% if %w[heb nyupress gabii michigan].include? @subdomain %>
         cozy.control.widget.panel({
           region: 'top.header.left',
           template: '<div class="logo"><%= link_to (image_tag logo(@subdomain), role: 'link', alt: @subdomain + ' catalog on Fulcrum'), URI.join(main_app.root_url, @subdomain).to_s %>',


### PR DESCRIPTION
Resolves HELIO-1965

Adds styles to brand the e-reader for michigan and display logo.

![screen shot 2018-08-27 at 3 09 43 pm](https://user-images.githubusercontent.com/1686111/44680304-61faf900-aa0b-11e8-81be-7221b299be69.png)

