### PR TITLE
Resolves HELIO-2510

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -583,14 +583,20 @@ footer.press {
 
     ul.toc li {
       line-height: 3em;
+      border-bottom: 1px solid #eee;
+      display: flex;
+      flex-direction: column;
+    }
+
+    ul.toc li .section-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
     }
 
     a.toc-link {
-      display: inline-block;
-    }
-
-    ul.toc li {
-      border-bottom: 1px solid #eee;
+     /* display: inline-block; */
+     max-width: 80%;
     }
 
     ul.toc li:first-child {
@@ -618,11 +624,11 @@ footer.press {
     }
 
     .download {
-      display: inline-block;
+      /* display: inline-block; */
       padding: 0;
-      position: absolute;
+      /* position: absolute; */
       margin-top: 11px;
-      right: 20px;
+      /* right: 20px; */
     }
   }
 
@@ -1331,7 +1337,7 @@ footer.press {
     }
   }
 
-  .monograph-assets-toc-epub {
+  .monograph .monograph-assets-toc-epub {
     a.toc-link {
       max-width: 65%;
       line-height: 2em;
@@ -1384,7 +1390,7 @@ footer.press {
     }
   }
 
-  .monograph-assets-toc-epub {
+  .monograph .monograph-assets-toc-epub {
     a.toc-link {
       max-width: 57%;
       line-height: 1.5em;

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -98,16 +98,21 @@ div.skip {
 
   .message {
     padding-bottom: 1em;
+    a {
+      text-decoration: underline;
+    }
   }
 
   a.btn-primary, a.btn-primary:hover, a.btn-primary:active {
     color: #fff;
+    text-decoration: none;
   }
 
   a.btn-default, a.btn-default:active, a.btn-default:hover {
     color: inherit;
     background-color: #d9edf7;
     border-color: #d9edf7;
+    text-decoration: none;
   }
 
   a.close {

--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -600,7 +600,6 @@ footer.press {
     }
 
     a.toc-link {
-     /* display: inline-block; */
      max-width: 80%;
     }
 
@@ -629,11 +628,8 @@ footer.press {
     }
 
     .download {
-      /* display: inline-block; */
       padding: 0;
-      /* position: absolute; */
       margin-top: 11px;
-      /* right: 20px; */
     }
   }
 

--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -17,18 +17,20 @@
       <% end %>
       <li>
     <% end %>
-    <a class="toc-link" href="<%= epub_path(id: @monograph_presenter.epub_id).gsub!(/\?.*/, '') + '#' + interval.cfi  %>"><%= interval.title %></a>
-    <% if @monograph_presenter.epub_presenter.multi_rendition? %>
-      <div class="btn-group download" role="group" aria-label="Read or Download Section">
-        <% if @press_policy.interval_download? && interval.downloadable? %>
-        <a class="btn btn-default btn-sm" href="<%= epub_download_interval_path(id: @monograph_presenter.epub_id, cfi: interval.cfi, title: interval.title) %>" data-turbolinks="false">
-          <i id="download" class="oi" data-glyph="data-transfer-download" title="Download section" aria-hidden="true"></i>
+    <div class="section-container">
+      <a class="toc-link" href="<%= epub_path(id: @monograph_presenter.epub_id).gsub!(/\?.*/, '') + '#' + interval.cfi  %>"><%= interval.title %></a>
+      <% if @monograph_presenter.epub_presenter.multi_rendition? %>
+        <div class="btn-group download" role="group" aria-label="Read or Download Section">
+          <% if @press_policy.interval_download? && interval.downloadable? %>
+          <a class="btn btn-default btn-sm" href="<%= epub_download_interval_path(id: @monograph_presenter.epub_id, cfi: interval.cfi, title: interval.title) %>" data-turbolinks="false">
+            <i id="download" class="oi" data-glyph="data-transfer-download" title="Download section" aria-hidden="true"></i>
           Download
-        </a>
-        <% end %>
-        <a class="btn btn-default btn-sm" href="<%= epub_path(id: @monograph_presenter.epub_id, anchor: interval.cfi + "/4/1:0") %>"><span class="glyphicon glyphicon-book" title="Read section" aria-hidden="true"></span> Read</a>
-      </div>
-    <% end %>
+          </a>
+          <% end %>
+          <a class="btn btn-default btn-sm" href="<%= epub_path(id: @monograph_presenter.epub_id, anchor: interval.cfi + "/4/1:0") %>"><span class="glyphicon glyphicon-book" title="Read section" aria-hidden="true"></span> Read</a>
+        </div>
+      <% end %>
+    </div>
   <% end %>
   </li>
 </ul>


### PR DESCRIPTION
Removes absolute positioning and inline-block display of download/read buttons, changes them to use flexbox and adds max-widths for title block elements to ensure they don't run over buttons. Small accessibility fix to EBC message so that links in the message are visible. 