### PR TITLE
Resolves HELIO-2582: Turnsole Greensub Refactor

### DIFF
--- a/app/controllers/api/v1/individuals_controller.rb
+++ b/app/controllers/api/v1/individuals_controller.rb
@@ -103,7 +103,7 @@ module API
       def update
         if params[:product_id].present?
           set_product
-          Greensub.subscribe(@individual, @product)
+          Greensub.subscribe(subscriber: @individual, target: @product)
           return head :ok
         end
         return render json: @individual.errors, status: :unprocessable_entity unless @individual.update(individual_params)
@@ -125,7 +125,7 @@ module API
       def destroy
         if params[:product_id].present?
           set_product
-          Greensub.unsubscribe(@individual, @product)
+          Greensub.unsubscribe(subscriber: @individual, target: @product)
         else
           return render json: @individual.errors, status: :accepted unless @individual.destroy
         end

--- a/app/controllers/api/v1/institutions_controller.rb
+++ b/app/controllers/api/v1/institutions_controller.rb
@@ -103,7 +103,7 @@ module API
       def update
         if params[:product_id].present?
           set_product
-          Greensub.subscribe(@institution, @product)
+          Greensub.subscribe(subscriber: @institution, target: @product)
           return head :ok # rubocop:disable Style/RedundantReturn
         else
           return render json: @institution.errors, status: :unprocessable_entity unless @institution.update(institution_params)
@@ -126,7 +126,7 @@ module API
       def destroy
         if params[:product_id].present?
           set_product
-          Greensub.unsubscribe(@institution, @product)
+          Greensub.unsubscribe(subscriber: @institution, target: @product)
         else
           return render json: @institution.errors, status: :accepted unless @institution.destroy
         end

--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -99,7 +99,7 @@ module PressHelper
     monograph = Sighrax.factory(@monograph_presenter&.id)
     return false unless monograph.valid?
     return false if Sighrax.open_access?(monograph)
-    Greensub.product_include?(product, monograph)
+    Greensub.product_include?(product: product, entity: monograph)
   end
 
   def banner_product(subdomain)

--- a/app/services/greensub.rb
+++ b/app/services/greensub.rb
@@ -10,17 +10,17 @@ module Greensub
       products.uniq
     end
 
-    def subscribed?(subscriber, product)
-      Authority.permits?(subscriber, permission_read, product)
+    def subscribed?(subscriber:, target:)
+      Authority.permits?(subscriber, permission_read, target)
     end
 
-    def subscribe(subscriber, product)
-      return if subscribed?(subscriber, product)
-      Authority.grant!(subscriber, permission_read, product) unless Authority.permits?(subscriber, permission_read, product)
+    def subscribe(subscriber:, target:)
+      return if subscribed?(subscriber: subscriber, target: target)
+      Authority.grant!(subscriber, permission_read, target) unless Authority.permits?(subscriber, permission_read, target)
     end
 
-    def unsubscribe(subscriber, product)
-      Authority.revoke!(subscriber, permission_read, product) if Authority.permits?(subscriber, permission_read, product)
+    def unsubscribe(subscriber:, target:)
+      Authority.revoke!(subscriber, permission_read, target) if Authority.permits?(subscriber, permission_read, target)
     end
 
     def subscriber_products(subscriber)
@@ -35,7 +35,7 @@ module Greensub
       subscribers.compact
     end
 
-    def product_include?(product, entity)
+    def product_include?(product:, entity:)
       return false unless product.present? && entity.present?
       noids = product.components.map(&:noid)
       noids.include?(entity.noid)

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe EPubsController, type: :controller do
           product = Product.create!(identifier: 'product', name: 'name', purchase: 'purchase')
           product.components << component
           product.save!
-          Greensub.subscribe(institution, product)
+          Greensub.subscribe(subscriber: institution, target: product)
           get :show, params: { id: file_set.id }
           expect(response).to have_http_status(:success)
           expect(response).to render_template(:show)
@@ -333,7 +333,7 @@ RSpec.describe EPubsController, type: :controller do
           product = Product.create!(identifier: 'product', name: 'name', purchase: 'purchase')
           product.components << component
           product.save!
-          Greensub.subscribe(individual, product)
+          Greensub.subscribe(subscriber: individual, target: product)
           sign_in(user)
           get :show, params: { id: file_set.id }
           expect(response).to have_http_status(:success)

--- a/spec/controllers/grants_controller_spec.rb
+++ b/spec/controllers/grants_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe GrantsController, type: :controller do
 
   describe "GET #index" do
     it "returns a success response" do
-      Greensub.subscribe(individual, product)
+      Greensub.subscribe(subscriber: individual, target: product)
       get :index, params: {}, session: valid_session
       expect(response).to be_success
       expect(response).to render_template(:index)
@@ -56,7 +56,7 @@ RSpec.describe GrantsController, type: :controller do
 
   describe "GET #show" do
     it "returns a success response" do
-      Greensub.subscribe(individual, product)
+      Greensub.subscribe(subscriber: individual, target: product)
       get :show, params: { id: grants_table_last.id }, session: valid_session
       expect(response).to be_success
       expect(response).to render_template(:show)
@@ -128,7 +128,7 @@ RSpec.describe GrantsController, type: :controller do
 
   describe "DELETE #destroy" do
     it "destroys the requested grant" do
-      Greensub.subscribe(individual, product)
+      Greensub.subscribe(subscriber: individual, target: product)
       delete :destroy, params: { id: grants_table_last.id }, session: valid_session
       expect(grants_table_count).to be_zero
       expect(response).to redirect_to(grants_url)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe SessionsController, type: :controller do
       product = Product.create!(identifier: 'product', name: 'name', purchase: 'purchase')
       product.components << component
       product.save!
-      Greensub.subscribe(institution1, product)
+      Greensub.subscribe(subscriber: institution1, target: product)
       get :discovery_feed, params: { id: file_set.id }
       expect(response).to have_http_status(:success)
       expect { JSON.parse response.body }.not_to raise_error

--- a/spec/helpers/press_helper_spec.rb
+++ b/spec/helpers/press_helper_spec.rb
@@ -156,7 +156,7 @@ describe PressHelper do
         before do
           allow(controller).to receive(:is_a?).with(PressCatalogController).and_return(false)
           allow(controller).to receive(:is_a?).with(MonographCatalogController).and_return(true)
-          allow(Greensub).to receive(:product_include?).with(product, monograph).and_return(product_include)
+          allow(Greensub).to receive(:product_include?).with(product: product, entity: monograph).and_return(product_include)
           allow(Sighrax).to receive(:factory).and_return(monograph)
           allow(Sighrax).to receive(:open_access?).with(monograph).and_return(open_access)
         end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Component, type: :model do
     end
 
     it 'grants present' do
-      Greensub.subscribe(individual, component)
+      Greensub.subscribe(subscriber: individual, target: component)
       expect(component.destroy).to be false
       expect(component.errors.count).to eq 1
       expect(component.errors.first[0]).to eq :base
@@ -116,13 +116,13 @@ RSpec.describe Component, type: :model do
       expect(subject.destroy?).to be true
       expect(subject.grants?).to be false
 
-      Greensub.subscribe(individual, subject)
+      Greensub.subscribe(subscriber: individual, target: subject)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.unsubscribe(individual, subject)
+      Greensub.unsubscribe(subscriber: individual, target: subject)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be true

--- a/spec/models/individual_spec.rb
+++ b/spec/models/individual_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Individual, type: :model do
     let(:component) { create(:component) }
 
     it 'grant product present' do
-      Greensub.subscribe(individual, product)
+      Greensub.subscribe(subscriber: individual, target: product)
       expect(individual.destroy).to be false
       expect(individual.errors.count).to eq 1
       expect(individual.errors.first[0]).to eq :base
@@ -58,13 +58,13 @@ RSpec.describe Individual, type: :model do
       expect(subject.destroy?).to be true
       expect(subject.grants?).to be false
 
-      Greensub.subscribe(subject, product)
+      Greensub.subscribe(subscriber: subject, target: product)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.unsubscribe(subject, product)
+      Greensub.unsubscribe(subscriber: subject, target: product)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be true
@@ -92,13 +92,13 @@ RSpec.describe Individual, type: :model do
 
         product_2
 
-        Greensub.subscribe(subject, product_2)
+        Greensub.subscribe(subscriber: subject, target: product_2)
         expect(subject.products.count).to eq 1
 
         product_2.components << component_b
         expect(subject.products.count).to eq 1
 
-        Greensub.subscribe(subject, product_1)
+        Greensub.subscribe(subscriber: subject, target: product_1)
         expect(subject.products.count).to eq 2
 
         product_1.components << component_b
@@ -107,10 +107,10 @@ RSpec.describe Individual, type: :model do
         clear_grants_table
         expect(subject.products.count).to eq 0
 
-        Greensub.subscribe(subject, component_b)
+        Greensub.subscribe(subscriber: subject, target: component_b)
         expect(subject.products.count).to eq 0
 
-        Greensub.subscribe(subject, component_a)
+        Greensub.subscribe(subscriber: subject, target: component_a)
         expect(subject.products.count).to eq 0
 
         clear_grants_table

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Institution, type: :model do
     let(:component) { create(:component) }
 
     it 'grant product present' do
-      Greensub.subscribe(institution, product)
+      Greensub.subscribe(subscriber: institution, target: product)
       expect(institution.destroy).to be false
       expect(institution.errors.count).to eq 1
       expect(institution.errors.first[0]).to eq :base
@@ -56,7 +56,7 @@ RSpec.describe Institution, type: :model do
     end
 
     it 'other grants present' do
-      Greensub.subscribe(institution, component)
+      Greensub.subscribe(subscriber: institution, target: component)
       expect(institution.destroy).to be false
       expect(institution.errors.count).to eq 1
       expect(institution.errors.first[0]).to eq :base
@@ -74,13 +74,13 @@ RSpec.describe Institution, type: :model do
       expect(subject.destroy?).to be true
       expect(subject.grants?).to be false
 
-      Greensub.subscribe(subject, product)
+      Greensub.subscribe(subscriber: subject, target: product)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.unsubscribe(subject, product)
+      Greensub.unsubscribe(subscriber: subject, target: product)
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be true
@@ -108,13 +108,13 @@ RSpec.describe Institution, type: :model do
 
         product_2
 
-        Greensub.subscribe(subject, product_2)
+        Greensub.subscribe(subscriber: subject, target: product_2)
         expect(subject.products.count).to eq 1
 
         product_2.components << component_b
         expect(subject.products.count).to eq 1
 
-        Greensub.subscribe(subject, product_1)
+        Greensub.subscribe(subscriber: subject, target: product_1)
         expect(subject.products.count).to eq 2
 
         product_1.components << component_b
@@ -123,10 +123,10 @@ RSpec.describe Institution, type: :model do
         clear_grants_table
         expect(subject.products.count).to eq 0
 
-        Greensub.subscribe(subject, component_b)
+        Greensub.subscribe(subscriber: subject, target: component_b)
         expect(subject.products.count).to eq 0
 
-        Greensub.subscribe(subject, component_a)
+        Greensub.subscribe(subscriber: subject, target: component_a)
         expect(subject.products.count).to eq 0
 
         clear_grants_table

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Product, type: :model do
 
     it 'grants present' do
       individual = create(:individual)
-      Greensub.subscribe(individual, product)
+      Greensub.subscribe(subscriber: individual, target: product)
       expect(product.destroy).to be false
       expect(product.errors.count).to eq 1
       expect(product.errors.first[0]).to eq :base
@@ -87,28 +87,28 @@ RSpec.describe Product, type: :model do
       expect(subject.destroy?).to be true
       expect(subject.grants?).to be false
 
-      Greensub.subscribe(individual, subject)
+      Greensub.subscribe(subscriber: individual, target: subject)
       expect(subject.subscribers).to match_array([individual])
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.subscribe(institution, subject)
+      Greensub.subscribe(subscriber: institution, target: subject)
       expect(subject.subscribers).to match_array([individual, institution])
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.unsubscribe(individual, subject)
+      Greensub.unsubscribe(subscriber: individual, target: subject)
       expect(subject.subscribers).to match_array([institution])
 
       expect(subject.update?).to be true
       expect(subject.destroy?).to be false
       expect(subject.grants?).to be true
 
-      Greensub.unsubscribe(institution, subject)
+      Greensub.unsubscribe(subscriber: institution, target: subject)
       expect(subject.subscribers).to be_empty
 
       expect(subject.update?).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -163,10 +163,10 @@ RSpec.describe User do
     product = create(:product)
     expect(user.grants?).to be false
 
-    Greensub.subscribe(user, product)
+    Greensub.subscribe(subscriber: user, target: product)
     expect(user.grants?).to be true
 
-    Greensub.unsubscribe(user, product)
+    Greensub.unsubscribe(subscriber: user, target: product)
     expect(user.grants?).to be false
   end
 

--- a/spec/requests/api/v1/individuals_spec.rb
+++ b/spec/requests/api/v1/individuals_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "Individuals", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(individual, product)).to be true
+          expect(Greensub.subscribed?(subscriber: individual, target: product)).to be true
         end
 
         it 'existing individual twice ok' do
@@ -300,7 +300,7 @@ RSpec.describe "Individuals", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(individual, product)).to be true
+          expect(Greensub.subscribed?(subscriber: individual, target: product)).to be true
           expect(grants_table_count).to eq(1)
         end
       end
@@ -326,7 +326,7 @@ RSpec.describe "Individuals", type: :request do
       end
 
       it 'existing with products accepted' do
-        Greensub.subscribe(individual, product)
+        Greensub.subscribe(subscriber: individual, target: product)
         delete api_individual_path(individual), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:accepted)
@@ -355,7 +355,7 @@ RSpec.describe "Individuals", type: :request do
       context 'existing product' do
         let(:product) { create(:product) }
 
-        before { Greensub.subscribe(individual, product) }
+        before { Greensub.subscribe(subscriber: individual, target: product) }
 
         it 'non existing individual not_found' do
           delete api_product_individual_path(product, 1), headers: headers
@@ -369,7 +369,7 @@ RSpec.describe "Individuals", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(individual, product)).to be false
+          expect(Greensub.subscribed?(subscriber: individual, target: product)).to be false
         end
 
         it 'existing individual twice ok' do
@@ -378,7 +378,7 @@ RSpec.describe "Individuals", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(individual, product)).to be false
+          expect(Greensub.subscribed?(subscriber: individual, target: product)).to be false
         end
       end
     end

--- a/spec/requests/api/v1/institutions_spec.rb
+++ b/spec/requests/api/v1/institutions_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "Institutions", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(institution, product)).to be true
+          expect(Greensub.subscribed?(subscriber: institution, target: product)).to be true
         end
 
         it 'existing institution twice ok' do
@@ -300,7 +300,7 @@ RSpec.describe "Institutions", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(institution, product)).to be true
+          expect(Greensub.subscribed?(subscriber: institution, target: product)).to be true
           expect(grants_table_count).to eq(1)
         end
       end
@@ -326,7 +326,7 @@ RSpec.describe "Institutions", type: :request do
       end
 
       it 'existing with products accepted' do
-        Greensub.subscribe(institution, product)
+        Greensub.subscribe(subscriber: institution, target: product)
         delete api_institution_path(institution), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:accepted)
@@ -355,7 +355,7 @@ RSpec.describe "Institutions", type: :request do
       context 'existing product' do
         let(:product) { create(:product) }
 
-        before { Greensub.subscribe(institution, product) }
+        before { Greensub.subscribe(subscriber: institution, target: product) }
 
         it 'non existing institution not_found' do
           delete api_product_institution_path(product, 1), headers: headers
@@ -369,7 +369,7 @@ RSpec.describe "Institutions", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(institution, product)).to be false
+          expect(Greensub.subscribed?(subscriber: institution, target: product)).to be false
         end
 
         it 'existing institution twice ok' do
@@ -378,7 +378,7 @@ RSpec.describe "Institutions", type: :request do
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:ok)
           expect(response.body).to be_empty
-          expect(Greensub.subscribed?(institution, product)).to be false
+          expect(Greensub.subscribed?(subscriber: institution, target: product)).to be false
         end
       end
     end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Products", type: :request do
       end
 
       it 'product ok' do
-        Greensub.subscribe(individual, product)
+        Greensub.subscribe(subscriber: individual, target: product)
         get api_individual_products_path(individual), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
@@ -165,8 +165,8 @@ RSpec.describe "Products", type: :request do
       end
 
       it 'products ok' do
-        Greensub.subscribe(individual, product)
-        Greensub.subscribe(individual, new_product)
+        Greensub.subscribe(subscriber: individual, target: product)
+        Greensub.subscribe(subscriber: individual, target: new_product)
         get api_individual_products_path(individual), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
@@ -201,7 +201,7 @@ RSpec.describe "Products", type: :request do
       end
 
       it 'product ok' do
-        Greensub.subscribe(institution, product)
+        Greensub.subscribe(subscriber: institution, target: product)
         get api_institution_products_path(institution), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
@@ -210,8 +210,8 @@ RSpec.describe "Products", type: :request do
       end
 
       it 'products ok' do
-        Greensub.subscribe(institution, product)
-        Greensub.subscribe(institution, new_product)
+        Greensub.subscribe(subscriber: institution, target: product)
+        Greensub.subscribe(subscriber: institution, target: new_product)
         get api_institution_products_path(institution), headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)

--- a/spec/services/greensub_spec.rb
+++ b/spec/services/greensub_spec.rb
@@ -27,71 +27,71 @@ RSpec.describe Greensub do
     expect(greensub.product_subscribers(products[1])).to be_empty
     expect(greensub.product_subscribers(products[2])).to be_empty
 
-    greensub.subscribe(individual, products[0])
-    expect(greensub.subscribed?(individual, products[0])).to be true
+    greensub.subscribe(subscriber: individual, target: products[0])
+    expect(greensub.subscribed?(subscriber: individual, target: products[0])).to be true
     expect(greensub.subscriber_products(individual)).to match_array([products[0]])
     expect(greensub.product_subscribers(products[0])).to match_array([individual])
     expect(greensub.actor_products(actor).count).to eq 1
     expect(greensub.actor_products(actor)).to match_array([products[0]])
 
-    greensub.subscribe(institutions[0], products[1])
-    expect(greensub.subscribed?(institutions[0], products[1])).to be true
+    greensub.subscribe(subscriber: institutions[0], target: products[1])
+    expect(greensub.subscribed?(subscriber: institutions[0], target: products[1])).to be true
     expect(greensub.subscriber_products(institutions[0])).to match_array([products[1]])
     expect(greensub.product_subscribers(products[1])).to match_array([institutions[0]])
     expect(greensub.actor_products(actor).count).to eq 2
     expect(greensub.actor_products(actor)).to match_array([products[0], products[1]])
 
-    greensub.subscribe(institutions[1], products[2])
-    expect(greensub.subscribed?(institutions[1], products[2])).to be true
+    greensub.subscribe(subscriber: institutions[1], target: products[2])
+    expect(greensub.subscribed?(subscriber: institutions[1], target: products[2])).to be true
     expect(greensub.subscriber_products(institutions[1])).to match_array([products[2]])
     expect(greensub.product_subscribers(products[2])).to match_array([institutions[1]])
     expect(greensub.actor_products(actor).count).to eq 3
     expect(greensub.actor_products(actor)).to match_array([products[0], products[1], products[2]])
 
-    greensub.subscribe(individual, products[1])
-    expect(greensub.subscribed?(individual, products[1])).to be true
+    greensub.subscribe(subscriber: individual, target: products[1])
+    expect(greensub.subscribed?(subscriber: individual, target: products[1])).to be true
     expect(greensub.subscriber_products(individual)).to match_array([products[0], products[1]])
     expect(greensub.product_subscribers(products[1])).to match_array([individual, institutions[0]])
     expect(greensub.actor_products(actor).count).to eq 3
     expect(greensub.actor_products(actor)).to match_array([products[0], products[1], products[2]])
 
-    greensub.subscribe(institutions[0], products[0])
-    expect(greensub.subscribed?(institutions[0], products[0])).to be true
+    greensub.subscribe(subscriber: institutions[0], target: products[0])
+    expect(greensub.subscribed?(subscriber: institutions[0], target: products[0])).to be true
     expect(greensub.subscriber_products(institutions[0])).to match_array([products[0], products[1]])
     expect(greensub.product_subscribers(products[0])).to match_array([individual, institutions[0]])
     expect(greensub.actor_products(actor).count).to eq 3
     expect(greensub.actor_products(actor)).to match_array([products[0], products[1], products[2]])
 
-    greensub.unsubscribe(individual, products[0])
-    expect(greensub.subscribed?(individual, products[0])).to be false
+    greensub.unsubscribe(subscriber: individual, target: products[0])
+    expect(greensub.subscribed?(subscriber: individual, target: products[0])).to be false
     expect(greensub.subscriber_products(individual)).to match_array([products[1]])
     expect(greensub.product_subscribers(products[0])).to match_array([institutions[0]])
     expect(greensub.actor_products(actor).count).to eq 3
     expect(greensub.actor_products(actor)).to match_array([products[0], products[1], products[2]])
 
-    greensub.unsubscribe(institutions[0], products[0])
-    expect(greensub.subscribed?(institutions[0], products[0])).to be false
+    greensub.unsubscribe(subscriber: institutions[0], target: products[0])
+    expect(greensub.subscribed?(subscriber: institutions[0], target: products[0])).to be false
     expect(greensub.subscriber_products(institutions[0])).to match_array([products[1]])
     expect(greensub.product_subscribers(products[0])).to be_empty
     expect(greensub.actor_products(actor).count).to eq 2
     expect(greensub.actor_products(actor)).to match_array([products[1], products[2]])
 
-    greensub.unsubscribe(institutions[0], products[1])
-    expect(greensub.subscribed?(institutions[0], products[1])).to be false
+    greensub.unsubscribe(subscriber: institutions[0], target: products[1])
+    expect(greensub.subscribed?(subscriber: institutions[0], target: products[1])).to be false
     expect(greensub.subscriber_products(institutions[0])).to be_empty
     expect(greensub.product_subscribers(products[1])).to match_array([individual])
     expect(greensub.actor_products(actor).count).to eq 2
     expect(greensub.actor_products(actor)).to match_array([products[1], products[2]])
 
-    greensub.unsubscribe(individual, products[1])
-    expect(greensub.subscribed?(individual, products[1])).to be false
+    greensub.unsubscribe(subscriber: individual, target: products[1])
+    expect(greensub.subscribed?(subscriber: individual, target: products[1])).to be false
     expect(greensub.subscriber_products(individual)).to be_empty
     expect(greensub.product_subscribers(products[1])).to be_empty
     expect(greensub.actor_products(actor).count).to eq 1
     expect(greensub.actor_products(actor)).to match_array([products[2]])
 
-    greensub.unsubscribe(institutions[1], products[2])
-    expect(greensub.subscribed?(institutions[1], products[2])).to be false
+    greensub.unsubscribe(subscriber: institutions[1], target: products[2])
+    expect(greensub.subscribed?(subscriber: institutions[1], target: products[2])).to be false
     expect(greensub.subscriber_products(institutions[1])).to be_empty
     expect(greensub.product_subscribers(products[2])).to be_empty
     expect(greensub.actor_products(actor).count).to eq 0
@@ -99,7 +99,7 @@ RSpec.describe Greensub do
   end
 
   describe '#product_include?' do
-    subject { greensub.product_include?(product, entity) }
+    subject { greensub.product_include?(product: product, entity: entity) }
 
     let(:product) { create(:product) }
     let(:component) { create(:component) }


### PR DESCRIPTION
Primarily added named parameters to the Greensub service methods.  

For example:

Greensub.subscribed?(subscriber, product) --> Greensub.subscribed?(subscriber:, product:)