### PR TITLE
HELIO-2052 Fix TOC Anchor tag for EPUBs

### DIFF
--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -1,7 +1,7 @@
 <% @monograph_presenter.epub_presenter.sections.each do |section| %>
   <div class="row chapter">
     <div class="col-sm-12">
-      <h3><a href="<%= epub_path(id: @monograph_presenter.epub_id, anchor: section.cfi + "/4/1:0") %>"><%= section.title %></a></h3>
+      <h3><a href="<%= epub_path(id: @monograph_presenter.epub_id, anchor: section.cfi) %>"><%= section.title %></a></h3>
       <% if @monograph_presenter.epub_presenter.multi_rendition? %>
         <div class="btn-group download" role="group" aria-label="Read or Download Chapter">
           <% if section.downloadable? %>

--- a/lib/e_pub/rendition.rb
+++ b/lib/e_pub/rendition.rb
@@ -24,12 +24,16 @@ module EPub
         next unless /toc/i.match?(toc.id)
         toc.headers.each do |header|
           next if header.text.blank?
-          next if /.*#.*/.match?(header.href)
           idref, index = @unmarshaller_rootfile.content.idref_with_index_from_href(header.href)
+          cfi = if /.*#.*/.match?(header.href)
+                  @unmarshaller_rootfile.content.cfi_from_href_anchor_tag(idref, index, header.href)
+                else
+                  "/6/#{index * 2}[#{idref}]!/4/1:0"
+                end
           args = {
             title: header.text,
             depth: header.depth,
-            cfi: "/6/#{index * 2}[#{idref}]!",
+            cfi: cfi,
             unmarshaller_chapter: @unmarshaller_rootfile.content.chapter_from_title(header.text)
           }
           @sections << Section.from_rendition_args(self, args)

--- a/lib/spec/e_pub/rendition_spec.rb
+++ b/lib/spec/e_pub/rendition_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe EPub::Rendition do
         it { expect(subject.sections.length).to eq 1 }
         it { expect(subject.sections.first.title).to eq 'text' }
         it { expect(subject.sections.first.level).to eq 1 }
-        it { expect(subject.sections.first.cfi).to eq '/6/2[idef]!' }
+        it { expect(subject.sections.first.cfi).to eq '/6/2[idef]!/4/1:0' }
         it { expect(subject.sections.first.downloadable?).to be true }
         it { expect(subject.sections.first.pages.length).to eq 1 }
         it { expect(subject.sections.first.pages.first).to be_an_instance_of(EPub::Page) }

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe EPubsController, type: :controller do
         expect(document).to receive(:image).with(/images\/00000005\.png/, fit: [512, 692])
         expect(document).to receive(:render).and_return(rendered)
         expect(controller).to receive(:send_data).with(rendered, type: "application/pdf", disposition: "inline").and_call_original
-        get :download_section, params: { id: file_set.id, cfi: '/6/2[xhtml00000003]!', title: "This is Chapter One's Title" }
+        get :download_section, params: { id: file_set.id, cfi: '/6/2[xhtml00000003]!/4/1:0', title: "This is Chapter One's Title" }
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq 'application/pdf'
         expect(response.headers['Content-Disposition']).to eq 'inline'


### PR DESCRIPTION
* This can make some quite long TOCs for reflowable epubs, https://heliotrope-staging.hydra.lib.umich.edu/concern/monographs/6m311p36k?locale=en

* Refactoring/deduplication of some of the cfi related code will happen in HELIO-2069 