### PR TITLE
MonographPresenter.monograph_thumbnail generates entire img tag

### DIFF
--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -250,11 +250,14 @@ module Hyrax
     end
 
     def monograph_thumbnail(width = 225)
-      if representative_id.present?
-        "/image-service/#{representative_id}/full/#{width},/0/default.jpg#{representative_presenter&.image_cache_breaker}"
-      else
-        thumbnail_path
-      end
+      img_tag = "<img class=\"img-responsive\" src="
+      img_tag += if representative_id.present?
+                   "\"/image-service/#{representative_id}/full/#{width},/0/default.jpg#{representative_presenter&.image_cache_breaker}\""
+                 else
+                   "\"#{thumbnail_path}\" style=\"max-width:#{width}px\""
+                 end
+      img_tag += " alt=\"Cover image for #{representative_alt_text}\">"
+      img_tag
     end
 
     # This overrides CC 1.6.2's work_show_presenter.rb which is recursive.

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -4,8 +4,7 @@
       <span class="Z3988" title="<%= @monograph_presenter.monograph_coins_title %>"></span>
   <% end %>
   <div class="col-sm-3 monograph-cover">
-    <img class="img-responsive" src="<%= @monograph_presenter.monograph_thumbnail(225) %>"
-         alt="Cover for <%= @monograph_presenter.representative_alt_text %>">
+    <%= raw @monograph_presenter.monograph_thumbnail(225) %>
     <% if can? :edit, @monograph_presenter %>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.monograph_show_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.show_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.show_page_button') %></a>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.edit_hyrax_monograph_path(@monograph_presenter.id) %>" title="<%= t('monograph_catalog.index.edit_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.edit_page_button') %></a>

--- a/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
@@ -2,8 +2,7 @@
 <div class="document col-xs-6 col-md-4">
   <div class="thumbnail">
     <a href="<%= polymorphic_path(url_for_document(document)) %>" data-turbolinks="false">
-      <img class="img-responsive" src="<%= presenter.monograph_thumbnail(145) %>"
-           alt="Cover image for <%= presenter.representative_alt_text %>">
+      <%= raw presenter.monograph_thumbnail(145) %>
     </a>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, document_counter: document_counter %>

--- a/app/views/press_catalog/_thumbnail_list_monograph.html.erb
+++ b/app/views/press_catalog/_thumbnail_list_monograph.html.erb
@@ -2,8 +2,7 @@
   <div class="col-sm-3">
     <% presenter = Hyrax::MonographPresenter.new(document, current_ability) %>
     <a href="<%= polymorphic_path(url_for_document(document)) %>" >
-      <img class="img-responsive" src="<%= presenter.monograph_thumbnail(225) %>"
-           alt="Cover image for <%= presenter.representative_alt_text %>">
+      <%= raw presenter.monograph_thumbnail(225) %>
     </a>
   </div>
 <% end %>

--- a/app/views/press_catalog/_thumbnail_monograph.html.erb
+++ b/app/views/press_catalog/_thumbnail_monograph.html.erb
@@ -1,5 +1,5 @@
 <% if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, counter: document_counter_with_offset(document_counter)) %>
   <div class="col-sm-3">
-    <a href="<%= polymorphic_path(url_for_document(document)) %>" ><img class="img-responsive" src="<%= presenter.monograph_thumbnail(225) %>" alt="Cover image for <%= document.title.first %>"></a>
+    <a href="<%= polymorphic_path(url_for_document(document)) %>" ><%= raw presenter.monograph_thumbnail(225) %></a>
   </div>
 <% end %>

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -657,7 +657,9 @@ RSpec.describe Hyrax::MonographPresenter do
     end
 
     context 'representative_id not set, uses Hyrax default' do
-      it { expect(presenter.monograph_thumbnail).to be '/assets/work.png' }
+      it {
+        expect(presenter.monograph_thumbnail).to eq '<img class="img-responsive" src="/assets/work.png" style="max-width:225px" alt="Cover image for ">'
+      }
     end
 
     context 'representative_id set, uses image-service, default width' do
@@ -665,7 +667,9 @@ RSpec.describe Hyrax::MonographPresenter do
         allow(mono_doc).to receive(:representative_id).and_return('999999999')
       end
 
-      it { expect(presenter.monograph_thumbnail).to start_with '/image-service/999999999/full/225,/0/default.jpg' }
+      it {
+        expect(presenter.monograph_thumbnail).to start_with '<img class="img-responsive" src="/image-service/999999999/full/225,/0/default.jpg" alt="Cover image for ">'
+      }
     end
 
     context 'representative_id set, uses image-service, custom width' do
@@ -673,7 +677,9 @@ RSpec.describe Hyrax::MonographPresenter do
         allow(mono_doc).to receive(:representative_id).and_return('999999999')
       end
 
-      it { expect(presenter.monograph_thumbnail(99)).to start_with '/image-service/999999999/full/99,/0/default.jpg' }
+      it {
+        expect(presenter.monograph_thumbnail(99)).to start_with '<img class="img-responsive" src="/image-service/999999999/full/99,/0/default.jpg" alt="Cover image for ">'
+      }
     end
   end
 end


### PR DESCRIPTION
The thumbnails for real covers are resized by the image service but the generic work icon for monographs without covers was turning up at very large sizes sometimes. By moving the img tag construction inside the monograph_thumbnail method (which was generating the img src) we are able to add a max-width to the generic icon of whatever width we'd request for the real cover.

Fixes #2617