### PR TITLE
banner logic refactor

### DIFF
--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -92,7 +92,6 @@ module PressHelper
   def show_banner?(actor, subdomain) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return false unless controller.is_a?(PressCatalogController) || controller.is_a?(::MonographCatalogController)
     return false if subdomain.blank?
-    return false unless /michigan/.match?(subdomain) || /heliotrope/.match?(subdomain)
     product = banner_product(subdomain)
     return false unless product.present? && product.name.present? && product.purchase.present?
     return false if Greensub.actor_products(actor).include?(product)

--- a/spec/helpers/press_helper_spec.rb
+++ b/spec/helpers/press_helper_spec.rb
@@ -117,25 +117,27 @@ describe PressHelper do
   describe "#show_banner?" do
     subject { show_banner?(actor, subdomain) }
 
+    def banner_product(_subdomain)
+      subdomain_product
+    end
+
     let(:actor) { double('actor') }
     let(:subdomain) { 'subdomain' }
-    let(:product) { double('product', name: 'name', purchase: 'purchase') }
+    let(:subdomain_product) { nil }
     let(:actor_products) { [] }
 
-    before do
-      allow(Product).to receive(:find_by).and_return(product)
-      allow(Greensub).to receive(:actor_products).with(actor).and_return(actor_products)
-    end
+    before { allow(Greensub).to receive(:actor_products).with(actor).and_return(actor_products) }
 
     it { is_expected.to be false }
 
-    context 'press catalog' do
-      before { allow(controller).to receive(:is_a?).with(PressCatalogController).and_return(true) }
+    context 'subdomain_product' do
+      let(:product) { double('product', name: 'name', purchase: 'purchase') }
+      let(:subdomain_product) { product }
 
       it { is_expected.to be false }
 
-      context 'michigan' do
-        let(:subdomain) { 'michigan' }
+      context 'press catalog' do
+        before { allow(controller).to receive(:is_a?).with(PressCatalogController).and_return(true) }
 
         it { is_expected.to be true }
 
@@ -146,60 +148,18 @@ describe PressHelper do
         end
       end
 
-      context 'heliotrope' do
-        let(:subdomain) { 'heliotrope' }
+      context 'monograph catalog' do
+        let(:monograph) { double('monograph', valid?: true, open_access?: open_access, epub_featured_representative: epub_featured_representative) }
+        let(:open_access) { false }
+        let(:epub_featured_representative) { double('epub_featured_representative') }
+        let(:product_include) { true }
 
-        it { is_expected.to be true }
-
-        context 'actor has product' do
-          let(:actor_products) { [product] }
-
-          it { is_expected.to be false }
+        before do
+          allow(controller).to receive(:is_a?).with(PressCatalogController).and_return(false)
+          allow(controller).to receive(:is_a?).with(MonographCatalogController).and_return(true)
+          allow(Greensub).to receive(:product_include?).with(product, epub_featured_representative).and_return(product_include)
+          allow(Sighrax).to receive(:factory).and_return(monograph)
         end
-      end
-    end
-
-    context 'monograph catalog' do
-      let(:monograph) { double('monograph', valid?: true, open_access?: open_access, epub_featured_representative: epub_featured_representative) }
-      let(:open_access) { false }
-      let(:epub_featured_representative) { double('epub_featured_representative') }
-      let(:product_include) { true }
-
-      before do
-        allow(controller).to receive(:is_a?).with(PressCatalogController).and_return(false)
-        allow(controller).to receive(:is_a?).with(MonographCatalogController).and_return(true)
-        allow(Greensub).to receive(:product_include?).with(product, epub_featured_representative).and_return(product_include)
-        allow(Sighrax).to receive(:factory).and_return(monograph)
-      end
-
-      it { is_expected.to be false }
-
-      context 'michigan' do
-        let(:subdomain) { 'michigan' }
-
-        it { is_expected.to be true }
-
-        context 'actor has product' do
-          let(:actor_products) { [product] }
-
-          it { is_expected.to be false }
-        end
-
-        context 'open access' do
-          let(:open_access) { true }
-
-          it { is_expected.to be false }
-        end
-
-        context 'not included in product' do
-          let(:product_include) { false }
-
-          it { is_expected.to be false }
-        end
-      end
-
-      context 'heliotrope' do
-        let(:subdomain) { 'heliotrope' }
 
         it { is_expected.to be true }
 


### PR DESCRIPTION
The line

    return false unless /michigan/.match?(subdomain) || /heliotrope/.match?(subdomain)

was unnecessary since the next line two lines return false if the product is blank

    product = banner_product(subdomain)
    return false unless product.present? && product.name.present? && product.purchase.present?

and the product is blank because banner_product(subdomain) returns nil unless 'michigan' or 'heliotrope' and the product exist.
