### PR TITLE
HELIO-1526 Preview PDFs in the View page should download inline

### DIFF
--- a/app/overrides/hyrax/downloads_controller_overrides.rb
+++ b/app/overrides/hyrax/downloads_controller_overrides.rb
@@ -17,7 +17,7 @@ Hyrax::DownloadsController.class_eval do
         else
           CounterService.from(self, presenter).count(request: 1)
           self.status = 200
-          send_file_headers! content_options.merge(disposition: 'attachment')
+          send_file_headers! content_options.merge(disposition: disposition(presenter))
           response.headers['Content-Length'] ||= file.size.to_s
           response.headers['Last-Modified'] = asset.modified_date.utc.strftime("%a, %d %b %Y %T GMT")
           stream_body file.stream
@@ -25,6 +25,11 @@ Hyrax::DownloadsController.class_eval do
       else
         render 'hyrax/base/unauthorized', status: :unauthorized
       end
+    end
+
+    def disposition(presenter)
+      return "inline" if presenter.pdf_ebook? == false && presenter.file_format&.match?(/^pdf/i)
+      "attachment"
     end
 
     # going to tweak this function from Hyrax to return the thumbnail if the full-size screenshot is empty

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -193,4 +193,31 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
       expect { get :show, params: { id: file_set.id, use_route: 'downloads' } }.not_to raise_error
     end
   end
+
+  describe "#disposition" do
+    context "a pdf asset" do
+      let(:presenter) { double("presenter", pdf_ebook?: false, file_format: "pdf (Portable Document Format)") }
+
+      it "is inline" do
+        expect(subject.disposition(presenter)).to eq "inline"
+      end
+    end
+
+    context "not a pdf" do
+      let(:presenter) { double("presenter", pdf_ebook?: false, file_format: "jpeg (JPEG File Interchange Format, JPEG EXIF)") }
+
+      it "is attachment" do
+        expect(subject.disposition(presenter)).to eq "attachment"
+      end
+    end
+
+    context "a pdf_ebook" do
+      # Users shouldn't get here, the file_set show page isn't normally user accessible
+      let(:presenter) { double("presenter", pdf_ebook?: true, file_format: "pdf (Portable Document Format)") }
+
+      it "is attachment" do
+        expect(subject.disposition(presenter)).to eq "attachment"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This works for me with pdf assets in chrome and FF