### PR TITLE
Add aptrust log view and start logging

### DIFF
--- a/app/views/aptrust_logs/index.html.erb
+++ b/app/views/aptrust_logs/index.html.erb
@@ -1,0 +1,46 @@
+<% size = 10 %>
+<div id="maincontent">
+  <div class="row">
+    <div class="col-md-12"><h1>Aptrust Log</h1></div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="row">
+        <form name="filter" method="get" action="<%=  %>">
+          <table class="table table-striped table-responsive" summary="Share Links List">
+            <tr>
+              <th></th>
+              <th><label for="noid_like">NOID</label></th>
+              <th><label for="where_like">Where</label></th>
+              <th><label for="stage_like">Stage</label></th>
+              <th><label for="status_like">Status</label></th>
+              <th><label for="action_like">Action</label></th>
+            </tr>
+            <tr>
+              <td><button name="submit" type="submit" value="filter">Filter</button></td>
+              <td><input type="text" name="noid_like" value="<%= params[:noid_like] %>" size="<%= size %>" aria-label="noid_like"></td>
+              <td><input type="text" name="where_like" value="<%= params[:where_like] %>" size="<%= size %>" aria-label="where_like"></td>
+              <td><input type="text" name="stage_like" value="<%= params[:stage_like] %>" size="<%= size %>" aria-label="stage_like"></td>
+              <td><input type="text" name="status_like" value="<%= params[:status_like] %>" size="<%= size %>" aria-label="status_like"></td>
+              <td><input type="text" name="action_like" value="<%= params[:action_like] %>" size="<%= size %>" aria-label="action_like"></td>
+              
+            </tr>
+            <% @aptrust_logs.each do |apt_log| %>
+              <tr>
+                <td></td>
+                <td><%= apt_log.noid %></td>
+                <td><%= apt_log.where %></td>
+                <td><%= apt_log.stage %></td>
+                <td><%= apt_log.status %></td>
+                <td><%= apt_log.action %></td>
+              </tr>
+            <% end %>
+          </table>
+        </form>
+      </div>
+      <div class="row">
+        <%= paginate @aptrust_logs %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         delete :truncate
       end
     end
+    resources :aptrust_logs, only: %i[index]
     resources :share_link_logs, only: %i[index]
     resources :grants, except: %i[edit update]
     resources :customers, only: %i[index] do


### PR DESCRIPTION
Converted puts comments and errors to logging statements.
Added logging view with filtering.
Added to routes.rb: 'resources :aptrust_logs, only: %i[index]'
Arrg: StandardError was failing when bagIt was creating a dir, so I'm now pre-making the dir for it.