### PR TITLE
HELIO-2144 Create COUNTER Platform Usage Report PR_P1

### DIFF
--- a/app/models/counter_report.rb
+++ b/app/models/counter_report.rb
@@ -17,4 +17,24 @@ class CounterReport < ApplicationRecord
 
   # Every record should have a corresponding press id
   validates :press, presence: true
+
+  scope :unique, -> { select(:session, :noid).distinct }
+  scope :unique_by_title, -> { select(:session, :parent_noid).distinct }
+  scope :investigations, -> { where(investigation: 1) }
+  scope :requests, -> { where(request: 1) }
+  scope :controlled, -> { where(access_type: 'Controlled') }
+
+  scope :press, ->(press) { where(press: press) if press.present? }
+
+  def self.institution(institution_id)
+    where(institution: institution_id)
+  end
+
+  def self.start_date(start_date)
+    where("created_at > ?", start_date)
+  end
+
+  def self.end_date(end_date)
+    where("created_at < ?", end_date)
+  end
 end

--- a/app/services/counter_reporter_service.rb
+++ b/app/services/counter_reporter_service.rb
@@ -1,10 +1,114 @@
 # frozen_string_literal: true
 
 class CounterReporterService
-  # TODO: this will generate the different kinds of COUNTER reports
-  # using the counter_report table
-
-  # Can we build these reports from what's in counter_report and in solr?
   # See notes in HELIO-1376
   # https://tools.lib.umich.edu/jira/browse/HELIO-1376?focusedCommentId=898167&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-898167
+
+  def self.pr_p1(params) # rubocop:disable Metrics/CyclomaticComplexity
+    # Example pr_p1 report:
+    # https://docs.google.com/spreadsheets/d/1fsF_JCuOelUs9s_cvu7x_Yn8FNsi5xK0CR3bu2X_dVI/edit#gid=1932253188
+    start_date  = Date.parse(params[:start_date]) || CounterReport.first.created_at
+    end_date    = Date.parse(params[:end_date]) || Time.now.utc
+    press       = params[:press] || nil
+    institution = params[:institution]
+
+    header = {
+      Report_Name: "Platform Usage",
+      Report_ID: "PR_P1",
+      Release: "5",
+      Institution_Name: Institution.where(identifier: institution).first&.name,
+      Institution_ID: institution,
+      Metric_Types: "Total_Item_Requests; Unique_Item_Requests; Unique_Title_Requests",
+      Report_Filters: "Access_Type=Controlled; Access_Method=Regular",
+      Report_Attributes: "",
+      Exceptions: "",
+      Reporting_Period: "#{start_date} to #{end_date}",
+      Created: Time.zone.today.iso8601,
+      Created_By: "Fulcrum"
+    }
+
+    items = []
+
+    # Total_Item_Requests
+    item = ActiveSupport::OrderedHash.new
+    item["Platform"] = "Fulcrum"
+    item["Metric_Type"] = "Total_Item_Requests"
+    item["Reporting_Period_Total"] = CounterReport.institution(institution)
+                                                  .requests
+                                                  .controlled
+                                                  .start_date(start_date)
+                                                  .end_date(end_date)
+                                                  .press(press)
+                                                  .count
+    this_month = start_date
+    until this_month > end_date
+      item_month = this_month.strftime("%b") + "-" + this_month.year.to_s
+      item[item_month] = CounterReport.institution(institution)
+                                      .requests
+                                      .controlled
+                                      .where("YEAR(created_at) = ? and MONTH(created_at) = ?", this_month.year, this_month.month)
+                                      .press(press)
+                                      .count
+      this_month = this_month.next_month
+    end
+
+    items << item
+
+    # Unique_Item_Requests
+    item = ActiveSupport::OrderedHash.new
+    item["Platform"] = "Fulcrum"
+    item["Metric_Type"] = "Unique_Item_Requests"
+    item["Reporting_Period_Total"] = CounterReport.institution(institution)
+                                                  .requests
+                                                  .controlled
+                                                  .unique
+                                                  .start_date(start_date)
+                                                  .end_date(end_date)
+                                                  .press(press)
+                                                  .count
+
+    this_month = start_date
+    until this_month > end_date
+      item_month = this_month.strftime("%b") + "-" + this_month.year.to_s
+      item[item_month] = CounterReport.institution(institution)
+                                      .requests
+                                      .controlled
+                                      .unique
+                                      .where("YEAR(created_at) = ? and MONTH(created_at) = ?", this_month.year, this_month.month)
+                                      .press(press)
+                                      .count
+      this_month = this_month.next_month
+    end
+
+    items << item
+
+    # Unique_Title_Requests
+    item = ActiveSupport::OrderedHash.new
+    item["Platform"] = "Fulcrum"
+    item["Metric_Type"] = "Unique_Title_Requests"
+    item["Reporting_Period_Total"] = CounterReport.institution(institution)
+                                                  .requests
+                                                  .controlled
+                                                  .unique_by_title
+                                                  .start_date(start_date)
+                                                  .end_date(end_date)
+                                                  .press(press)
+                                                  .count
+    this_month = start_date
+    until this_month > end_date
+      item_month = this_month.strftime("%b") + "-" + this_month.year.to_s
+      item[item_month] = CounterReport.institution(institution)
+                                      .requests
+                                      .controlled
+                                      .unique_by_title
+                                      .where("YEAR(created_at) = ? and MONTH(created_at) = ?", this_month.year, this_month.month)
+                                      .press(press)
+                                      .count
+      this_month = this_month.next_month
+    end
+
+    items << item
+
+    { header: header, items: items }
+  end
 end

--- a/spec/factories/counter_reports.rb
+++ b/spec/factories/counter_reports.rb
@@ -2,16 +2,31 @@
 
 FactoryBot.define do
   factory :counter_report do
-    session { "MyString" }
-    institution { "" }
+    session do
+      ip = 1.upto(4).map { |_| Random.rand(255) }.join(".")
+      from = 1_483_228_800.0 # 2017-01-01
+      to = Time.now
+      date = Time.at(from + rand * (to.to_f - from.to_f)).strftime("%Y-%m-%d")
+      "#{ip}|Some UserAgent String/1.0|#{date}|#{Random.rand(24)}"
+    end
+    institution do
+      inst = %w[1 45 987 43 24 643 22 6 18 745]
+      inst[Random.rand(10)]
+    end
     noid { "validnoid" }
     model { "FileSet" }
     section { "" }
     section_type { "" }
-    investigation { "" }
-    request { "" }
-    turnaway { "" }
-    access_type { "" }
+    investigation { 1 }
+    request { 0 }
+    turnaway do
+      ta = ["No_License", "", "", "", ""]
+      ta[Random.rand(5)]
+    end
+    access_type do
+      at = ["Controlled", "OA_Gold"]
+      at[Random.rand(2)]
+    end
     press { 1 }
     parent_noid { "ValidNoid" }
   end

--- a/spec/models/counter_report_spec.rb
+++ b/spec/models/counter_report_spec.rb
@@ -14,4 +14,102 @@ RSpec.describe CounterReport, type: :model do
       expect(described_class.create(section_type: "Magazine")).not_to be_valid
     end
   end
+
+  describe "unique scope" do
+    # unique is a distinct combination of session and noid
+    before do
+      create(:counter_report, session: 1, noid: 'a')
+      create(:counter_report, session: 1, noid: 'b')
+      create(:counter_report, session: 1, noid: 'a')
+      create(:counter_report, session: 2, noid: 'a')
+      create(:counter_report, session: 2, noid: 'c')
+    end
+
+    after { CounterReport.destroy_all }
+
+    it do
+      expect(described_class.unique.length).to eq 4
+    end
+  end
+
+  describe "chained scopes/methods for a PR report" do
+    before do
+      create(:counter_report, session: 1, noid: 'a', parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-02").utc)
+      create(:counter_report, session: 1, noid: 'a', parent_noid: 'A', institution: 1, created_at: Time.parse("2018-02-02").utc)
+      create(:counter_report, session: 1, noid: 'b', parent_noid: 'B', institution: 1, created_at: Time.parse("2018-02-04").utc, request: 1)
+      create(:counter_report, session: 1, noid: 'c', parent_noid: 'C', institution: 1, created_at: Time.parse("2018-11-11").utc)
+
+      create(:counter_report, session: 2, noid: 'b', parent_noid: 'B', institution: 1, created_at: Time.parse("2018-02-02").utc)
+
+      create(:counter_report, session: 3, noid: 'a', parent_noid: 'A', institution: 2, created_at: Time.parse("2018-02-01").utc)
+
+      create(:counter_report, session: 4, noid: 'c', parent_noid: 'C', institution: 1, created_at: Time.parse("2018-02-02").utc, request: 1)
+    end
+
+    after { CounterReport.destroy_all }
+
+    context "Total_Item_Investigations for Institution 1 in February" do
+      it do
+        expect(described_class.institution(1)
+                              .investigations
+                              .start_date("2018-02-01")
+                              .end_date("2018-02-28")
+                              .count).to eq 4
+      end
+    end
+
+    context "Total_Item_Requests for Institution 1 in February" do
+      it do
+        expect(described_class.institution(1)
+                              .requests
+                              .start_date("2018-02-01")
+                              .end_date("2018-02-28")
+                              .count).to eq 2
+      end
+    end
+
+    context "Unique_Item_Investigations for Instiution 1 in February" do
+      it do
+        expect(described_class.institution(1)
+                            .investigations
+                            .unique
+                            .start_date("2018-02-01")
+                            .end_date("2018-02-28")
+                            .count).to eq 4
+      end
+    end
+
+    context "Unique_Item_Requests for Institution 1 in February" do
+      it do
+        expect(described_class.institution(1)
+                              .requests
+                              .unique
+                              .start_date("2018-02-01")
+                              .end_date("2018-02-28")
+                              .count).to eq 2
+      end
+    end
+
+    context "Unique_Title_Investigations for Institution 1 in Feburary" do
+      it do
+        expect(described_class.institution(1)
+                              .investigations
+                              .unique_by_title
+                              .start_date("2018-02-01")
+                              .end_date("2018-02-28")
+                              .count).to eq 4
+      end
+    end
+
+    context "Unique_Title_Requests for Institution 1 in Feburary" do
+      it do
+        expect(described_class.institution(1)
+                              .requests
+                              .unique_by_title
+                              .start_date("2018-02-01")
+                              .end_date("2018-02-28")
+                              .count).to eq 2
+      end
+    end
+  end
 end

--- a/spec/services/counter_reporter_service_spec.rb
+++ b/spec/services/counter_reporter_service_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CounterReporterService do
+  describe "#pr_p1" do
+    # See https://docs.google.com/spreadsheets/d/1fsF_JCuOelUs9s_cvu7x_Yn8FNsi5xK0CR3bu2X_dVI/edit#gid=1932253188
+
+    subject { described_class.pr_p1(institution: institution, start_date: start_date, end_date: end_date) }
+
+    let(:institution_name) { double("institution_name", name: "U of Something") }
+    let(:start_date) { "2018-01-01" }
+    let(:end_date) { "2018-12-01" }
+
+    after { CounterReport.destroy_all }
+
+    context "header" do
+      let(:institution) { 1 }
+
+      it do
+        allow(Institution).to receive(:where).with(identifier: institution).and_return([institution_name])
+
+        expect(subject[:header][:Report_Name]).to eq "Platform Usage"
+        expect(subject[:header][:Report_ID]).to eq "PR_P1"
+        expect(subject[:header][:Release]).to eq "5"
+        expect(subject[:header][:Institution_Name]).to eq institution_name.name
+        expect(subject[:header][:Institution_ID]).to eq institution
+        expect(subject[:header][:Metric_Types]).to eq "Total_Item_Requests; Unique_Item_Requests; Unique_Title_Requests"
+        expect(subject[:header][:Report_Filters]).to eq "Access_Type=Controlled; Access_Method=Regular"
+        expect(subject[:header][:Report_Attributes]).to eq ""
+        expect(subject[:header][:Exceptions]).to eq ""
+        expect(subject[:header][:Reporting_Period]).to eq "#{start_date} to #{end_date}"
+        expect(subject[:header][:Created]).to eq Time.zone.today.iso8601
+        expect(subject[:header][:Created_By]).to eq "Fulcrum"
+      end
+    end
+
+    context "no press" do
+      let(:institution) { 1 }
+
+      before do
+        create(:counter_report, session: 1,  noid: 'a',  parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-02").utc, access_type: "Controlled")
+        create(:counter_report, session: 1,  noid: 'a',  parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-02").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, session: 1,  noid: 'a2', parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-02").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, session: 1,  noid: 'a',  parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-02").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, session: 6,  noid: 'b',  parent_noid: 'B', institution: 1, created_at: Time.parse("2018-11-11").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, session: 10, noid: 'b',  parent_noid: 'B', institution: 2, created_at: Time.parse("2018-11-11").utc, access_type: "Controlled", request: 1)
+      end
+
+      after { CounterReport.destroy_all }
+
+      it do
+        allow(Institution).to receive(:where).with(identifier: institution).and_return([institution_name])
+
+        expect(subject[:items][0]["Metric_Type"]).to eq "Total_Item_Requests"
+        expect(subject[:items][0]["Reporting_Period_Total"]).to eq 4
+        expect(subject[:items][0]["Jan-2018"]).to eq 3
+        expect(subject[:items][0]["Nov-2018"]).to eq 1
+
+        expect(subject[:items][1]["Metric_Type"]).to eq "Unique_Item_Requests"
+        expect(subject[:items][1]["Reporting_Period_Total"]).to eq 3
+        expect(subject[:items][1]["Jan-2018"]).to eq 2
+        expect(subject[:items][1]["Nov-2018"]).to eq 1
+
+        expect(subject[:items][2]["Metric_Type"]).to eq "Unique_Title_Requests"
+        expect(subject[:items][2]["Reporting_Period_Total"]).to eq 2
+        expect(subject[:items][2]["Jan-2018"]).to eq 1
+        expect(subject[:items][2]["Nov-2018"]).to eq 1
+      end
+    end
+
+    context "limit by press" do
+      subject { described_class.pr_p1(institution: institution, start_date: start_date, end_date: end_date, press: 1) }
+
+      let(:institution) { 1 }
+
+      before do
+        create(:press, id: 1, subdomain: "this_press")
+        create(:press, id: 2, subdomain: "other_press")
+        create(:counter_report, press: 1, session: 1, noid: 'a', parent_noid: 'A', institution: 1, created_at: Time.parse("2018-01-11").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, press: 1, session: 2, noid: 'b', parent_noid: 'B', institution: 1, created_at: Time.parse("2018-02-11").utc, access_type: "Controlled", request: 1)
+        create(:counter_report, press: 2, session: 3, noid: 'c', parent_noid: 'C', institution: 1, created_at: Time.parse("2018-03-11").utc, access_type: "Controlled", request: 1)
+      end
+
+      after do
+        Press.destroy_all
+        CounterReport.destroy_all
+      end
+
+      it do
+        allow(Institution).to receive(:where).with(identifier: institution).and_return([institution_name])
+
+        expect(subject[:items][0]["Reporting_Period_Total"]).to eq 2 # Total_Item_Requests
+        expect(subject[:items][1]["Reporting_Period_Total"]).to eq 2 # Unique_Item_Requests
+        expect(subject[:items][2]["Reporting_Period_Total"]).to eq 2 # Unique_Title_Requests
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR creates the PR_P1 COUNTER 5 report, but is not hooked in to the UI or deals with auth in any way. It's a very "shameless green" approach. Refactoring to a more sustainable pattern will happen as we create the different kinds of COUNTER reports and thereby gather better/more information on what kinds of patterns should be used.