### PR TITLE
Rake task to add a monograph with 8500 assets one file_set at a time.

### DIFF
--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -222,13 +222,13 @@ module Hyrax
         @ordered_member_docs = []
         return @ordered_member_docs
       else
-        query_results = ActiveFedora::SolrService.query("{!terms f=id}#{ids.join(',')}", rows: ids.count)
+        query_results = ActiveFedora::SolrService.query("{!terms f=monograph_id_ssim}#{solr_document.id}", rows: ids.count)
 
         docs_hash = query_results.each_with_object({}) do |res, h|
           h[res['id']] = ::SolrDocument.new(res)
         end
 
-        @ordered_member_docs = ids.map { |id| docs_hash[id] }
+        @ordered_member_docs = ids.map { |id| docs_hash[id] }.compact
       end
     end
 

--- a/lib/tasks/ingest_per_fileset.rake
+++ b/lib/tasks/ingest_per_fileset.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# This is really only to be used for a single 8500+ fileset monograph
+# so is very specific. Could be generalized for other monographs with
+# a very large number of assets
+
+desc "Ingest a monograph + files one file at a time"
+namespace :heliotrope do
+  # To run: rake "heliotrope:ingest_per_fileset[/path/to/csv/file.csv, 999999999]"  # monograph id is optional
+  task :ingest_per_fileset, [:csv_input_file, :optional_monograph_id] => :environment do |_t, args|
+    attrs = Import::CSVParser.new(args.csv_input_file).attributes
+    filenames = attrs.delete("files")
+    file_metadata = attrs.delete("files_metadata")
+    attrs.delete("row_errors")
+    attrs['press'] = 'heb'
+    attrs['visibility'] = 'restricted'
+    user = User.batch_user
+    current_ability = Ability.new(user)
+
+    if args.optional_monograph_id.present?
+      mono = Monograph.find args.optional_monograph_id
+      puts "#{Time.new}: Using Monograph #{mono.id}"
+    else
+      mono = Monograph.new
+      Hyrax::CurationConcern.actor.create(Hyrax::Actors::Environment.new(mono, current_ability, attrs))
+      sleep(1) until (Resque.info[:pending] == 0 && Resque.info[:working] == 0)
+      mono.reload
+      puts "#{Time.new}: Monograph #{mono.id} created"
+    end
+
+    filenames.each_index do |i|
+      sleep(1) until (Resque.info[:pending] == 0 && Resque.info[:working] == 0)
+
+      file_set = FileSet.where(label: filenames[i])&.first
+      if file_set.present? && file_set.original_file&.file_name&.first == filenames[i]
+        # already ingested. just in case this rake task dies and we need to re-run it
+        puts "#{Time.new}: #{filenames[i]} already ingested!"
+      else
+        file = File.join(File.dirname(args.csv_input_file), filenames[i])
+        uploaded_file = Hyrax::UploadedFile.create(file: File.new(file), user: user)
+        attrs['import_uploaded_files_ids'] = [uploaded_file['id']]
+        attrs['import_uploaded_files_attributes'] = [file_metadata[i]]
+
+        Hyrax::CurationConcern.actor.update(Hyrax::Actors::Environment.new(mono, current_ability, attrs))
+
+        puts "#{Time.now}: Ingesting #{filenames[i]}"
+      end
+    end
+
+    puts "#{Time.now}: Done"
+  end
+end

--- a/spec/features/external_resource_icons_spec.rb
+++ b/spec/features/external_resource_icons_spec.rb
@@ -17,6 +17,8 @@ describe "Monograph Catalog Facets" do
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
+      cover.save!
+      file_set1.save!
     end
 
     it "image shows picture icon in list view" do
@@ -44,6 +46,8 @@ describe "Monograph Catalog Facets" do
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
+      cover.save!
+      file_set1.save!
     end
 
     it "text shows file icon in list view" do
@@ -71,6 +75,8 @@ describe "Monograph Catalog Facets" do
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
+      cover.save!
+      file_set1.save!
     end
 
     it "video shows film icon in list view" do
@@ -98,6 +104,8 @@ describe "Monograph Catalog Facets" do
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
+      cover.save!
+      file_set1.save!
     end
 
     it "audio shows 'volume up' icon in list view" do

--- a/spec/features/monograph_catalog_facets_spec.rb
+++ b/spec/features/monograph_catalog_facets_spec.rb
@@ -20,6 +20,8 @@ describe "Monograph Catalog Facets" do
       monograph.ordered_members << cover
       monograph.ordered_members << file_set1
       monograph.save!
+      cover.save!
+      file_set1.save!
     end
 
     it "shows keywords in the intended order" do
@@ -50,6 +52,10 @@ describe "Monograph Catalog Facets" do
     let(:fs4) { build(:public_file_set, title: ['Sec 3 File 1'], section_title: s3_title) }
     let(:fs5) { build(:public_file_set, title: ['Sec 3 File 2'], section_title: s3_title) }
     let(:fs6) { build(:public_file_set, title: ['Sec 3 File 3'], section_title: s3_title) }
+
+    before do
+      [cover, fs1, fs2, fs3, fs4, fs5, fs6].each(&:save!)
+    end
 
     it "shows sections in intended order" do
       visit monograph_catalog_facet_path(id: 'section_title_sim', monograph_id: monograph.id)
@@ -90,6 +96,10 @@ describe "Monograph Catalog Facets" do
     let(:fs5) { build(:public_file_set, title: ['File 5'], section_title: ['B 2']) }
     let(:fs6) { build(:public_file_set, title: ['File 6'], section_title: ['A 3']) }
 
+    before do
+      [cover, fs1, fs2, fs3, fs4, fs5, fs6].each(&:save!)
+    end
+
     it "shows sections in intended order" do
       visit monograph_catalog_facet_path(id: 'section_title_sim', monograph_id: monograph.id)
 
@@ -110,6 +120,10 @@ describe "Monograph Catalog Facets" do
     end
 
     let(:fs) { create(:public_file_set, section_title: ["A Section with _Italicized Title_ Stuff"]) }
+
+    before do
+      [cover, fs].each(&:save!)
+    end
 
     it "shows italics (emphasis) in section facet links" do
       visit monograph_catalog_path(id: monograph.id)
@@ -137,6 +151,10 @@ describe "Monograph Catalog Facets" do
     let(:file_set) { create(:public_file_set, resource_type: [expected_resource_facet], content_type: [expected_content_facet]) }
     let(:facets) { "#facets" }
     let(:selected_facets) { "#appliedParams" }
+
+    before do
+      [cover, file_set].each(&:save!)
+    end
 
     it "Select facets from resource_type (parent) and content_type (child)" do
       visit monograph_catalog_path(id: monograph.id)
@@ -281,6 +299,7 @@ describe "Monograph Catalog Facets" do
       login_as user
       monograph.ordered_members = [cover, file_set]
       monograph.save!
+      [cover, file_set].each(&:save!)
     end
 
     it "shows the correct facets" do

--- a/spec/features/monograph_catalog_sort_spec.rb
+++ b/spec/features/monograph_catalog_sort_spec.rb
@@ -23,6 +23,8 @@ describe 'Monograph catalog sort' do
       fileset_count.times { |index| monograph.ordered_members << FactoryBot.create(:file_set, sort_date: "#{1900 + index}-01-01") }
       monograph.save!
       monograph.ordered_members.to_a.each(&:save!)
+      cover.save!
+      fileset_outlier.save!
       # Stub the pagination to a low number so that we don't
       # have to create so many records to exercise pagination.
       allow_any_instance_of(::Blacklight::Configuration).to receive(:default_per_page).and_return(per_page)

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Hyrax::MonographPresenter do
                          ordered_member_ids_ssim: ordered_ids)
     }
 
-    let(:cover) { ::SolrDocument.new(id: 'cover', has_model_ssim: ['FileSet']) }
-    let(:blue_file) { ::SolrDocument.new(id: 'blue', has_model_ssim: ['FileSet']) }
-    let(:green_file) { ::SolrDocument.new(id: 'green', has_model_ssim: ['FileSet']) }
+    let(:cover) { ::SolrDocument.new(id: 'cover', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:blue_file) { ::SolrDocument.new(id: 'blue', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:green_file) { ::SolrDocument.new(id: 'green', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
 
     context 'has assets' do
       let(:ordered_ids) { [cover.id, blue_file.id, green_file.id] }
@@ -211,9 +211,9 @@ RSpec.describe Hyrax::MonographPresenter do
                          ordered_member_ids_ssim: ordered_ids)
     }
 
-    let(:cover) { ::SolrDocument.new(id: 'cover', has_model_ssim: ['FileSet']) }
-    let(:blue_file) { ::SolrDocument.new(id: 'blue', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 2']) }
-    let(:green_file) { ::SolrDocument.new(id: 'green', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 4']) }
+    let(:cover) { ::SolrDocument.new(id: 'cover', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:blue_file) { ::SolrDocument.new(id: 'blue', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 2']) }
+    let(:green_file) { ::SolrDocument.new(id: 'green', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 4']) }
 
     context 'monograph.ordered_members contains a non-file' do
       let(:non_file) { SolrDocument.new(id: 'NotAFile', has_model_ssim: ['Monograph']) } # It doesn't have section_title_tesim
@@ -231,7 +231,7 @@ RSpec.describe Hyrax::MonographPresenter do
     end
 
     context 'a fileset that belongs to more than 1 chapter' do
-      let(:red_file) { ::SolrDocument.new(id: 'red', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 1', 'chapter 3']) }
+      let(:red_file) { ::SolrDocument.new(id: 'red', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet'], section_title_tesim: ['chapter 1', 'chapter 3']) }
 
       let(:ordered_ids) {
         # red_file appears in both chapter 1 and chapter 3
@@ -311,10 +311,10 @@ RSpec.describe Hyrax::MonographPresenter do
 
   context 'a monograph with attached members' do
     # the cover FileSet won't be included in the ordered_file_sets_ids
-    let(:cover_fileset_doc) { ::SolrDocument.new(id: 'cover', has_model_ssim: ['FileSet']) }
-    let(:fs1_doc) { ::SolrDocument.new(id: 'fs1', has_model_ssim: ['FileSet']) }
-    let(:fs2_doc) { ::SolrDocument.new(id: 'fs2', has_model_ssim: ['FileSet']) }
-    let(:fs3_doc) { ::SolrDocument.new(id: 'fs3', has_model_ssim: ['FileSet']) }
+    let(:cover_fileset_doc) { ::SolrDocument.new(id: 'cover', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:fs1_doc) { ::SolrDocument.new(id: 'fs1', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:fs2_doc) { ::SolrDocument.new(id: 'fs2', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
+    let(:fs3_doc) { ::SolrDocument.new(id: 'fs3', monograph_id_ssim: 'mono', has_model_ssim: ['FileSet']) }
 
     let(:expected_id_count) { 3 }
 

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe 'hyrax/file_sets/show' do
       monograph.ordered_members = []
       monograph.ordered_members << file_set1 << file_set2 << file_set3 << file_set
       monograph.save!
+      [file_set1, file_set2, file_set3, file_set].each(&:save!)
       render
       expect(rendered).to have_css('ul.tabular.list-unstyled li.attribute.section_title', count: 3)
       expect(rendered).to match(/.*Chapter 1.*Chapter 2.*Chapter 3.*/)
@@ -103,6 +104,7 @@ RSpec.describe 'hyrax/file_sets/show' do
       monograph.ordered_members = []
       monograph.ordered_members << file_set
       monograph.save!
+      file_set.save!
       render
       expect(rendered).to have_css('ul.tabular.list-unstyled li.attribute.section_title', count: 2)
       expect(rendered).to match(/Chapter 1.*Chapter 3/)


### PR DESCRIPTION
Also: invert the way the monograph_search_builder gets a monograph's
file_sets. Instead of sending file_set noids in a big list (which
results in a huge solr query for monographs with many, many file_sets),
get file_sets that have the monograph's id in it's monograph_id_ssim.

When we add a new Work type we're going to have to adjust this, but that was going to have to happen anyway (rename 'monograph_id_ssim' to 'parent_id_ssim' or something in the indexer, but now also the monograph_search_builder too).
