### PR TITLE
Resolves HELIO-2514, CSB-206 and CSB-211

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '939c94d4078c4ce46c7a10f6a893fc660c2f0da6'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'eccf588f811e0de91912f40731017baf8f00cad7'
 
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '9ba35ad2948eb9bff4be81bca06923ae03a34208'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '939c94d4078c4ce46c7a10f6a893fc660c2f0da6'
 
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 939c94d4078c4ce46c7a10f6a893fc660c2f0da6
-  ref: 939c94d4078c4ce46c7a10f6a893fc660c2f0da6
+  revision: eccf588f811e0de91912f40731017baf8f00cad7
+  ref: eccf588f811e0de91912f40731017baf8f00cad7
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 9ba35ad2948eb9bff4be81bca06923ae03a34208
-  ref: 9ba35ad2948eb9bff4be81bca06923ae03a34208
+  revision: 939c94d4078c4ce46c7a10f6a893fc660c2f0da6
+  ref: 939c94d4078c4ce46c7a10f6a893fc660c2f0da6
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Resolves HELIO-2514 in heliotrope
Resolves CSB-206 and CSB-211 in cozy-sun-bear

This version of CSB updates the scrolling manager to handle pre-paginated volumes, and also sets us up to do hypothes.is integration. In particular:

    use IntersectionObserver for performance
    bundle polyfills for IntersectionObserver
    separate preferences between layouts

This should allow us to stop making `.sm.epub`s and passing `useArchive` to CSB for pre-paginated volumes, a practice that was established to deal with performance issues that were experienced in HEB pre paginated EPUBs.

I have tested this on heliotrope preview server with both pre-paginated and reflowable EPUBs and across Firefox, Chrome, Safari, Edge and IE 11.
