### PR TITLE
2404_aptrust_clean_up4

### DIFF
--- a/lib/tasks/bag_updated_monographs.rake
+++ b/lib/tasks/bag_updated_monographs.rake
@@ -96,7 +96,7 @@ namespace :aptrust do
       heads["X-Pharos-API-Key"] = @aptrust['AptrustApiKey']
 
       base_apt_url = @aptrust['AptrustApiUrl']
-      bag_name = "fulcrum.org.#{record['press']}-#{record['id']}.tar"
+      bag_name = "#{record['press']}-#{record['id']}.tar"
 
       updated_after = Time.parse(record['date_uploaded'].to_s) - (60 * 60 * 24)
       updated_after = updated_after.iso8601


### PR DESCRIPTION
Not longer need to prepend bag names with "fulcrum.org." since fulcrum has its own aptrust domain of that name.
Added 'Internal-Sender-Description' and 'Internal-Sender-Identifier' bag_info.txt since these show up when listed in the Pharos web interface.