### PR TITLE
Turn off fallback_to_idp and display :internal_server_error instead

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
   # :database_authenticatable, :registerable, :recoverable, :rememberable,
   # :trackable, :validatable, :confirmable, :lockable, :timeoutable and :omniauthable
 
-  devise :rememberable, :keycard_authenticatable
+  devise :keycard_authenticatable
 
   alias_attribute :user_key, :email
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,5 @@
 shibboleth:
-  fallback_to_idp: true
+  fallback_to_idp: false
   default_idp:
     entity_id: https://shibboleth.umich.edu/idp/shibboleth
   sp:


### PR DESCRIPTION
Don't mask Shibboleth configuration error, blow up instead!