### PR TITLE
2525_make_aptrust_upload_tracking_table

### DIFF
--- a/app/models/aptrust_upload.rb
+++ b/app/models/aptrust_upload.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AptrustUpload < ApplicationRecord
+  validates :noid, presence: { message: "noid must be given" }
+  validates :noid, uniqueness: true, on: :create
+  validates :bag_status, presence: true
+  validates :s3_status, presence: true
+  validates :apt_status, presence: true
+  validates :bag_status, numericality: { only_integer: true }
+  validates :s3_status, numericality: { only_integer: true }
+  validates :apt_status, numericality: { only_integer: true }
+end

--- a/db/migrate/20190218193221_create_aptrust_uploads.rb
+++ b/db/migrate/20190218193221_create_aptrust_uploads.rb
@@ -1,0 +1,30 @@
+class CreateAptrustUploads < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :aptrust_uploads, id: false do |t|
+      t.integer :row_number, autoincrement: true
+      t.string :noid, limit: 9, null: false, primary_key: true, unique: true
+      t.string :press, limit: 50
+      t.string :author, limit: 50
+      t.string :model, limit: 50, default: "monograph"
+      t.integer :bag_status, default: 0
+      t.integer :s3_status, default: 0
+      t.integer :apt_status, default: 0
+      t.datetime :date_monograph_modified
+      t.datetime :date_fileset_modified
+      t.datetime :date_bagged
+      t.datetime :date_uploaded
+      t.datetime :date_confirmed
+
+      t.timestamps
+    end
+    add_index :aptrust_uploads, :noid, unique: true
+    add_index :aptrust_uploads, :bag_status
+    add_index :aptrust_uploads, :s3_status
+    add_index :aptrust_uploads, :apt_status
+  end
+
+  def self.down
+    drop_table :aptrust_uploads
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190201204370) do
+ActiveRecord::Schema.define(version: 20190218193221) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -22,6 +22,27 @@ ActiveRecord::Schema.define(version: 20190201204370) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_api_requests_on_user_id"
+  end
+
+  create_table "aptrust_uploads", primary_key: "noid", id: :string, limit: 9, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "row_number"
+    t.string "press", limit: 50
+    t.string "author", limit: 50
+    t.string "model", limit: 50, default: "monograph"
+    t.integer "bag_status", default: 0
+    t.integer "s3_status", default: 0
+    t.integer "apt_status", default: 0
+    t.datetime "date_monograph_modified"
+    t.datetime "date_fileset_modified"
+    t.datetime "date_bagged"
+    t.datetime "date_uploaded"
+    t.datetime "date_confirmed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["apt_status"], name: "index_aptrust_uploads_on_apt_status"
+    t.index ["bag_status"], name: "index_aptrust_uploads_on_bag_status"
+    t.index ["noid"], name: "index_aptrust_uploads_on_noid", unique: true
+    t.index ["s3_status"], name: "index_aptrust_uploads_on_s3_status"
   end
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/factories/aptrust_uploads.rb
+++ b/spec/factories/aptrust_uploads.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :aptrust_upload do
+    row_number { 1 }
+    noid { "MyNoidsAA" }
+    press { "MyPress" }
+    author { "MyAuthor" }
+    bag_status { 0 }
+    s3_status { 0 }
+    apt_status { 0 }
+    date_monograph_modified { "2019-02-18 14:32:21" }
+    date_fileset_modified { "2019-02-18 14:32:21" }
+    date_uploaded { "2019-02-18 14:32:21" }
+    date_confirmed { "2019-02-18 14:32:21" }
+  end
+end

--- a/spec/models/aptrust_upload_spec.rb
+++ b/spec/models/aptrust_upload_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AptrustUpload, type: :model do
+  subject { described_class.new(noid: "Anything", bag_status: 0, s3_status: 0, apt_status: 0) }
+
+  it "is valid with valid attributes" do
+    expect(subject).to be_valid
+  end
+
+  it "is not valid without a noid" do
+    subject.noid = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "is not valid without a bag_status" do
+    subject.bag_status = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "is not valid without a s3_status" do
+    subject.s3_status = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "is not valid without an apt_status" do
+    subject.apt_status = nil
+    expect(subject).not_to be_valid
+  end
+end


### PR DESCRIPTION
Adds:
a migration for aptrust_uploads table
a model aptrust_upload.rb
an updated db/schema.rb
a spec/factories/aptrust_uploads.rb
a spec/models/aptrust_upload_spec.rb

rubocop and specs pass