### PR TITLE
HELIO-2461 fix render time of _index_epub_toc.html.erb

### DIFF
--- a/app/presenters/concerns/featured_representatives/monograph_presenter.rb
+++ b/app/presenters/concerns/featured_representatives/monograph_presenter.rb
@@ -22,7 +22,7 @@ module FeaturedRepresentatives
     end
 
     def epub_presenter
-      EPubPresenter.new(EPub::Publication.from_directory(UnpackService.root_path_from_noid(epub_id, 'epub')))
+      @epub_presenter ||= EPubPresenter.new(EPub::Publication.from_directory(UnpackService.root_path_from_noid(epub_id, 'epub')))
     end
 
     def webgl?
@@ -42,8 +42,9 @@ module FeaturedRepresentatives
     end
 
     def database
+      return @database if @database.present?
       solr_doc = ordered_member_docs.find { |doc| doc.id == database_id }
-      Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
+      @database ||= Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
     end
 
     def database_id
@@ -55,8 +56,9 @@ module FeaturedRepresentatives
     end
 
     def aboutware
+      return @aboutware if @aboutware.present?
       solr_doc = ordered_member_docs.find { |doc| doc.id == aboutware_id }
-      Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
+      @aboutware ||= Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
     end
 
     def aboutware_id
@@ -68,10 +70,9 @@ module FeaturedRepresentatives
     end
 
     def reviews
-      # This somewhat oddly returns a presenter not a solr_doc. Maybe they all should
-      # return presenters?
+      return @reviews if @reviews.present?
       solr_doc = ordered_member_docs.find { |doc| doc.id == reviews_id }
-      Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
+      @reviews ||= Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
     end
 
     def reviews_id
@@ -83,10 +84,9 @@ module FeaturedRepresentatives
     end
 
     def related
-      # This somewhat oddly returns a presenter not a solr_doc. Maybe they all should
-      # return presenters?
+      return @related if @related.present?
       solr_doc = ordered_member_docs.find { |doc| doc.id == related_id }
-      Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
+      @related ||= Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
     end
 
     def related_id
@@ -114,8 +114,9 @@ module FeaturedRepresentatives
     end
 
     def peer_review
+      return @peer_review if @peer_review.present?
       solr_doc = ordered_member_docs.find { |doc| doc.id == peer_review_id }
-      Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
+      @peer_review ||= Hyrax::FileSetPresenter.new(solr_doc, current_ability, request) if solr_doc.present?
     end
 
     def peer_review_id

--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -17,7 +17,7 @@
       <% end %>
       <li>
     <% end %>
-    <a class="toc-link" href="<%= epub_path(id: @monograph_presenter.epub_id, anchor: interval.cfi) %>"><%= interval.title %></a>
+    <a class="toc-link" href="<%= epub_path(id: @monograph_presenter.epub_id).gsub!(/\?.*/, '') + '#' + interval.cfi  %>"><%= interval.title %></a>
     <% if @monograph_presenter.epub_presenter.multi_rendition? %>
       <div class="btn-group download" role="group" aria-label="Read or Download Section">
         <% if interval.downloadable? %>

--- a/lib/e_pub/rendition.rb
+++ b/lib/e_pub/rendition.rb
@@ -26,7 +26,9 @@ module EPub
           next if header.text.blank?
           idref, index = @unmarshaller_rootfile.content.idref_with_index_from_href(header.href)
           cfi = if /.*#.*/.match?(header.href)
-                  @unmarshaller_rootfile.content.cfi_from_href_anchor_tag(idref, index, header.href)
+                  # Don't use the CFI for multi level TOCs that have url fragments/anchors where
+                  # the TOC might be very large and take a long time to calculate all the CFIs. See HELIO-2461
+                  file_url(header.href)
                 else
                   "/6/#{index * 2}[#{idref}]!/4/1:0"
                 end
@@ -48,6 +50,12 @@ module EPub
     end
 
     private
+
+      def file_url(href)
+        # This works due to a change in CSB
+        # https://github.com/mlibrary/cozy-sun-bear/commit/8875fb87669d23363d5bb6bb244f291a13793971
+        "/#{File.dirname(@publication.content_file)}/#{href.gsub('#', '%23')}"
+      end
 
       def initialize(publication, unmarshaller_rootfile)
         @publication = publication

--- a/lib/e_pub/unmarshaller/content.rb
+++ b/lib/e_pub/unmarshaller/content.rb
@@ -57,17 +57,6 @@ module EPub
         @chapter_list
       end
 
-      def cfi_from_href_anchor_tag(idref, index, toc_href)
-        tag = toc_href.split('#').last
-
-        chapter_href = @content_doc.xpath(".//manifest/item[@id='#{idref}']").first.attributes["href"].value
-        chapter = File.join(File.dirname(@full_path), chapter_href)
-        doc = Nokogiri::XML::Document.parse(File.open(chapter)).remove_namespaces!
-        node = doc.at_css(%([id="#{tag}"]))
-
-        "/6/#{index * 2}[#{idref}]!" + EPub::CFI.from(node).cfi
-      end
-
       private
 
         def initialize(rootfile, full_path)

--- a/lib/spec/e_pub/unmarshaller/content_spec.rb
+++ b/lib/spec/e_pub/unmarshaller/content_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe EPub::Unmarshaller::Content do
             it { expect(subject.chapter_from_title('title')).to be_an_instance_of(EPub::Unmarshaller::ChapterNullObject) }
             it { expect(subject.nav).to be_an_instance_of(EPub::Unmarshaller::Nav) }
             it { expect(subject.chapter_list).to be_an_instance_of(EPub::Unmarshaller::ChapterList) }
-            it { expect(subject.cfi_from_href_anchor_tag(idref, index, href)).to eq "/6/2[1]!/4/2[one]" }
           end
         end
       end


### PR DESCRIPTION
* Do not calculate CFIs for TOC members with anchor tags
* Do not re-open the epub every time monograph_presenter.epub_presenter is called

According to skylight and testing this is a vast improvment, but is still not perfect.