### PR TITLE
add demo or repo url to aptrust.yml.sample

### DIFF
--- a/config/aptrust.yml.sample
+++ b/config/aptrust.yml.sample
@@ -2,8 +2,9 @@
 
 # Config for apt_upload and apt_download
 DownloadDir: Settings.APTrustRestore
+AptrustApiUrl: "ADD_DEMO_OR_REPO_URL_HERE"
 AptrustApiUser: "USER@umich.edu"
-AptrustApiKey: "ADD_USER_API_KEY_HERE"
+AptrustApiKey: "ADD_USER_DEMO_OR_REPO_API_KEY_HERE"
 
 Bucket: "s3 bucket"
 BucketRegion: "s3 bucket region"


### PR DESCRIPTION
When using the aptrust api to check on the status of ingesting/ingested bag, you can contact the demo or production urls.
Demo: https://demo.aptrust/member-api/v2/
Repo: https://repo.aptrust/member-api/v2/

These have various end points as described here: https://wiki.aptrust.org/Member_API#Object_Resource