### PR TITLE
HELIO-2643 - resolves CSB-208 and CSB-210

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'eccf588f811e0de91912f40731017baf8f00cad7'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'd8e417aa44dc46c640908b2a8defc72073896741'
 
 gem 'devise', '~> 4.6.0'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'd8e417aa44dc46c640908b2a8defc72073896741'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'd1c1314be41ec57fa90e46257f999a640a896fb9'
 
 gem 'devise', '~> 4.6.0'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: d8e417aa44dc46c640908b2a8defc72073896741
-  ref: d8e417aa44dc46c640908b2a8defc72073896741
+  revision: d1c1314be41ec57fa90e46257f999a640a896fb9
+  ref: d1c1314be41ec57fa90e46257f999a640a896fb9
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: eccf588f811e0de91912f40731017baf8f00cad7
-  ref: eccf588f811e0de91912f40731017baf8f00cad7
+  revision: d8e417aa44dc46c640908b2a8defc72073896741
+  ref: d8e417aa44dc46c640908b2a8defc72073896741
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Updates to use latest from CSB, which resolves CSB-208 and CSB-210. 

In FF, tall tables with a height greater than the size of the canvas do not reflow onto the next page and become clipped. This fix introduces a feature that detects the clipping in FF, and presents a button for the reader to open the table in modal window. See attached screenshots. Tested on preview.

![Screen Shot 2019-04-12 at 10 34 03 AM](https://user-images.githubusercontent.com/1686111/56047229-f9029000-5d12-11e9-9d17-0621f0ef0b59.png)

![Screen Shot 2019-04-12 at 10 34 12 AM](https://user-images.githubusercontent.com/1686111/56047239-fdc74400-5d12-11e9-9433-d57f8549d1d7.png)
