### PR TITLE
HELIO-2091 - change binding to respect turbolinks

### DIFF
--- a/app/assets/javascripts/application_message.js
+++ b/app/assets/javascripts/application_message.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+$(document).on('turbolinks:load', function () {
   if ($(".heb").length > 0 ) {
     closeMessage();
   }


### PR DESCRIPTION
Resolve HELIO-2091

By changing the binding to wait for turbolinks to load, the JS function closeMessage() becomes executable when the DOM or window does not actually re-load; this modification appears to fix the issue of being unable to close the message window upon login or logout, or other thinks that utilize turbolinks.