### PR TITLE
HELIO-2691 - update CSB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'clamav', group: :production
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'd1c1314be41ec57fa90e46257f999a640a896fb9'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'ad304dbc53fe4d4c059775166117f0e570661801'
 
 gem 'devise', '~> 4.6.0'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: d1c1314be41ec57fa90e46257f999a640a896fb9
-  ref: d1c1314be41ec57fa90e46257f999a640a896fb9
+  revision: ad304dbc53fe4d4c059775166117f0e570661801
+  ref: ad304dbc53fe4d4c059775166117f0e570661801
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
to latest version, featuring hooks for hypothes.is annotation support and continued work for HELIO-2587 (hypothes.is integration in heliotrope).