### PR TITLE
2541_rake_add_apt_check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,11 @@ gem 'jbuilder', '~> 2.5'
 # HELIO-2318
 gem 'rack', '~> 2.0.6'
 
-# HELIO-2404
+# HELIO-2404 APTRUST PRESERVATION
 gem 'bagit'
 gem 'minitar', '~>0.8'
 gem 'aws-sdk-s3', '~> 1'
+gem 'typhoeus', '~> 1.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1044,6 +1044,7 @@ DEPENDENCIES
   swagger_client!
   therubyracer
   turbolinks (~> 5)
+  typhoeus (~> 1.1)
   tzinfo-data
   uglifier (>= 3.2.0)
   web-console (>= 3.3.0)

--- a/lib/tasks/bag_updated_monographs.rake
+++ b/lib/tasks/bag_updated_monographs.rake
@@ -10,6 +10,8 @@ namespace :aptrust do
     S3_STATUSES = { 'not_uploaded' => 0, 'uploaded' => 1, 'upload_failed' => 3 }.freeze
     APT_STATUSES = { 'not_checked' => 0, 'confirmed' => 1, 'pending' => 3, 'failed' => 4 }.freeze
 
+    DEBUG = false
+
     # SAVING FOR POSSIBLE LATER USE
     # upload_docs = ActiveFedora::SolrService.query("+has_model_ssim:Monograph AND +press_sim:#{args.press_id} AND +visibility_ssi:'open'",
     #                                          fq: '-suppressed_bsi:true',
@@ -34,7 +36,6 @@ namespace :aptrust do
       begin
         record = AptrustUpload.find_by!(noid: noid)
       rescue ActiveRecord::RecordNotFound => e
-        puts "Error in find_record for noid #{noid}: #{e}"
         record = nil
       end
       record
@@ -44,130 +45,218 @@ namespace :aptrust do
       begin
         record = AptrustUpload.create!(noid:  noid)
       rescue AptrustUpload::RecordInvalid => e
-        puts "Error in create_record for noid #{noid}: #{e}"
         record = nil
       end
       record
     end
 
-    def update_record(record, noid)
-      # first get the monograph
-      update_docs = ActiveFedora::SolrService.query('+has_model_ssim:Monograph AND +press_sim:heb AND +visibility_ssi:restricted',
-                                      fq: "id:#{noid}",
-                                      fl: ['id', 'press_tesim', "creator_tesim", 'identifier_tesim', 'title_tesim', 'date_uploaded_dtsi', "has_model_ssim"])
-      update_docs.each do |update_doc|
+    def update_record(record)
+      solr_monographs = ActiveFedora::SolrService.query("+has_model_ssim:Monograph",
+                                      fq: "id:#{record.id}",
+                                      fl: ['id', 
+                                          'press_tesim', 
+                                          'creator_tesim', 
+                                          'identifier_tesim', 
+                                          'title_tesim', 
+                                          'date_uploaded_dtsi', 
+                                          'has_model_ssim'])
+      puts "solr_monographs count is: #{solr_monographs.count}"
+      data = solr_monographs.first
         begin
           record.update!(
                           # noid:  up_doc[:id], # this is already in record
-                          press: update_doc['press_tesim'].first[0..49],
-                          author: update_doc["creator_tesim"].first[0..49],
-                          title: update_doc["title_tesim"].first[0..49],
-                          model: update_doc["has_model_ssim"].first[0..49],
+                          press: data['press_tesim'].first[0..49],
+                          author: data["creator_tesim"].first[0..49],
+                          title: data["title_tesim"].first[0..249],
+                          model: data["has_model_ssim"].first[0..49],
                           bag_status: BAG_STATUSES['not_bagged'],
                           s3_status: S3_STATUSES['not_uploaded'],
                           apt_status: APT_STATUSES['not_checked'],
-                          date_monograph_modified: update_doc['date_modified_dtsi'],
+                          date_monograph_modified: data['date_modified_dtsi'],
                           date_fileset_modified: nil,
                           date_bagged: nil,
                           date_uploaded: nil,
                           date_confirmed: nil
                         )
         rescue ActiveRecord::RecordInvalid => e
-          puts "Error in update_record for noid #{noid}: #{e}"
           record = nil
         end
-      end
       record
     end
 
-    def create_bag(record, noid)
+    def create_bag(record)
       if record.nil?
-        puts "WARNING: nil record for noid #{noid}. We should never see this error!"
+        puts "WARNING: nil record for noid in create_bag. We should never see this error!"
       else
-        exporter = Export::Exporter.new(noid, :monograph)
+        exporter = Export::Exporter.new(record.id, :monograph)
         exporter.export_bag
       end
     end
 
-    def check_mono_fileset_mod_dates(record, doc, recreate_bag_ids)
-      doc_fsets = ActiveFedora::SolrService.query("+has_model_ssim:FileSet AND +monograph_id_ssim:#{doc[:id]}", rows: 100_000)
-      return if doc_fsets.blank?
-
+    def check_mono_mod_date(record, pdoc)
+      need_to_recreate = false
       record_bagged_time = DateTime.parse(record.date_bagged.to_s).utc
-      # puts "record.date_bagged parse utc is #{record_bagged_time}"
+      pub_pdoc_time = DateTime.parse(pdoc['date_modified_dtsi'].to_s).utc
+      need_to_recreate = (pub_pdoc_time > record_bagged_time)
+    end
 
-      add_to_recreate = false
-      doc_fsets.each do |fset|
-        unless add_to_recreate
-        # puts "fset['date_modified_dtsi'] is #{fset['date_modified_dtsi']}"
+    def check_mono_fileset_mod_dates(record, pdoc)
+      # Try to get the filesets for this published monograph; if there are none return false
+      pdoc_fsets = ActiveFedora::SolrService.query("+has_model_ssim:FileSet AND +monograph_id_ssim:#{pdoc[:id]}", rows: 100_000)
+      return false if pdoc_fsets.blank?
+
+      # Get date_bagged from database
+      return false if record.date_bagged.blank?
+      record_bagged_time = DateTime.parse(record.date_bagged.to_s).utc
+
+      need_to_recreate = false
+
+      # Loop through filesets to see if any have a newer date than the db date_bagged
+      pdoc_fsets.each do |fset|
+        # if we found a newer date stop checking
+        unless need_to_recreate
           fset_time = DateTime.parse(fset['date_modified_dtsi']).utc
-          # puts "In doc noid #{doc[:id]} for fset #{fset.id} date_modified_dtsi parse to utc is #{fset_time}"
-          add_to_recreate = (fset_time > record_bagged_time)
-          recreate_bag_ids << doc[:id] if add_to_recreate
-          puts "add_to_recreate is #{add_to_recreate} for fset #{fset.id} and noid #{doc[:id]}" if add_to_recreate
+          need_to_recreate = (fset_time > record_bagged_time)
         end
       end
+      need_to_recreate
     end
 
-    published_docs = monographs_solr_all_published
+    def update_db_aptrust_status(record)
+      filename = Rails.root.join('config', 'aptrust.yml')
+      yaml = YAML.safe_load(File.read(filename)) if File.exist?(filename)
+      @aptrust = yaml || nil
+      abort "Not getting authentication secrets via @aptrust yml" if @aptrust.nil?
 
-    abort "WARNING in aptrust:bag_given_press published_docs is NIL!" if published_docs.nil?
+      heads = {}
+      heads["Content-Type"] = "application/json"
+      heads["Accept"] = "application/json"
+      heads["X-PHAROS-API-USER"] = @aptrust['AptrustApiUser']
+      heads["X-PHAROS-API-KEY"] = @aptrust['AptrustApiKey']
 
-    new_bag_ids = []
-    recreate_bag_ids = []
+      base_apt_url = @aptrust['AptrustApiUrl']
+      bag_name = "umich.fulcrum-#{record['press']}-#{record['id']}"
 
-    # # Check solr docs for ones that represent new or update monographs
-    published_docs.each do |doc|
-      puts "doc :id is #{doc[:id]}"
-      record = find_record(doc[:id])
-      if record.nil?
-        puts "In published_docs loop record was nil"
-        new_bag_ids << doc[:id]
-      elsif record.bag_status.zero?
-        puts "In published_docs loop bag_status was zero"
-        new_bag_ids << doc[:id]
-      # elsif doc modified date is more recent that bagged date
-      elsif doc['date_modified_dtsi'] > record.date_bagged
-        puts "In published_docs loop doc modified date is greater than db date_bagged"
-        recreate_bag_ids << doc[:id]
-      else
-        puts "In published_docs loop, checking fileset date against date_bagged"
-        # if any of the docs filesets modified date is more recent that bagged date
-        # will add to recreate_bag_ids
-        check_mono_fileset_mod_dates(record, doc, recreate_bag_ids)
+      updated_after = Time.parse(record['date_uploaded'].to_s) - (60 * 60 * 24)
+      updated_after = updated_after.iso8601
+
+      this_url = base_apt_url + "items/?per_page=200&action=ingest&name=#{bag_name}&updated_after=#{updated_after}"
+      puts "this_url: #{this_url}" if DEBUG
+
+      response = Typhoeus::Request.new(this_url, headers: heads).run
+
+      if DEBUG
+        puts "response.code: #{response.code}"
+        puts "response.total_time: #{response.total_time}"
+        puts "response.headers: #{response.headers}"
+        puts "response.body: #{response.body}"
       end
-    end
 
-    puts "new_bag_ids array is #{new_bag_ids}"
+      parsed = JSON.parse(response.response_body)
 
-    new_bag_ids.each do |noid|
-      record = create_record(noid)
-      if record.nil?
-        puts "In new bags could not create a record for noid #{noid}"
-      else
-        record = update_record(record, noid)
-        if record.nil?
-          puts "In new bags could not update_record a record for noid #{noid}"
+      if DEBUG
+        put "count is #{parsed['count']}" unless parsed.nil?
+      end
+
+      if parsed["results"].nil?
+        puts "WARNING: In update_aptrust_status got no data back from aptrust api"
+        return
+      end
+
+      if DEBUG
+        puts parsed["results"] unless parsed["results"].nil?
+        puts "parsed['results'].count is #{parsed['results'].count}" unless parsed["results"].nil?
+      end
+
+      # We might get back more than one matching aptrust record
+      # the following handles that possibility by find the most current one
+      saved_results = {}
+
+      parsed["results"].each do |res|
+        current_results = res
+
+        # See if we've already stored a subhash for this noid
+        if saved_results.empty?
+          saved_results = current_results
         else
-          puts "In new bags about to create a bag for noid #{noid} and record #{record}"
-          create_bag(record, noid)
+          puts "Some dates, saved_results['bag_date']: #{saved_results['bag_date']} and current_results['bag_date'] #{current_results['bag_date']}" if DEBUG
+          saved_datetime = DateTime.parse(saved_results['bag_date'].to_s).utc
+          current_datetime = DateTime.parse(current_results['bag_date'].to_s).utc
+
+          # Replace saved_results with current_results if current bag_date is newer
+          saved_results = current_results if current_datetime > saved_datetime
         end
+      end
+
+      case saved_results['status']
+      when 'Success'
+        apt_key = 'confirmed'
+      when 'Failed', 'Cancelled'
+        apt_key = 'failed'
+      when 'Started', 'Pending'
+        apt_key = 'pending'
+      else
+        apt_key = 'failed'
+      end
+
+      # UPDATE RECORD WITH STATUS HERE
+      puts "Update record #{record['id']}with apt_key #{apt_key} and status code #{APT_STATUSES[apt_key]}"
+      begin
+        record.update!(
+                        apt_status: APT_STATUSES[apt_key]
+                      )
+      rescue ActiveRecord::RecordInvalid => e
+        record = nil
+      end
+      record
+    end
+
+    solr_monographs = monographs_solr_all_published
+
+    abort "WARNING in aptrust:bag_updated_monographs published_docs is NIL!" if solr_monographs.nil?
+
+    # SORT SOLR PUBLISHED MONOGRAPHS INTO ARRAYS
+    create_bag_ids = []
+
+    # Check solr docs for ones that represent new or update monographs
+    # pdoc means published monograph
+    solr_monographs.each do |pdoc|
+      record = find_record(pdoc[:id])
+      if record.nil?
+        # There is no db record
+        create_bag_ids << pdoc[:id]
+      elsif record.bag_status == BAG_STATUSES['not_bagged']
+        # There is a db record but this noid hasn't been bagged yet
+        create_bag_ids << pdoc[:id]
+      elsif check_mono_mod_date(record, pdoc)
+        # if doc modified date is more recent that db bagged date
+        create_bag_ids << pdoc[:id]
+      elsif check_mono_fileset_mod_dates(record, pdoc)
+        # If any of the docs filesets modified date is more recent that db bagged date
+        create_bag_ids << pdoc[:id]
+      else
+        # Otherwise check deposit for this pdoc in aptrust and update DB
+        check = update_db_aptrust_status(record)
+        puts "Error return from update_db_aptrust_status in bag_updated_monographs" if check.nil?
       end
     end
 
-    puts "recreate_bag_ids array is #{recreate_bag_ids}"
-
-    recreate_bag_ids.each do |noid|
+    # CREATE BAGS
+    create_bag_ids.each do |noid|
       record = find_record(noid)
       if record.nil?
-        puts "In recreate bags could not find a record for noid #{noid}"
-      else
-        record = update_record(record, noid)
+        puts "In create bag ids could not find a record for noid #{noid}, will try to create one"
+        record = create_record(noid)
         if record.nil?
-          puts "In recreate bags could not update_record a record for noid #{noid}"
+          puts "In create bag ids could not create a record for noid #{noid}"
         else
-          puts "In recreate bags about to create a bag for noid #{noid} and record #{record}"
-          create_bag(record, noid)
+          record = update_record(record)
+          if record.nil?
+            puts "In create bag ids could not update_record a record for noid #{noid}"
+          else
+            puts "In create bag ids about to create a bag for noid #{noid} and record #{record}"
+            create_bag(record)
+          end
         end
       end
     end


### PR DESCRIPTION
Changes include:

- Various simplifications as they become clearer.
- Use one array for new and recreated bags.
- Where I passed record and noid before just pass record if possible
- When the published solo record doesn't need a new bag record its APTrust API deposit status in db row for record (note this doesn't work for desktop development because there is not API for A&E s3).