### PR TITLE
Sighrax Hyrax Presenter Support

### DIFF
--- a/app/controllers/api/v1/monographs_controller.rb
+++ b/app/controllers/api/v1/monographs_controller.rb
@@ -76,7 +76,7 @@ module API
         extract_dir = File.join(extract_path, noid)
         FileUtils.rm_rf(extract_dir) if Dir.exist?(extract_dir)
         FileUtils.mkdir(extract_dir)
-        Export::Exporter.new(noid).extract(extract_dir)
+        Export::Exporter.new(noid).extract(extract_dir, true)
         extract_zip = File.join(extract_path, "#{noid}.zip")
         FileUtils.rm_rf(extract_zip) if File.exist?(extract_zip)
         Zip::File.open(extract_zip, Zip::File::CREATE) do |zipfile|

--- a/app/jobs/output_monograph_files_job.rb
+++ b/app/jobs/output_monograph_files_job.rb
@@ -6,8 +6,8 @@ class OutputMonographFilesJob < ApplicationJob
   def perform(noid, path)
     monograph = Sighrax.factory(noid)
 
-    monograph.data['ordered_member_ids_ssim']&.each do |member_id|
-      presenter = Sighrax.factory(member_id).presenter
+    monograph.children.each do |member|
+      presenter = Sighrax.hyrax_presenter(member)
 
       # The importer is written to exit on zero-size files. We shouldn't have any in the system in future, see:
       # https://tools.lib.umich.edu/jira/browse/HELIO-2246
@@ -17,7 +17,7 @@ class OutputMonographFilesJob < ApplicationJob
 
       begin
         File.open File.join(path, filename), "wb" do |dest|
-          FileSet.find(member_id).original_file.stream.each { |chunk| dest.write(chunk) }
+          FileSet.find(member.noid).original_file.stream.each { |chunk| dest.write(chunk) }
         end
       rescue NoMemoryError => e
         Rails.logger.error "OutputMonographFilesJob failed with NoMemoryError: #{e}"

--- a/app/models/null_press.rb
+++ b/app/models/null_press.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class NullPress < Press; end

--- a/app/models/press.rb
+++ b/app/models/press.rb
@@ -33,4 +33,8 @@ class Press < ApplicationRecord
   def agent_id
     id
   end
+
+  def self.null_press
+    NullPress.new
+  end
 end

--- a/app/models/sighrax/asset.rb
+++ b/app/models/sighrax/asset.rb
@@ -12,7 +12,6 @@ module Sighrax
 
       def initialize(noid, data)
         super(noid, data)
-        @presenter = Hyrax::PresenterFactory.build_for(ids: [noid], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil)&.first || self.class.null_entity
       end
   end
 end

--- a/app/models/sighrax/entity.rb
+++ b/app/models/sighrax/entity.rb
@@ -5,7 +5,6 @@ module Sighrax
     private_class_method :new
 
     attr_reader :noid
-    attr_reader :data
 
     # Class Methods
 
@@ -35,15 +34,21 @@ module Sighrax
       resource_type.to_s + ':' + resource_id.to_s
     end
 
+    def title
+      noid
+    end
+
     def parent
       self.class.null_entity
     end
 
-    def title
-      Array(data['title_tesim']).first || noid
+    def children
+      []
     end
 
     protected
+
+      attr_reader :data
 
       def type
         @type ||= /^Sighrax::(.+$)/.match(self.class.to_s)[1].to_sym

--- a/app/models/sighrax/model.rb
+++ b/app/models/sighrax/model.rb
@@ -4,7 +4,9 @@ module Sighrax
   class Model < Entity
     private_class_method :new
 
-    attr_reader :presenter
+    def title
+      Array(data['title_tesim']).first || super
+    end
 
     protected
 
@@ -16,7 +18,6 @@ module Sighrax
 
       def initialize(noid, data)
         super(noid, data)
-        @presenter = self.class.null_entity
       end
   end
 end

--- a/app/models/sighrax/monograph.rb
+++ b/app/models/sighrax/monograph.rb
@@ -4,6 +4,10 @@ module Sighrax
   class Monograph < Model
     private_class_method :new
 
+    def children
+      Array(data['ordered_member_ids_ssim']).map { |noid| Sighrax.factory(noid) }
+    end
+
     def epub_featured_representative
       Sighrax.factory(FeaturedRepresentative.find_by(monograph_id: noid, kind: 'epub')&.file_set_id)
     end
@@ -12,7 +16,6 @@ module Sighrax
 
       def initialize(noid, data)
         super(noid, data)
-        @presenter = Hyrax::PresenterFactory.build_for(ids: [noid], presenter_class: Hyrax::MonographPresenter, presenter_args: nil)&.first || self.class.null_entity
       end
   end
 end

--- a/app/presenters/hyrax/presenter.rb
+++ b/app/presenters/hyrax/presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class Presenter
+    private_class_method :new
+
+    attr_reader :noid
+
+    def self.null_presenter(noid = 'null_noid')
+      NullPresenter.send(:new, noid)
+    end
+
+    private
+
+      def initialize(noid)
+        @noid = noid
+      end
+  end
+
+  class NullPresenter < Presenter
+    private_class_method :new
+
+    private
+
+      def initialize(noid)
+        super(noid)
+      end
+  end
+end

--- a/spec/lib/export/exporter_spec.rb
+++ b/spec/lib/export/exporter_spec.rb
@@ -51,7 +51,7 @@ describe Export::Exporter do
     let(:monograph) { create(:monograph) }
 
     it "initializes" do
-      expect(subject.monograph.data.id).to eq monograph.id
+      expect(subject.monograph.noid).to eq monograph.id
       expect(subject.columns).to eq :all
       expect(subject.aptrust["AwsAccessKeyId"]).not_to be_empty
       expect(subject.aptrust['AwsSecretAccessKey']).not_to be_empty

--- a/spec/models/press_spec.rb
+++ b/spec/models/press_spec.rb
@@ -130,4 +130,10 @@ RSpec.describe Press, type: :model do
 
     it { is_expected.to be press.id }
   end
+
+  describe '#null_press' do
+    subject { described_class.null_press }
+
+    it { is_expected.to be_an_instance_of(NullPress) }
+  end
 end

--- a/spec/models/sighrax/asset_spec.rb
+++ b/spec/models/sighrax/asset_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Sighrax::Asset, type: :model do
   it { is_expected.to be_a_kind_of(Sighrax::Model) }
   it { expect(subject.resource_type).to eq :Asset }
   it { expect(subject.parent).to be_an_instance_of(Sighrax::NullEntity) }
-  it { expect(subject.presenter).to be_an_instance_of(Sighrax::NullEntity) }
 
   describe '#parent' do
     let(:data) { { 'monograph_id_ssim' => [noid] } }
@@ -21,12 +20,5 @@ RSpec.describe Sighrax::Asset, type: :model do
     before { allow(Sighrax).to receive(:factory).with(noid).and_return(parent) }
 
     it { expect(subject.parent).to be parent }
-  end
-
-  describe '#presenter' do
-    let(:file_set) { create(:file_set) }
-    let(:noid) { file_set.id }
-
-    it { expect(subject.presenter).to be_an_instance_of(Hyrax::FileSetPresenter) }
   end
 end

--- a/spec/models/sighrax/child_parent_spec.rb
+++ b/spec/models/sighrax/child_parent_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Sighrax do
       expect(child.noid).to eq(file_set.id)
     end
 
+    it '#parent' do
+      expect(child.parent).to be_an_instance_of(Sighrax::Monograph)
+      expect(child.parent.noid).to eq(monograph.id)
+    end
+
+    it '#children' do
+      expect(child.children).to be_empty
+    end
+
     it '#title' do
       expect(child.title).not_to be_empty
       expect(child.title).to eq(child_presenter.title)
@@ -35,6 +44,16 @@ RSpec.describe Sighrax do
     it 'is the monograph' do
       expect(parent).to be_an_instance_of(Sighrax::Monograph)
       expect(parent.noid).to eq(monograph.id)
+    end
+
+    it '#parent' do
+      expect(parent.parent).to be_an_instance_of(Sighrax::NullEntity)
+    end
+
+    it '#children' do
+      expect(parent.children.count).to eq(1)
+      expect(parent.children[0]).to be_a_kind_of(Sighrax::Asset)
+      expect(parent.children[0].noid).to eq(file_set.id)
     end
 
     it '#title' do

--- a/spec/models/sighrax/entity_spec.rb
+++ b/spec/models/sighrax/entity_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sighrax::Entity, type: :model do
 
     it { is_expected.to be_an_instance_of(Sighrax::NullEntity) }
     it { expect(subject.noid).to eq 'null_noid' }
-    it { expect(subject.data).to eq({}) }
+    it { expect(subject.send(:data)).to eq({}) }
     it { expect(subject.valid?).to be false }
     it { expect(subject.uri).to eq ActiveFedora::Base.id_to_uri('null_noid') }
     it { expect(subject.resource_type).to eq :NullEntity }
@@ -26,7 +26,7 @@ RSpec.describe Sighrax::Entity, type: :model do
 
     it { is_expected.to be_an_instance_of(described_class) }
     it { expect(subject.noid).to eq noid }
-    it { expect(subject.data).to eq data }
+    it { expect(subject.send(:data)).to eq data }
     it { expect(subject.valid?).to be true }
     it { expect(subject.uri).to eq ActiveFedora::Base.id_to_uri(noid) }
     it { expect(subject.resource_type).to eq :Entity }
@@ -34,11 +34,5 @@ RSpec.describe Sighrax::Entity, type: :model do
     it { expect(subject.resource_token).to eq "#{subject.resource_type}:#{subject.resource_id}" }
     it { expect(subject.parent).to be_an_instance_of(Sighrax::NullEntity) }
     it { expect(subject.title).to eq noid }
-
-    context 'with title' do
-      let(:data) { { 'title_tesim' => ['Title'] } }
-
-      it { expect(subject.title).to eq 'Title' }
-    end
   end
 end

--- a/spec/models/sighrax/model_spec.rb
+++ b/spec/models/sighrax/model_spec.rb
@@ -12,11 +12,16 @@ RSpec.describe Sighrax::Model, type: :model do
   it { is_expected.to be_a_kind_of(Sighrax::Entity) }
   it { expect(subject.resource_type).to eq :Model }
   it { expect(subject.send(:model_type)).to be_nil }
-  it { expect(subject.presenter).to be_an_instance_of(Sighrax::NullEntity) }
 
   describe '#model_type' do
     let(:data) { { 'has_model_ssim' => ['Model'] } }
 
     it { expect(subject.send(:model_type)).to eq 'Model' }
+  end
+
+  context '#title' do
+    let(:data) { { 'title_tesim' => ['Title'] } }
+
+    it { expect(subject.title).to eq 'Title' }
   end
 end

--- a/spec/models/sighrax/monograph_spec.rb
+++ b/spec/models/sighrax/monograph_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Sighrax::Monograph, type: :model do
   it { is_expected.to be_a_kind_of(Sighrax::Model) }
   it { expect(subject.resource_type).to eq :Monograph }
   it { expect(subject.epub_featured_representative).to be_an_instance_of(Sighrax::NullEntity) }
-  it { expect(subject.presenter).to be_an_instance_of(Sighrax::NullEntity) }
 
   describe '#epub_featured_representative' do
     let(:epub_featured_representative) { double('epub_featured_representative', file_set_id: 'file_set_id') }
@@ -24,12 +23,5 @@ RSpec.describe Sighrax::Monograph, type: :model do
     end
 
     it { expect(subject.epub_featured_representative).to be electronic_publication }
-  end
-
-  describe '#presenter' do
-    let(:monograph) { create(:monograph) }
-    let(:noid) { monograph.id }
-
-    it { expect(subject.presenter).to be_an_instance_of(Hyrax::MonographPresenter) }
   end
 end

--- a/spec/presenters/hyrax/presenter_spec.rb
+++ b/spec/presenters/hyrax/presenter_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::Presenter do
+  context 'null presenter' do
+    subject { described_class.null_presenter }
+
+    it { is_expected.to be_an_instance_of(Hyrax::NullPresenter) }
+  end
+
+  context 'presenter' do
+    subject(:presenter) { described_class.send(:new, noid) }
+
+    let(:noid) { 'validnoid' }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+  end
+end

--- a/spec/services/sighrax_spec.rb
+++ b/spec/services/sighrax_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Sighrax do
       it do
         is_expected.to be_an_instance_of(Sighrax::Entity)
         expect(subject.noid).to be noid
-        expect(subject.data).to be data
+        expect(subject.send(:data)).to be data
       end
 
       context 'Model' do
@@ -85,276 +85,381 @@ RSpec.describe Sighrax do
     end
   end
 
-  describe '#access?' do
-    subject { described_class.access?(actor, target) }
+  describe '#press' do
+    subject { described_class.press(entity) }
 
-    let(:actor) { double('actor') }
-    let(:target) { double('target', noid: noid) }
-    let(:noid) { double('noid') }
-    let(:component) { double('component', products: [component_product]) }
-    let(:component_product) { double('component_product') }
-    let(:greensub_product) { double('greensub_product') }
-    let(:sudo_actor) { false }
-    let(:incognito_product) { double('incognito_product') }
+    let(:entity) { described_class.factory(noid) }
+    let(:noid) { 'validnoid' }
+    let(:data) { {} }
 
-    before do
-      allow(Greensub::Component).to receive(:find_by).with(noid: noid).and_return(component)
-      allow(Greensub).to receive(:actor_products).with(actor).and_return([greensub_product])
-      allow(Incognito).to receive(:sudo_actor?).with(actor).and_return(sudo_actor)
-      allow(Incognito).to receive(:sudo_actor_products).with(actor).and_return([incognito_product])
+    it { is_expected.to be_an_instance_of(NullPress) }
+
+    context 'Entity' do
+      let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+      before { allow(ActiveFedora::SolrService).to receive(:query).with("{!terms f=id}#{noid}", rows: 1).and_return([data]) }
+
+      it { is_expected.to be_an_instance_of(NullPress) }
     end
 
-    it { is_expected.to be false }
+    context 'Monograph with FileSet' do
+      let(:noid) { monograph.id }
+      let(:monograph) do
+        create(:public_monograph, press: press.subdomain) do |m|
+          m.ordered_members << file_set
+          m.save!
+          file_set.save!
+          m
+        end
+      end
+      let(:press) { create(:press) }
+      let(:file_set) { create(:public_file_set) }
 
-    context 'product intersection' do
-      let(:product) { double('product') }
-      let(:greensub_product) { product }
-      let(:component_product) { product }
+      it { is_expected.to be_an_instance_of(Press) }
+      it { expect(subject.subdomain).to eq(press.subdomain) }
 
-      it { is_expected.to be true }
+      context 'Orphan FileSet' do
+        let(:noid) { file_set.id }
 
-      context 'incognito' do
-        let(:sudo_actor) { true }
+        it { is_expected.to be_an_instance_of(NullPress) }
 
-        it { is_expected.to be false }
+        context 'Monograph FileSet' do
+          before { monograph }
 
-        context 'product intersection' do
-          let(:incognito_product) { product }
-
-          it { is_expected.to be true }
+          it { is_expected.to be_an_instance_of(Press) }
+          it { expect(subject.subdomain).to eq(press.subdomain) }
         end
       end
     end
   end
 
-  describe '#allow_download?' do
-    subject { described_class.allow_download?(entity) }
+  describe '#hyrax_presenter' do
+    subject { described_class.hyrax_presenter(entity) }
 
-    let(:entity) { double('entity', valid?: true, data: data) }
-    let(:data) { { 'allow_download_ssim' => ['yes'] } }
-    let(:downloadable) { true }
-
-    before { allow(described_class).to receive(:downloadable?).with(entity).and_return(downloadable) }
-
-    it { is_expected.to be true }
-
-    context 'do not allow download' do
-      let(:data) { { 'allow_download_ssim' => ['anything but yes'] } }
-
-      it { is_expected.to be false }
-    end
-
-    context 'non downloadable' do
-      let(:downloadable) { false }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe '#deposited?' do
-    subject { described_class.deposited?(entity) }
-
-    let(:entity) { double('entity', valid?: true, data: data) }
+    let(:entity) { described_class.factory(noid) }
+    let(:noid) { 'validnoid' }
     let(:data) { {} }
 
-    it { is_expected.to be true }
+    it { is_expected.to be_an_instance_of(Hyrax::Presenter) }
 
-    context "'suppressed_bsi' => false" do
-      let(:data) { { 'suppressed_bsi' => false } }
+    context 'Entity' do
+      let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
 
-      it { is_expected.to be true }
+      before { allow(ActiveFedora::SolrService).to receive(:query).with("{!terms f=id}#{noid}", rows: 1).and_return([data]) }
+
+      it { is_expected.to be_an_instance_of(Hyrax::Presenter) }
     end
 
-    context "'suppressed_bsi' => true" do
-      let(:data) { { 'suppressed_bsi' => true } }
+    context 'Monograph' do
+      let(:noid) { monograph.id }
+      let(:monograph) { create(:public_monograph) }
 
-      it { is_expected.to be false }
-    end
-  end
-
-  describe '#downloadable?' do
-    subject { described_class.downloadable?(entity) }
-
-    let(:entity) { double('entity', valid?: true, data: data) }
-    let(:data) { {} }
-    let(:asset) { true }
-
-    before { allow(entity).to receive(:is_a?).with(Sighrax::Asset).and_return(asset) }
-
-    it { is_expected.to be true }
-
-    context 'external resource url' do
-      let(:data) { { 'external_resource_url_ssim' => url } }
-      let(:url) { 'url' }
-
-      it { is_expected.to be false }
-
-      context 'blank url' do
-        let(:url) { '' }
-
-        it { is_expected.to be true }
-      end
+      it { is_expected.to be_an_instance_of(Hyrax::MonographPresenter) }
     end
 
-    context 'non asset' do
-      let(:asset) { false }
+    context 'Asset' do
+      let(:noid) { file_set.id }
+      let(:file_set) { create(:public_file_set) }
 
-      it { is_expected.to be false }
+      it { is_expected.to be_an_instance_of(Hyrax::FileSetPresenter) }
     end
   end
 
-  describe '#hyrax_can?' do
-    subject { described_class.hyrax_can?(actor, action, target) }
+  context 'Checkpoint Helpers' do
+    describe '#access?' do
+      subject { described_class.access?(actor, target) }
 
-    let(:actor) { double('actor', is_a?: anonymous) }
-    let(:anonymous) { false }
-    let(:action) { :action }
-    let(:target) { double('target', valid?: valid, noid: 'noid') }
-    let(:valid) { true }
-    let(:allow_hyrax_can) { true }
-    let(:ability) { double('ability') }
-    let(:can) { true }
+      let(:actor) { double('actor') }
+      let(:target) { double('target', noid: noid) }
+      let(:noid) { double('noid') }
+      let(:component) { double('component', products: [component_product]) }
+      let(:component_product) { double('component_product') }
+      let(:greensub_product) { double('greensub_product') }
+      let(:sudo_actor) { false }
+      let(:incognito_product) { double('incognito_product') }
 
-    before do
-      allow(Incognito).to receive(:allow_hyrax_can?).with(actor).and_return(allow_hyrax_can)
-      allow(Ability).to receive(:new).with(actor).and_return(ability)
-      allow(ability).to receive(:can?).with(action, target.noid).and_return(can)
-    end
-
-    context 'user can' do
-      it { is_expected.to be true }
-
-      context 'anonymous' do
-        let(:anonymous) { true }
-
-        it { is_expected.to be false }
+      before do
+        allow(Greensub::Component).to receive(:find_by).with(noid: noid).and_return(component)
+        allow(Greensub).to receive(:actor_products).with(actor).and_return([greensub_product])
+        allow(Incognito).to receive(:sudo_actor?).with(actor).and_return(sudo_actor)
+        allow(Incognito).to receive(:sudo_actor_products).with(actor).and_return([incognito_product])
       end
-
-      context 'invalid action' do
-        let(:action) { 'action' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'invalid target' do
-        let(:valid) { false }
-
-        it { is_expected.to be false }
-      end
-
-      context 'do not allow hyrax_can' do
-        let(:allow_hyrax_can) { false }
-
-        it { is_expected.to be false }
-      end
-
-      context 'can not' do
-        let(:can) { false }
-
-        it { is_expected.to be false }
-      end
-    end
-  end
-
-  describe '#open_access?' do
-    subject { described_class.open_access?(entity) }
-
-    let(:entity) { double('entity', valid?: true, data: data) }
-    let(:data) { {} }
-
-    it { is_expected.to be false }
-
-    context "'open_access_tesim' => ''" do
-      let(:data) { { 'open_access_tesim' => ['anything but yes'] } }
-
-      it { is_expected.to be false }
-    end
-
-    context "'open_access_tesim' => 'yes'" do
-      let(:data) { { 'open_access_tesim' => ['yes'] } }
-
-      it { is_expected.to be true }
-    end
-  end
-
-  describe '#platform_admin?' do
-    subject { described_class.platform_admin?(actor) }
-
-    let(:actor) { double('actor') }
-    let(:user) { false }
-    let(:platform_admin) { false }
-    let(:allow_platform_admin) { true }
-
-    before do
-      allow(actor).to receive(:is_a?).with(User).and_return(user)
-      allow(actor).to receive(:platform_admin?).and_return(platform_admin)
-      allow(Incognito).to receive(:allow_platform_admin?).with(actor).and_return(allow_platform_admin)
-    end
-
-    it { is_expected.to be false }
-
-    context 'user' do
-      let(:user) { true }
 
       it { is_expected.to be false }
 
-      context 'platform_admin' do
-        let(:platform_admin) { true }
+      context 'product intersection' do
+        let(:product) { double('product') }
+        let(:greensub_product) { product }
+        let(:component_product) { product }
 
         it { is_expected.to be true }
 
         context 'incognito' do
-          let(:allow_platform_admin) { false }
+          let(:sudo_actor) { true }
+
+          it { is_expected.to be false }
+
+          context 'product intersection' do
+            let(:incognito_product) { product }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+    end
+
+    describe '#hyrax_can?' do
+      subject { described_class.hyrax_can?(actor, action, target) }
+
+      let(:actor) { double('actor', is_a?: anonymous) }
+      let(:anonymous) { false }
+      let(:action) { :action }
+      let(:target) { double('target', valid?: valid, noid: 'noid') }
+      let(:valid) { true }
+      let(:allow_hyrax_can) { true }
+      let(:ability) { double('ability') }
+      let(:can) { true }
+
+      before do
+        allow(Incognito).to receive(:allow_hyrax_can?).with(actor).and_return(allow_hyrax_can)
+        allow(Ability).to receive(:new).with(actor).and_return(ability)
+        allow(ability).to receive(:can?).with(action, target.noid).and_return(can)
+      end
+
+      context 'user can' do
+        it { is_expected.to be true }
+
+        context 'anonymous' do
+          let(:anonymous) { true }
+
+          it { is_expected.to be false }
+        end
+
+        context 'invalid action' do
+          let(:action) { 'action' }
+
+          it { is_expected.to be false }
+        end
+
+        context 'invalid target' do
+          let(:valid) { false }
+
+          it { is_expected.to be false }
+        end
+
+        context 'do not allow hyrax_can' do
+          let(:allow_hyrax_can) { false }
+
+          it { is_expected.to be false }
+        end
+
+        context 'can not' do
+          let(:can) { false }
 
           it { is_expected.to be false }
         end
       end
     end
-  end
 
-  describe '#published?' do
-    subject { described_class.published?(entity) }
+    describe '#platform_admin?' do
+      subject { described_class.platform_admin?(actor) }
 
-    let(:entity) { double('entity', valid?: true, data: data) }
-    let(:data) { {} }
+      let(:actor) { double('actor') }
+      let(:user) { false }
+      let(:platform_admin) { false }
+      let(:allow_platform_admin) { true }
 
-    it { is_expected.to be false }
-
-    context "'visibility_ssi' => 'restricted'" do
-      let(:data) { { 'visibility_ssi' => 'restricted' } }
+      before do
+        allow(actor).to receive(:is_a?).with(User).and_return(user)
+        allow(actor).to receive(:platform_admin?).and_return(platform_admin)
+        allow(Incognito).to receive(:allow_platform_admin?).with(actor).and_return(allow_platform_admin)
+      end
 
       it { is_expected.to be false }
-    end
 
-    context "'visibility_ssi' => 'open'" do
-      let(:data) { { 'visibility_ssi' => 'open' } }
-
-      it { is_expected.to be true }
-
-      context "'suppressed_bsi' => true" do
-        let(:data) { { 'suppressed_bsi' => true, 'visibility_ssi' => 'open' } }
+      context 'user' do
+        let(:user) { true }
 
         it { is_expected.to be false }
+
+        context 'platform_admin' do
+          let(:platform_admin) { true }
+
+          it { is_expected.to be true }
+
+          context 'incognito' do
+            let(:allow_platform_admin) { false }
+
+            it { is_expected.to be false }
+          end
+        end
       end
     end
   end
 
-  describe '#restricted?' do
-    subject { described_class.restricted?(entity) }
+  context 'Entity Helpers' do
+    let(:entity) { described_class.factory(noid) }
+    let(:noid) { 'validnoid' }
+    let(:data) { {} }
 
-    let(:entity) { double('entity', valid?: true, noid: 'noid') }
-    let(:component) {}
+    before { allow(ActiveFedora::SolrService).to receive(:query).with("{!terms f=id}#{noid}", rows: 1).and_return([data]) }
 
-    before do
-      allow(Greensub::Component).to receive(:find_by).with(noid: entity.noid).and_return(component)
+    describe '#allow_download?' do
+      subject { described_class.allow_download?(entity) }
+
+      it { is_expected.to be false }
+
+      context 'Entity' do
+        let(:data) { { 'allow_download_ssim' => ['yes'] } }
+        let(:downloadable) { true }
+
+        before { allow(described_class).to receive(:downloadable?).with(entity).and_return(downloadable) }
+
+        it { is_expected.to be true }
+
+        context 'do not allow download' do
+          let(:data) { { 'allow_download_ssim' => ['anything but yes'] } }
+
+          it { is_expected.to be false }
+        end
+
+        context 'non downloadable' do
+          let(:downloadable) { false }
+
+          it { is_expected.to be false }
+        end
+      end
     end
 
-    it { is_expected.to be false }
+    describe '#deposited?' do
+      subject { described_class.deposited?(entity) }
 
-    context 'present?' do
-      let(:component) { double('component') }
+      it { is_expected.to be false }
+
+      context 'Entity' do
+        let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+        it { is_expected.to be true }
+
+        context "'suppressed_bsi' => false" do
+          let(:data) { { 'suppressed_bsi' => false } }
+
+          it { is_expected.to be true }
+        end
+
+        context "'suppressed_bsi' => true" do
+          let(:data) { { 'suppressed_bsi' => true } }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    describe '#downloadable?' do
+      subject { described_class.downloadable?(entity) }
+
+      it { is_expected.to be false }
+
+      context 'Entity' do
+        let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+        it { is_expected.to be false }
+
+        context 'Asset' do
+          let(:asset) { true }
+
+          before { allow(entity).to receive(:is_a?).with(Sighrax::Asset).and_return(asset) }
+
+          it { is_expected.to be true }
+
+          context 'external resource url' do
+            let(:data) { { 'external_resource_url_ssim' => url } }
+            let(:url) { 'url' }
+
+            it { is_expected.to be false }
+
+            context 'blank url' do
+              let(:url) { '' }
+
+              it { is_expected.to be true }
+            end
+          end
+        end
+      end
+    end
+
+    describe '#open_access?' do
+      subject { described_class.open_access?(entity) }
+
+      it { is_expected.to be false }
+
+      context 'Entity' do
+        let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+        it { is_expected.to be false }
+
+        context "'open_access_tesim' => ''" do
+          let(:data) { { 'open_access_tesim' => ['anything but yes'] } }
+
+          it { is_expected.to be false }
+        end
+
+        context "'open_access_tesim' => 'yes'" do
+          let(:data) { { 'open_access_tesim' => ['yes'] } }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#published?' do
+      subject { described_class.published?(entity) }
+
+      it { is_expected.to be false }
+
+      context 'Entity' do
+        let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+        it { is_expected.to be false }
+
+        context "'visibility_ssi' => 'restricted'" do
+          let(:data) { { 'visibility_ssi' => 'restricted' } }
+
+          it { is_expected.to be false }
+        end
+
+        context "'visibility_ssi' => 'open'" do
+          let(:data) { { 'visibility_ssi' => 'open' } }
+
+          it { is_expected.to be true }
+
+          context "'suppressed_bsi' => true" do
+            let(:data) { { 'suppressed_bsi' => true, 'visibility_ssi' => 'open' } }
+
+            it { is_expected.to be false }
+          end
+        end
+      end
+    end
+
+    describe '#restricted?' do
+      subject { described_class.restricted?(entity) }
 
       it { is_expected.to be true }
+
+      context 'Entity' do
+        let(:data) { { "non_empty_solr_document" => "otherwise factory will return NullEntity!" } }
+
+        context 'Component' do
+          let(:component) { double('component') }
+
+          before do
+            allow(Greensub::Component).to receive(:find_by).with(noid: entity.noid).and_return(component)
+          end
+
+          it { is_expected.to be true }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Refactor Sighrax to seperate Hyrax from Sighrax by making request for a Hyrax presenter an explicit 'factory' call, see Sighrax.hyrax_presenter(entity) class method.

Also added explicit press factory: Sighrax.press(entity).