### PR TITLE
add download button that displays for platform admins only

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -408,6 +408,12 @@ footer.press {
       font-size: 24px;
       font-weight: 700;
       display: block;
+      padding-bottom: .2em;
+    }
+
+    .pubdate {
+      padding-right: .4em;
+      vertical-align: middle;
     }
 
     .funder {

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -1081,17 +1081,22 @@ $um-black-80: #342f2e;
   }
 
   // links
-  a {
+  a,
+  button {
     color: $um-blue;
   }
 
   a:hover,
-  a:active {
+  a:active,
+  a:focus,
+  button:hover,
+  button:active,
+  button:focus {
     color: $um-accent-link;
   }
 
   // buttons
-  .btn {
+  .btn, .btn-group {
     @include meta;
   }
 

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -26,7 +26,7 @@
     <span aria-label="publication date" class="pubdate"><%= @monograph_presenter.date_created.first %></span>
     <% end %>
     <% if @monograph_presenter.license? %>
-      <a rel="license" href="<%= @monograph_presenter.license.first %>" target="_blank"><%= @monograph_presenter.license_link_content %></a>
+      <span class="license"><a aria-label="license" rel="license" href="<%= @monograph_presenter.license.first %>" target="_blank"><%= @monograph_presenter.license_link_content %></a></span>
     <% end %>
     <% if @monograph_presenter.copyright_holder? %>
        <% if @monograph_presenter.holding_contact? %>
@@ -48,13 +48,25 @@
       <%= render_markdown @monograph_presenter.description.first || '' %>
     </div>
     <% if @monograph_presenter.buy_url? || @monograph_presenter.epub? %>
-        <div class="btn-toolbar" role="toolbar" aria-label="">
-          <div class="btn-group" role="group" aria-label="">
+    <!-- TODO: add check for allow download of EPUB or PDF to line 50 -->
+        <div class="btn-toolbar" role="toolbar">
+          <div class="btn-group btn-group-lg" role="group">
             <% if @monograph_presenter.epub? %>
-                <a id="monograph-read-btn" href="<%= epub_path(@monograph_presenter.epub) %>" title="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %>" class="btn btn-default btn-lg" data-turbolinks="false"><%= t('monograph_catalog.index.read_book') %></a>
+                <a id="monograph-read-btn" href="<%= epub_path(@monograph_presenter.epub) %>" title="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %>" aria-label="<%= t('monograph_catalog.index.read', title: @monograph_presenter.title) %>" class="btn btn-default" data-turbolinks="false"><%= t('monograph_catalog.index.read_book') %></a>
+            <% end %>
+            <% if current_ability.platform_admin? %>
+                <!-- TODO: replace line 57 with 1) if EPUB or PDF rep is allow download and 2) checkpoint integration - only authorized users should see DL button -->
+                <div class="btn-group btn-group-lg">
+                  <button type="button" id="monograph-download-btn" target="_blank" title="<%= t('monograph_catalog.index.download', title: @monograph_presenter.title) %>" aria-label="<%= t('monograph_catalog.index.download', title: @monograph_presenter.title) %>" aria-haspopus="true" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><%= t('monograph_catalog.index.download_book') %> <span class="caret"></span></button>
+                  <!-- TODO: this may need to be more dynamic if coming from an array -->
+                  <ul class="dropdown-menu">
+                    <li><a href="#">EPUB (size)</a></li>
+                    <li><a href="#">PDF (size)</a></li>
+                  </ul>
+                </div>
             <% end %>
             <% if @monograph_presenter.buy_url? %>
-                <a id="monograph-buy-btn" href="<%= @monograph_presenter.buy_url %>" target="_blank" title="<%= t('monograph_catalog.index.buy', title: @monograph_presenter.title) %>" class="btn btn-default btn-lg" data-turbolinks="false"><%= t('monograph_catalog.index.buy_book') %></a>
+              <a id="monograph-buy-btn" href="<%= @monograph_presenter.buy_url %>" target="_blank" title="<%= t('monograph_catalog.index.buy', title: @monograph_presenter.title) %>" aria-label="<%= t('monograph_catalog.index.buy', title: @monograph_presenter.title) %>" class="btn btn-default" data-turbolinks="false"><%= t('monograph_catalog.index.buy_book') %></a>
             <% end %>
           </div><!-- /.btn-group -->
         </div><!-- /.btn-toolbar -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,12 +132,14 @@ en:
   monograph_catalog:
     banner: "You can access this title through a library that has purchased it. More information about purchasing is available at <a href=\"https://www.press.umich.edu/librarians\" id=\"banner-librarians-link\">our website</a>. <a href=\"https://www.fulcrum.org/default_login?locale=en\">Try logging in</a> if you believe your library has already purchased this collection."
     index:
-      buy: "Buy %{title}"
+      buy: "Buy a print copy of %{title}"
       buy_book: "Buy Book"
+      download: "Download %{title}"
+      download_book: "Download"
       show_page_button: "Manage Monograph and Files"
       edit_page_button: "Edit Monograph"
       home: "Home"
-      read: "Read %{title}"
+      read: "Start reading %{title}"
       read_book: "Read Book"
       reindex: "Reindex Monograph"
       reindexing: "Reindexing %{title}"


### PR DESCRIPTION
Resolves HELIO-2447

Styles download button and makes a couple minor tweaks to the display of cc licenses and pub year in monograph metadata.