### PR TITLE
Addresses HELIO-2286 facet sort options

### DIFF
--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -65,13 +65,15 @@ class PressCatalogController < ::CatalogController
         blacklight_config.per_page = [10, 15, 50, 100]
 
         # facets
-        blacklight_config.add_facet_field Solrizer.solr_name('open_access', :facetable), label: "Open Access", limit: 1, url_method: :facet_url_helper
-        blacklight_config.add_facet_field Solrizer.solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper
-        blacklight_config.add_facet_field Solrizer.solr_name('creator', :facetable), label: "Author", limit: 5, url_method: :facet_url_helper
+        # Sort HEB facets alphabetically, others by count
+        sort = (@press.subdomain == 'heb') ? 'index' : 'count'
+        blacklight_config.add_facet_field Solrizer.solr_name('open_access', :facetable), label: "Open Access", limit: 1, url_method: :facet_url_helper, sort: sort
+        blacklight_config.add_facet_field Solrizer.solr_name('subject', :facetable), label: "Subject", limit: 10, url_method: :facet_url_helper, sort: sort
+        blacklight_config.add_facet_field Solrizer.solr_name('creator', :facetable), label: "Author", limit: 5, url_method: :facet_url_helper, sort: sort
         if @press.subdomain == 'heb'
-          blacklight_config.add_facet_field Solrizer.solr_name('publisher', :facetable), label: "Publisher", limit: 5, url_method: :facet_url_helper
+          blacklight_config.add_facet_field Solrizer.solr_name('publisher', :facetable), label: "Publisher", limit: 5, url_method: :facet_url_helper, sort: sort
         end
-        blacklight_config.add_facet_field Solrizer.solr_name('series', :facetable), label: "Series", limit: 5, url_method: :facet_url_helper
+        blacklight_config.add_facet_field Solrizer.solr_name('series', :facetable), label: "Series", limit: 5, url_method: :facet_url_helper, sort: sort
         blacklight_config.add_facet_fields_to_solr_request!
       end
 


### PR DESCRIPTION
Just makes it so HEB facets are sorted alphabetically, instead of by count.