### PR TITLE
Development Production Resque Worker Environment: devproque

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Rails/UnknownEnv:
   - development
   - test
   - cucumber
+  - devproque
 
 RSpec/AnyInstance:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :development, :test do
   gem 'selenium-webdriver'
 end
 
-group :development do
+group :development, :devproque do
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,3 +1,6 @@
+devproque:
+  adapter: solr
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 development:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,3 +1,6 @@
+devproque:
+  adapter: async
+
 development:
   adapter: async
 

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -17,6 +17,10 @@ default: &default
   #shost: localhost
   #port: 3306
 
+devproque:
+  <<: *default
+  database: heliotrope_development
+
 development:
   <<: *default
   database: heliotrope_development

--- a/config/environments/devproque.rb
+++ b/config/environments/devproque.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'development'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Don't log all the asset requests
+  config.assets.quiet = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Web Console is activated in the devproque environment. This is
+  # usually a mistake. To ensure it's only activated in development
+  # mode, move it to the development group of your Gemfile:
+  #
+  #   gem 'web-console', group: :development
+  #
+  # If you still want to run it in the devproque environment (and know
+  # what you are doing), put this in your Rails application
+  # configuration:
+  #
+  #   config.web_console.development_only = false
+  config.web_console.development_only = false
+end

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,3 +1,8 @@
+devproque:
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: <%= ENV['FEDORA_URL'] || "http://127.0.0.1:#{ENV.fetch('FCREPO_DEVELOPMENT_PORT', 8984)}/rest" %>
+  base_path: /dev
 development:
   user: fedoraAdmin
   password: fedoraAdmin

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,6 @@
+devproque:
+  host: localhost
+  port: 6379
 development:
   host: localhost
   port: 6379

--- a/config/role_map.yml.sample
+++ b/config/role_map.yml.sample
@@ -1,3 +1,9 @@
+devproque:
+  admin:
+  - admin@fulcrum.org
+  archivist:
+  - archivist1@example.com
+
 development:
   admin:
     - admin@fulcrum.org

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -10,6 +10,9 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+devproque:
+  secret_key_base: ce8e524e16f8aafae63aa0a00781e57c0e32339790163a6d5ae66d23df4522e6dfee3d6ccadc2af30dc88fa826f3b2ad151d9c17c60e5b52ed8bd6da7c71e5a1
+
 development:
   secret_key_base: ce8e524e16f8aafae63aa0a00781e57c0e32339790163a6d5ae66d23df4522e6dfee3d6ccadc2af30dc88fa826f3b2ad151d9c17c60e5b52ed8bd6da7c71e5a1
 

--- a/config/settings/devproque.yml
+++ b/config/settings/devproque.yml
@@ -1,0 +1,28 @@
+# settings for curation concerns in a developemnt environment:
+# derivatives_path contains thumbnails and web-friendly audio, and video files for playbock
+derivatives_path: <%= File.join(Rails.root, 'tmp', 'derivatives') %>
+# uploads_path stashes files uploaded via the browser before ingest to fedora
+# on distributed architectures, uploads_path must be on a drive shared with the web server
+uploads_path: <%= File.join(Rails.root, 'tmp', 'uploads') %>
+# minter_path tracks the ID of the last-created object
+minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
+
+# aptrust_bags_path is the directory in which bags for aptrust will be created
+aptrust_bags_path: <%= File.join(Rails.root, 'tmp', 'aptrust-bags') %>
+
+resque_namespace: heliotrope-development
+host: localhost:3000
+
+keycard:
+  database:
+    adapter: sqlite
+    database: db/keycard-development.sqlite3
+    pool: 5
+    timeout: 5000
+
+checkpoint:
+  database:
+    adapter: sqlite
+    database: db/checkpoint-development.sqlite3
+    pool: 5
+    timeout: 5000

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,4 +1,6 @@
 # This is a sample config file that points to a solr server for each environment
+devproque:
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test:


### PR DESCRIPTION
Allows you to run a production resque worker in your development environment.

QUEUE=* VERBOSE=1 RAILS_ENV=devproque bundle exec rake resque:work

This worker will eager load the rails application once hence the actor stack will be created like the one in production and you'll be able to use the ExtractIngestJob to copy content from fulcrum.org into your development environment.