### PR TITLE
HELIO-2201 - move styles from representative file into heliotrope.scss

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -312,6 +312,28 @@ footer.press {
 ///////////////////////////////////
 .monograph {
 
+  figure.peer_review {
+    margin-top: 1.5em;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+  
+  figure.peer_review img {
+    border: none !important;
+    width: 85px;
+    height: 80px;
+    margin-right: .5em;
+  }
+
+  figure.peer_review figcaption {
+    font-size: 11px;
+  }
+
   .fulcrum_sidebar {
     // In hyrax2 this defaults to grey which we don't want
     background-color: white;

--- a/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
@@ -1,7 +1,7 @@
 <% presenter = Hyrax::PresenterFactory.build_for(ids: [document.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first %>
 <div class="document col-xs-6 col-md-4">
   <div class="thumbnail">
-    <a href="<%= polymorphic_path(url_for_document(document)) %>" >
+    <a href="<%= polymorphic_path(url_for_document(document)) %>" data-turbolinks="false">
       <img class="img-responsive" src="/image-service/<%=document.representative_id%>/full/145,/0/default.jpg<%= presenter.representative_presenter&.image_cache_breaker %>"
            alt="Cover image for <%= presenter.representative_alt_text %>">
     </a>


### PR DESCRIPTION
To deal with CSS not loading from the file representative and turbolinks interference.