### PR TITLE
Resolves HELIO-1941: Locale parameter lost on Blacklight catalog redi…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -194,3 +194,8 @@ group :development do
   # Yay! A Ruby Documentation Tool
   gem 'yard'
 end
+
+group :development do
+  # Capybara save_and_open_page thingy
+  gem 'launchy', '~>2.4.3'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,6 +493,8 @@ GEM
     keycard (0.2.4)
       sequel
     kramdown (1.17.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     ld-patch (0.3.3)
       ebnf (~> 1.1)
       rdf (>= 2.2, < 4.0)
@@ -999,6 +1001,7 @@ DEPENDENCIES
   jquery-turbolinks
   jwt
   keycard (~> 0.2.4)
+  launchy (~> 2.4.3)
   legato (~> 0.3)
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -44,10 +44,10 @@ module BreadcrumbsHelper
       crumbs = []
       if press.parent_id.present?
         parent = Press.find(press.parent_id)
-        crumbs << { href: "/#{parent.subdomain}", text: translate('monograph_catalog.index.home'), class: "" }
-        crumbs << { href: "/#{press.subdomain}", text: press.name, class: "" }
+        crumbs << { href: main_app.press_catalog_path(parent), text: translate('monograph_catalog.index.home'), class: "" }
+        crumbs << { href: main_app.press_catalog_path(press), text: press.name, class: "" }
       else
-        crumbs << { href: "/#{press.subdomain}", text: translate('monograph_catalog.index.home'), class: "" }
+        crumbs << { href: main_app.press_catalog_path(press), text: translate('monograph_catalog.index.home'), class: "" }
       end
       crumbs
     end

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -165,8 +165,12 @@ module Hyrax
       Array(solr_document['press_name_ssim']).first
     end
 
-    def press_url
-      Press.find_by(subdomain: subdomain).press_url
+    def press_obj
+      Press.find_by(subdomain: subdomain)
+    end
+
+    def press_url # rubocop:disable Rails/Delegate
+      press_obj.press_url
     end
 
     def previous_file_sets_id?(file_sets_id)

--- a/app/views/presses/index.html.erb
+++ b/app/views/presses/index.html.erb
@@ -1,6 +1,6 @@
 <h2>Presses</h2>
 <ul>
   <% @presses.each do |press| %>
-    <li><%= link_to press.name, press.subdomain %></li>
+    <li><%= link_to press.name, press_catalog_path(press) %></li>
   <% end %>
 </ul>

--- a/app/views/shared/_brand_press_bar.html.erb
+++ b/app/views/shared/_brand_press_bar.html.erb
@@ -9,11 +9,11 @@
         <span class="icon-bar"></span>
       </button>
       <% if defined?(@press.name) %>
-        <a class="navbar-brand" href="/<%= @press.subdomain %>"><%= @press.name %></a>
+        <a class="navbar-brand" href="<%= main_app.press_catalog_path(@press) %>"><%= @press.name %></a>
       <% elsif defined?(@monograph_presenter.press) %>
-        <a class="navbar-brand" href="/<%= @monograph_presenter.subdomain %>"><%= @monograph_presenter.press %></a>
+        <a class="navbar-brand" href="<%= main_app.press_catalog_path(@monograph_presenter.press_obj) %>"><%= @monograph_presenter.press %></a>
       <% elsif defined?(@presenter.monograph.press) %>
-        <a class="navbar-brand" href="/<%= @presenter.monograph.subdomain %>"><%= @presenter.monograph.press %></a>
+        <a class="navbar-brand" href="<%= main_app.press_catalog_path(@presenter.monograph.press_obj) %>"><%= @presenter.monograph.press %></a>
       <% else %>
         <a class="navbar-brand" href="#">University Press</a>
       <% end %>

--- a/spec/factories/presses.rb
+++ b/spec/factories/presses.rb
@@ -6,9 +6,7 @@ FactoryBot.define do
     sequence(:description) { |n| "Description of Press #{n}" }
     sequence(:press_url) { |n| "http://www.external_link_to_press#{n}" }
     sequence(:google_analytics) { |n| "UA-87654321-#{n}" }
-    logo_path do
-      Rack::Test::UploadedFile.new(File.open(Rails.root.join('spec', 'fixtures', 'csv', 'import', 'shipwreck.jpg')), 'image/jpg')
-    end
+    logo_path { nil }
     sequence(:subdomain) { |_n| "press-#{srand}" }
   end
 end

--- a/spec/features/create_external_resource_spec.rb
+++ b/spec/features/create_external_resource_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 describe 'Create an external resource' do
   context 'as a logged in user' do
     let(:user) { create(:platform_admin) }
-    let!(:press) { create(:press) }
 
     # We need to be able to accept "fileless" file_sets, which will
     # just be links to "external resources". Right now in Hyrax there's

--- a/spec/features/create_press_spec.rb
+++ b/spec/features/create_press_spec.rb
@@ -24,7 +24,7 @@ describe 'Adding a new press' do
       # fill_in 'Footer block a', with: '<div>Footer Block A Stuff</div>'
       fill_in 'Footer block c', with: '<div>Footer Block C Stuff</div>'
       click_button 'Save'
-      expect(page).to have_link 'Test Publisher', href: 'testpub'
+      expect(page).to have_link 'Test Publisher', href: '/testpub?locale=en'
       click_link 'Test Publisher'
       expect(page).to have_content 'Test Publisher'
       expect(page).to have_content 'A Test Publisher description'

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -322,6 +322,8 @@ RSpec.describe Hyrax::MonographPresenter do
       ::SolrDocument.new(
         id: 'mono',
         has_model_ssim: ['Monograph'],
+        press_tesim: ['press_tesim'],
+        press_name_ssim: ['press_name_ssim'],
         # representative_id has a rather different Solr name!
         hasRelatedMediaFragment_ssim: cover_fileset_doc.id,
         ordered_member_ids_ssim: [cover_fileset_doc.id, fs1_doc.id, fs2_doc.id, fs3_doc.id]
@@ -486,6 +488,36 @@ RSpec.describe Hyrax::MonographPresenter do
         subject { presenter.epub_id }
 
         it { expect(subject).to eq fs2_doc.id }
+      end
+
+      context 'press' do
+        let(:press) { double('press', press_url: 'press_url') }
+
+        before { allow(Press).to receive(:find_by).with(subdomain: 'press_tesim').and_return(press) }
+
+        describe '#subdomain' do
+          subject { presenter.subdomain }
+
+          it { is_expected.to eq('press_tesim') }
+        end
+
+        describe '#press' do
+          subject { presenter.press }
+
+          it { is_expected.to eq('press_name_ssim') }
+        end
+
+        describe '#press_obj' do
+          subject { presenter.press_obj }
+
+          it { is_expected.to be press }
+        end
+
+        describe '#press_url' do
+          subject { presenter.press_url }
+
+          it { is_expected.to eq('press_url') }
+        end
       end
 
       describe '#webgl?' do

--- a/spec/system/epub_share_links_spec.rb
+++ b/spec/system/epub_share_links_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe "EPub Share Links", type: :system do
   let(:platform_admin) { create(:platform_admin) }
-  let(:press) { create(:press, subdomain: 'blue', share_links: true, logo_path: Rack::Test::UploadedFile.new(File.open(Rails.root.join(fixture_path, 'csv', 'shipwreck.jpg')))) }
+  let(:press) { create(:press, subdomain: 'blue', share_links: true) }
   let(:monograph) { create(:public_monograph, press: press.subdomain, user: platform_admin, visibility: "open", representative_id: cover.id) }
   let(:cover) { create(:public_file_set, content: File.open(File.join(fixture_path, 'csv', 'miranda.jpg'))) }
   let(:file_set) { create(:public_file_set, allow_download: 'yes', content: File.open(File.join(fixture_path, 'fake_epub_multi_rendition.epub'))) }

--- a/spec/system/toc_epub_chapter_spec.rb
+++ b/spec/system/toc_epub_chapter_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe "Cozy Sun Bear", type: :system do
   let(:user) { create(:platform_admin) }
-  let(:press) { create(:press, subdomain: 'blue', logo_path: Rack::Test::UploadedFile.new(File.open(Rails.root.join(fixture_path, 'csv', 'shipwreck.jpg')))) }
-  let(:monograph) { create(:monograph, press: 'blue', user: user, visibility: "open", representative_id: cover.id) }
+  let(:press) { create(:press, subdomain: 'blue') }
+  let(:monograph) { create(:monograph, press: press.subdomain, user: user, visibility: "open", representative_id: cover.id) }
   let(:cover) { create(:file_set, content: File.open(File.join(fixture_path, 'csv', 'miranda.jpg'))) }
   let(:file_set) { create(:file_set, id: '999999999', allow_download: 'yes', content: File.open(File.join(fixture_path, 'fake_epub01.epub'))) }
   let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }


### PR DESCRIPTION
…rects.

Replaced href: "/#{press.subdomain}" with main_app.press_catalog_path(press).