### PR TITLE
HELIO-2562 Download widget displays files when 'Allow Download?'='no'

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -106,8 +106,10 @@ module Hyrax
 
     def allow_download?
       return false if external_resource?
+      # AbilityCheckpoint erroneously returns true for can?(:edit, ...) whereas Ability returns a sane value.
+      return true if !current_ability.instance_of?(AbilityCheckpoint) && current_ability&.can?(:edit, id)
       # safe navigation (&.) as current_Ability is nil in some specs, should match allow_download? logic in downloads_controller
-      allow_download&.casecmp('yes')&.zero? || current_ability&.platform_admin? || current_ability&.can?(:edit, id)
+      allow_download&.casecmp('yes')&.zero? || current_ability&.platform_admin?
     end
 
     # Google Analytics


### PR DESCRIPTION
I am hoping the Checkpoint cleanup can make the need for this hack go away.