### PR TITLE
HELIO-2382 epub share link logic changes

### DIFF
--- a/app/models/share_link_log.rb
+++ b/app/models/share_link_log.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ShareLinkLog < ApplicationRecord
+end

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -411,16 +411,15 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         }).addTo(reader);
 
         // Download widget
-        <% if @epub_download_presenter.download_links.length.positive? %>
+        <% if @epub_download_presenter.download_links.length.positive? && @share_link.nil? %>
         cozy.control.download({
             region: 'top.toolbar.left',
             template: '<button class="button--sm cozy-download" data-toggle="open" aria-label="Download book" role="button"><i id="download" class="oi" data-glyph="data-transfer-download" title="Download book" aria-hidden="true"></i></button>',
         }).addTo(reader);
         <% end %>
 
-
         // Restricted Share Link widget
-        <% if @component.present? && @press.allow_share_links? %>
+        <% if @component.present? && @press.allow_share_links? && @share_link.nil? %>
         cozy.control.widget.button({
           region: 'top.toolbar.left',
           template: '<button id="share-link-btn" class="button--sm cozy-close" data-toggle="button" data-slot="label" aria-label="Share Unrestricted Link"><i class="oi" data-glyph="link-intact" title="Share Unrestricted Link" aria-hidden="true"></i></button>',

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,8 @@ minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
 resque_namespace: heliotrope-testing
 host: test.host
 
+e_pub_checkpoint_authorization: true
+
 keycard:
   database:
     adapter: sqlite

--- a/db/migrate/20181214194406_create_share_link_logs.rb
+++ b/db/migrate/20181214194406_create_share_link_logs.rb
@@ -1,0 +1,15 @@
+class CreateShareLinkLogs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :share_link_logs do |t|
+      t.string :ip_address
+      t.string :institution
+      t.string :press
+      t.string :title
+      t.string :noid
+      t.string :token
+      t.string :action
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181119202429) do
+ActiveRecord::Schema.define(version: 20181214194406) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -369,6 +369,18 @@ ActiveRecord::Schema.define(version: 20181119202429) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
+  create_table "share_link_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "ip_address"
+    t.string "institution"
+    t.string "press"
+    t.string "title"
+    t.string "noid"
+    t.string "token"
+    t.string "action"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "single_use_links", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "downloadKey"
     t.string "path"
@@ -631,6 +643,7 @@ ActiveRecord::Schema.define(version: 20181119202429) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "api_requests", "users"
   add_foreign_key "components_products", "components"
   add_foreign_key "components_products", "products"
   add_foreign_key "curation_concerns_operations", "users"

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe EPubsController, type: :controller do
 
   context "show" do
     let(:show) { true }
+    let(:policy) { double('policy', show?: true) }
 
-    before { allow_any_instance_of(described_class).to receive(:show?).and_return(show) }
+    before do
+      allow_any_instance_of(described_class).to receive(:show?).and_return(show)
+      allow(EPubPolicy).to receive(:new).and_return(policy)
+    end
 
     describe "#show" do
       context 'not found' do
@@ -264,10 +268,35 @@ RSpec.describe EPubsController, type: :controller do
     end
   end
 
+  describe 'session[:set_show]' do
+    let(:policy) { double('policy', show?: true) }
+    let(:n) { 20 }
+    let(:m) { 10 }
+    let(:presenter) { double('presenter', id: 'id', epub?: true, citable_link: 'link', monograph_id: 'mono_id') }
+    let(:parent) { double('monograph_presenter', title: 'Title', subdomain: 'subdomain', id: 'mono_id') }
+
+    before do
+      allow(EPubPolicy).to receive(:new).and_return(policy)
+      allow(Hyrax::PresenterFactory).to receive(:build_for).and_return([presenter])
+      allow(presenter).to receive(:parent).and_return(parent)
+      allow(presenter).to receive(:monograph).and_return(parent)
+    end
+
+    it 'buffers m ids' do
+      session[:show_set] = []
+      n.times do |i|
+        get :show, params: { id: i }
+        expect(response).to have_http_status(:success)
+        expect(session[:show_set].include?(i.to_s)).to be true
+        expect(session[:show_set].length).to be <= m
+      end
+    end
+  end
+
   context "checkpoint" do
     describe '#set_show' do
-      let(:monograph) { create(:monograph) }
-      let(:file_set) { create(:file_set, id: '999999999', content: File.open(File.join(fixture_path, 'fake_epub01.epub'))) }
+      let(:monograph) { create(:public_monograph) }
+      let(:file_set) { create(:public_file_set, id: '999999999', content: File.open(File.join(fixture_path, 'fake_epub01.epub'))) }
       let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
 
       before do
@@ -317,67 +346,43 @@ RSpec.describe EPubsController, type: :controller do
         it 'Platform Admin' do
           sign_in(create(:platform_admin))
           get :show, params: { id: file_set.id }
-          expect(session[:show_set].include?(file_set.id)).to be false
+          expect(session[:show_set].include?(file_set.id)).to be true
           expect(response).to have_http_status(:success)
-          expect(response).to render_template(:access)
+          expect(response).to render_template(:show)
         end
 
         it "Subscribed Institution" do
           institution = create(:institution, identifier: dlpsInstitutionId)
           product = Product.create!(identifier: 'product', name: 'name', purchase: 'purchase')
           product.components << component
-          product.lessees << institution.lessee
           product.save!
+          Greensub.subscribe(institution, product)
           get :show, params: { id: file_set.id }
           expect(session[:show_set].include?(file_set.id)).to be true
           expect(response).to have_http_status(:success)
-          expect(response).not_to render_template(:access)
+          expect(response).to render_template(:show)
         end
 
         it "Subscribed Individual" do
           email = 'wolverine@umich.edu'
           user = create(:user, email: email)
-          individual = create(:individual, identifier: email)
+          individual = create(:individual, identifier: email, email: email)
           product = Product.create!(identifier: 'product', name: 'name', purchase: 'purchase')
           product.components << component
-          product.lessees << individual.lessee
           product.save!
+          Greensub.subscribe(individual, product)
           sign_in(user)
           get :show, params: { id: file_set.id }
           expect(session[:show_set].include?(file_set.id)).to be true
           expect(response).to have_http_status(:success)
-          expect(response).not_to render_template(:access)
-        end
-      end
-    end
-
-    describe 'session[:set_show]' do
-      let(:presenter) { double('presenter', id: 'id', epub?: true, citable_link: 'link', monograph_id: 'mono_id') }
-      let(:parent) { double('monograph_presenter', title: 'Title', subdomain: 'subdomain', id: 'mono_id') }
-
-      let(:n) { 20 }
-      let(:m) { 10 }
-
-      before do
-        allow(Hyrax::PresenterFactory).to receive(:build_for).and_return([presenter])
-        allow(presenter).to receive(:parent).and_return(parent)
-        allow(presenter).to receive(:monograph).and_return(parent)
-      end
-
-      it 'buffers m ids' do
-        session[:show_set] = []
-        n.times do |i|
-          get :show, params: { id: i }
-          expect(response).to have_http_status(:success)
-          expect(session[:show_set].include?(i.to_s)).to be true
-          expect(session[:show_set].length).to be <= m
+          expect(response).to render_template(:show)
         end
       end
     end
 
     describe '#download_chapter' do
-      let(:monograph) { create(:monograph) }
-      let(:file_set) { create(:file_set, id: '999999999', content: File.open(File.join(fixture_path, 'fake_epub_multi_rendition.epub'))) }
+      let(:monograph) { create(:public_monograph) }
+      let(:file_set) { create(:public_file_set, id: '999999999', content: File.open(File.join(fixture_path, 'fake_epub_multi_rendition.epub'))) }
       let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
 
       before do
@@ -463,6 +468,11 @@ RSpec.describe EPubsController, type: :controller do
           get :show, params: { id: file_set.id, share: valid_share_token }
           expect(response).to have_http_status(:success)
           expect(response).to render_template(:show)
+          expect(ShareLinkLog.count).to eq 1
+          expect(ShareLinkLog.last.action).to eq 'use'
+          expect(ShareLinkLog.last.title).to eq monograph.title.first
+          expect(ShareLinkLog.last.noid).to eq file_set.id
+          expect(ShareLinkLog.last.token).to eq valid_share_token
         end
 
         it "with an expired share_link" do
@@ -483,8 +493,8 @@ RSpec.describe EPubsController, type: :controller do
   describe '#share_link' do
     let(:now) { Time.now }
     let(:presenters) { double("presenters", first: presenter) }
-    let(:presenter) { double("presenter", monograph: monograph) }
-    let(:monograph) { double("monograph", subdomain: press.subdomain) }
+    let(:presenter) { double("presenter", id: 'fileset_id', monograph: monograph) }
+    let(:monograph) { double("monograph", subdomain: press.subdomain, title: ["A Thing"]) }
 
     before do
       allow(Time).to receive(:now).and_return(now)
@@ -494,10 +504,26 @@ RSpec.describe EPubsController, type: :controller do
     context "when the press shares links" do
       let(:press) { create(:press, subdomain: 'blah', share_links: true) }
 
-      it 'returns a share link with a valid JSON webtoken' do
+      it 'returns a share link with a valid JSON webtoken and logs the creation' do
         get :share_link, params: { id: 'noid' }
         expect(response).to have_http_status(:success)
         expect(response.body).to eq "http://test.host/epubs/noid?share=#{JsonWebToken.encode(data: 'noid', exp: now.to_i + 48 * 3600)}"
+        expect(ShareLinkLog.count).to eq 1
+        expect(ShareLinkLog.last.action).to eq 'create'
+      end
+
+      context 'with a user with institutions' do
+        let(:inst1) { create(:institution, identifier: 1, name: 'U of M') }
+        let(:inst2) { create(:institution, identifier: 2, name: 'O of U') }
+
+        before { allow_any_instance_of(described_class).to receive(:current_institutions).and_return([inst1, inst2]) }
+
+        it 'logs the institutions' do
+          get :share_link, params: { id: 'noid' }
+          expect(response).to have_http_status(:success)
+          expect(ShareLinkLog.count).to eq 1
+          expect(ShareLinkLog.last.institution).to eq "U of M|O of U"
+        end
       end
     end
 
@@ -508,6 +534,7 @@ RSpec.describe EPubsController, type: :controller do
         get :share_link, params: { id: 'noid' }
         expect(response).to have_http_status(:success)
         expect(response.body).to be_empty
+        expect(ShareLinkLog.count).to eq 0
       end
     end
   end

--- a/spec/factories/share_link_logs.rb
+++ b/spec/factories/share_link_logs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :share_link_log do
+    ip_address { "MyString" }
+    institution { "MyString" }
+    press { "MyString" }
+    title { "MyString" }
+    noid { "MyString" }
+    token { "MyString" }
+    action { "MyString" }
+  end
+end

--- a/spec/system/epub_share_links_spec.rb
+++ b/spec/system/epub_share_links_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "EPub Share Links", type: :system do
+  let(:platform_admin) { create(:platform_admin) }
+  let(:press) { create(:press, subdomain: 'blue', share_links: true, logo_path: Rack::Test::UploadedFile.new(File.open(Rails.root.join(fixture_path, 'csv', 'shipwreck.jpg')))) }
+  let(:monograph) { create(:monograph, press: press.subdomain, user: platform_admin, visibility: "open", representative_id: cover.id) }
+  let(:cover) { create(:file_set, content: File.open(File.join(fixture_path, 'csv', 'miranda.jpg'))) }
+  let(:file_set) { create(:file_set, allow_download: 'yes', content: File.open(File.join(fixture_path, 'fake_epub_multi_rendition.epub'))) }
+  let(:epub) { Sighrax.factory(file_set.id) }
+
+  before do
+    stub_out_redis
+    monograph.ordered_members << cover
+    monograph.ordered_members << file_set
+    monograph.save!
+    cover.save!
+    file_set.save!
+    FeaturedRepresentative.create!(monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub')
+    UnpackJob.perform_now(file_set.id, 'epub')
+    Component.create!(identifier: epub.resource_token, name: epub.title, noid: epub.noid, handle: HandleService.path(epub.noid))
+  end
+
+  def take_failed_screenshot
+    false
+  end
+
+  context "depending on if you are using a share link to access an epub" do
+    it "there's an epub download button and share link button, or not" do
+      sign_in platform_admin
+
+      # For a platform_admin (or other authed user)
+      visit epub_path(id: file_set.id)
+
+      expect(page).to have_content("This is the Title")
+      # download epub button is present
+      expect(page.has_css?('.cozy-download')).to be true
+      # share link button is present
+      expect(page).to have_selector('#share-link-btn')
+
+      accept_alert do
+        # click to create a sharable link
+        find('#share-link-btn').click
+      end
+
+      # log out
+      visit presses_path
+      within("footer") do
+        click_link "Log Out"
+      end
+
+      # For an anon user following a share link
+      visit epub_path(id: file_set.id, share: ShareLinkLog.last.token)
+
+      expect(page).to have_content("This is the Title")
+      # download epub button is not present
+      expect(page.has_css?('.cozy-download')).to be false
+      # share link button is not present
+      expect(page).to have_no_selector('#share-link-btn')
+    end
+  end
+end


### PR DESCRIPTION
  Log share link creation and use (including ip addr and instituion if possible
  A user coming to the ereader from a share link:
    a) does not see the download button
    b) does not see the scholarly sharing link button