### PR TITLE
HELIO-2649 EPub TOC id attribute default is wrong

### DIFF
--- a/lib/e_pub/unmarshaller/toc.rb
+++ b/lib/e_pub/unmarshaller/toc.rb
@@ -19,7 +19,7 @@ module EPub
       # Instance Methods
 
       def id
-        @toc_element["id"] || 0
+        @toc_element["id"] || "toc"
       end
 
       def headers

--- a/lib/spec/e_pub/unmarshaller/toc_spec.rb
+++ b/lib/spec/e_pub/unmarshaller/toc_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EPub::Unmarshaller::TOC do
     subject { described_class.null_object }
 
     it { is_expected.to be_an_instance_of(EPub::Unmarshaller::TOCNullObject) }
-    it { expect(subject.id).to be_zero }
+    it { expect(subject.id).to eq "toc" }
     it { expect(subject.headers).to be_empty }
   end
 


### PR DESCRIPTION
Change the default nav id attribute to "toc" from 0

I've put this on preview and tested it with a variety of epubs there.