### PR TITLE
Resolves HELIO-2476: reindex_everything

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -4,7 +4,7 @@ class ReindexJob < ApplicationJob
   def perform(target)
     case target
     when 'everything'
-      ActiveFedora::Base.reindex_everything
+      RestfulFedora.reindex_everything
     when 'monographs'
       Monograph.all.each do |monograph|
         UpdateIndexJob.perform_later(monograph.id)

--- a/app/services/restful_fedora.rb
+++ b/app/services/restful_fedora.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module RestfulFedora
+  class << self
+    def reindex_everything
+      Rails.logger.debug "reindex_everything ... "
+      restful_fedora = RestfulFedora::Service.new
+      Rails.logger.debug "reindex_everything ... restful_fedora"
+      contains = restful_fedora.contains
+      Rails.logger.debug "reindex_everything ... contains"
+      contains.each do |first_level_uri|
+        first_level_path = RestfulFedora.uri_to_path(first_level_uri)
+        first_level_id = RestfulFedora.path_to_id(first_level_path)
+        first_level_object = RestfulFedora.id_to_object(first_level_id)
+        Rails.logger.debug "reindex_everything ... uri: #{first_level_uri} path: #{first_level_path} id: #{first_level_id} object: #{first_level_object}"
+        next if first_level_object.blank?
+        first_level_object_and_descendants = ActiveFedora::Indexing::DescendantFetcher.new(first_level_path).descendant_and_self_uris
+        batch = []
+        first_level_object_and_descendants.each do |uri|
+          Rails.logger.debug "reindex_everything ... to_solr #{ActiveFedora::Base.uri_to_id(uri)}"
+          batch << ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri)).to_solr
+        end
+        Rails.logger.debug "reindex_everything ... batch add"
+        ActiveFedora::SolrService.add(batch, softCommit: true)
+      end
+      Rails.logger.debug "reindex_everything ... commit"
+      ActiveFedora::SolrService.commit
+    end
+
+    def url
+      ActiveFedora.config.credentials[:url]
+    end
+
+    def base_path
+      ActiveFedora.config.credentials[:base_path].gsub(/^./, '')
+    end
+
+    def uri_to_path(uri)
+      /(^.*)((#{base_path})(\/..\/..\/..\/..\/)(.*))/.match(uri)[2]
+    rescue StandardError => e
+      Rails.logger.error("ERROR: RestfulFedora.uri_to_path(#{uri}) #{e.message}")
+      uri
+    end
+
+    def path_to_id(path)
+      ActiveFedora::Base.uri_to_id(path)
+    rescue StandardError => e
+      Rails.logger.error("ERROR: RestfulFedora.path_to_id(#{path}) #{e.message}")
+      path
+    end
+
+    def id_to_object(noid)
+      ActiveFedora::Base.find(noid)
+    rescue StandardError => e
+      Rails.logger.error("ERROR: RestfulFedora.path_to_id(#{noid}) #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/restful_fedora/service.rb
+++ b/app/services/restful_fedora/service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday_middleware'
+require 'json'
+
+module RestfulFedora
+  class Service
+    def contains
+      response = connection.get do |request|
+        request.url RestfulFedora.base_path
+        request.options[:timeout] = 3600 # 1 hour
+        request.options[:open_timeout] = 4800 # 1.5 hours
+      end
+      return [] unless response.success? && response.body.present? && response.body.first.present? && response.body.first.is_a?(Hash)
+      ldp_contains = response.body.first["http://www.w3.org/ns/ldp#contains"] || []
+      ldp_contains.map { |h| h["@id"] }
+    end
+
+    def initialize(options = {})
+      @base = options[:base] || RestfulFedora.url
+    end
+
+    private
+
+      def connection
+        @connection ||= Faraday.new(@base) do |conn|
+          conn.headers = {
+            accept: "application/ld+json",
+            content_type: "application/ld+json"
+          }
+          conn.request :json
+          conn.response :json, content_type: /\bjson$/
+          conn.adapter Faraday.default_adapter
+        end
+      end
+  end
+end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe ReindexJob, type: :job do
     let(:target) { 'everything' }
 
     before do
-      allow(ActiveFedora::Base).to receive(:reindex_everything)
+      allow(RestfulFedora).to receive(:reindex_everything)
     end
 
     it 'executes perform' do
       perform_enqueued_jobs { job }
-      expect(ActiveFedora::Base).to have_received(:reindex_everything)
+      expect(RestfulFedora).to have_received(:reindex_everything)
     end
   end
 

--- a/spec/services/restful_fedora/service_spec.rb
+++ b/spec/services/restful_fedora/service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RestfulFedora::Service do
+  describe '#contains' do
+    subject(:contains) { described_class.new.contains }
+
+    before { ActiveFedora::Cleaner.clean! }
+
+    it { is_expected.to eq([]) }
+
+    it 'something' do
+      monograph = create(:monograph)
+      expect(contains.count).to eq(2)
+      paths = contains.map { |uri| RestfulFedora.uri_to_path(uri) }
+      ids = paths.map { |path| RestfulFedora.path_to_id(path) }
+      expect(ids).to include(monograph.id)
+      objects = ids.map { |id| RestfulFedora.id_to_object(id) }
+      expect(objects[0].is_a?(Monograph) || objects[1].is_a?(Monograph)).to be true
+      expect(objects[0].is_a?(Hydra::AccessControl) || objects[1].is_a?(Hydra::AccessControl)).to be true
+    end
+  end
+end

--- a/spec/services/restful_fedora_spec.rb
+++ b/spec/services/restful_fedora_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RestfulFedora do
+  describe '#reindex_everything' do
+    let(:restful_fedora) { double('restful_fedora') }
+    let(:contains) { [] }
+
+    before do
+      allow(RestfulFedora::Service).to receive(:new).and_return(restful_fedora)
+      allow(restful_fedora).to receive(:contains).and_return(contains)
+      allow(ActiveFedora::SolrService).to receive(:commit)
+    end
+
+    it do
+      described_class.reindex_everything
+      expect(ActiveFedora::SolrService).to have_received(:commit)
+    end
+
+    context 'something' do
+      let(:contains) { [uri] }
+      let(:uri) { described_class.url + '/' + object_path }
+      let(:object_path) { described_class.base_path + '/va/li/dn/oi/' + object_id }
+      let(:object_id) { 'validnoid' }
+      let(:object) { double('object') }
+      let(:object_to_solr) { double('object_to_solr') }
+      let(:descendant_fetcher) { double('descendant_fetcher') }
+      let(:descendant_path) { described_class.base_path + '/no/id/va/li/' + descendant_id }
+      let(:descendant_id) { 'noidvalid' }
+      let(:descendant) { double('descendants') }
+      let(:descendant_to_solr) { double('descendant_to_solr') }
+      let(:descendants) { [object_path, descendant_path] }
+      let(:batch) { [object_to_solr, descendant_to_solr] }
+
+      before do
+        allow(ActiveFedora::Base).to receive(:find).with(object_id).and_return(object)
+        allow(ActiveFedora::Base).to receive(:find).with(descendant_id).and_return(descendant)
+        allow(ActiveFedora::Indexing::DescendantFetcher).to receive(:new).with(object_path).and_return(descendant_fetcher)
+        allow(descendant_fetcher).to receive(:descendant_and_self_uris).and_return(descendants)
+        allow(object).to receive(:to_solr).and_return(object_to_solr)
+        allow(descendant).to receive(:to_solr).and_return(descendant_to_solr)
+        allow(ActiveFedora::SolrService).to receive(:add).with(batch, softCommit: true)
+      end
+
+      it do
+        described_class.reindex_everything
+        expect(ActiveFedora::SolrService).to have_received(:add)
+        expect(ActiveFedora::SolrService).to have_received(:commit)
+      end
+    end
+  end
+
+  describe '#url' do
+    subject { described_class.url }
+
+    it { is_expected.to eq ActiveFedora.config.credentials[:url] }
+  end
+
+  describe '#base_path' do
+    subject { described_class.base_path }
+
+    it { is_expected.to eq ActiveFedora.config.credentials[:base_path].gsub(/^./, '') }
+  end
+
+  describe '#uri_to_path' do
+    subject { described_class.uri_to_path(uri) }
+
+    let(:uri) { described_class.url + '/' + described_class.base_path + prefix + id }
+    let(:prefix) { '/va/li/dn/oi/' }
+    let(:id) { 'validnoid' }
+
+    it { is_expected.to eq described_class.base_path + prefix + id }
+
+    context 'invalid uri' do
+      let(:uri) { described_class.url + '/' + prefix + id }
+
+      it { is_expected.to eq uri }
+    end
+  end
+
+  describe '#path_to_id' do
+    subject { described_class.path_to_id(path) }
+
+    let(:path) { described_class.base_path + prefix + id }
+    let(:prefix) { '/va/li/dn/oi/' }
+    let(:id) { 'validnoid' }
+
+    it { is_expected.to eq id }
+
+    context 'invalid path' do
+      before { allow(ActiveFedora::Base).to receive(:uri_to_id).with(path).and_raise(StandardError) }
+
+      it { is_expected.to eq path }
+    end
+  end
+
+  describe '#id_to_object' do
+    subject { described_class.id_to_object(id) }
+
+    let(:id) { 'validnoid' }
+    let(:object) { double('object') }
+
+    before { allow(ActiveFedora::Base).to receive(:find).with(id).and_return(object) }
+
+    it { is_expected.to eq object }
+
+    context 'not found' do
+      before { allow(ActiveFedora::Base).to receive(:find).with(id).and_raise(StandardError) }
+
+      it { is_expected.to eq nil }
+    end
+  end
+end

--- a/spec/services/sighrax_spec.rb
+++ b/spec/services/sighrax_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Sighrax, type: :model do
+RSpec.describe Sighrax do
   describe '#facotry' do
     subject { described_class.factory(noid) }
 


### PR DESCRIPTION
When ActiveFedora::Base.reindex_everything times out or overflows the buffer try RestfulFedora.reindex_everything. 