### PR TITLE
HELIO-2655 Add crossref submission api endpoint

### DIFF
--- a/app/controllers/api/v1/crossref_registrations_controller.rb
+++ b/app/controllers/api/v1/crossref_registrations_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class CrossrefRegistrationsController < API::ApplicationController
+      def create
+        file = params[:fname].read
+        resp = Crossref::Register.new(file).post
+
+        if resp.code == 200 && resp.body.match(/SUCCESS/)
+          render json: { body: resp.body }, status: :ok
+        else
+          # Crossref will often send back 200 :ok status codes
+          # even if there are problems. It seems like the only reliable
+          # indication there's an error is in the html body. Which is
+          # not great.
+          render json: { body: resp.body }, status: :bad_request
+        end
+      end
+
+      private
+
+        # Only log exceptions, we do crossref specific logging
+        # in the CrossrefSubmissionLog from Crossref::Register
+        def log_request_response(exception = nil)
+          super(exception) if exception.present?
+        end
+
+        def crossref_registrations_params
+          params.require(:crossref_registrations).permit(:fname)
+        end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :api do # no json constraints
+    scope module: :v1, constraints: API::Version.new('v1', true) do
+      post 'crossref_register', controller: :crossref_registrations, action: :create
+    end
+  end
+
   constraints platform_administrator_constraint do
     namespace :greensub do
       resources :individuals do

--- a/spec/fixtures/fake_crossref_submit.xml
+++ b/spec/fixtures/fake_crossref_submit.xml
@@ -1,0 +1,1 @@
+<xml><doi_batch_id>test-batch-id</doi_batch_id>Some xml</xml>

--- a/spec/requests/api/v1/crossref_registrations_spec.rb
+++ b/spec/requests/api/v1/crossref_registrations_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "CrossrefRegistrations", type: :request do
+  context "unauthorized" do
+    it do
+      post api_crossref_register_path, params: {}
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'authorized' do
+    before do
+      allow_any_instance_of(API::ApplicationController).to receive(:authorize_request).and_return(nil)
+      allow(Crossref::Register).to receive(:new).and_return(register)
+    end
+
+    describe "POST /api/crossref_register" do
+      let(:register) { double("register", post: resp) }
+
+      context "with bad parameters" do
+        let(:params) { { fname: "<xml>Should be a file, not a string</xml>" } }
+        let(:resp) { double("resp", code: 200, body: "we won't get this far before failure") }
+
+        it "falls through the API::ApplicationController's rescue" do
+          post api_crossref_register_path, params: params
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.body).to match(/NoMethodError: undefined method `read/)
+        end
+      end
+
+      context "with good parameters" do
+        let(:params) { { fname: Rack::Test::UploadedFile.new(File.open(Rails.root.join('spec', 'fixtures', 'fake_crossref_submit.xml'))) } }
+
+        context "the correct response from crossref" do
+          let(:resp) { double("resp", code: 200, body: "\n\n\n\n<html>\n<head><title>SUCCESS</title>\n</head>\n<body>\n<h2>SUCCESS</h2>\n<p>Your batch submission was successfully received.</p>\n</body>\n</html>\n") }
+
+          it "returns success" do
+            post api_crossref_register_path, params: params
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to match(/SUCCESS/)
+          end
+        end
+
+        context "a failed response from crossref" do
+          # Crossref will respond with 200 even if there are problems.
+          # Not always I think, but often.
+          let(:resp) { double("resp", code: 200, body: "<html></head><title>Crossref Administration Home Page</title></head><body>some buried error message</body></html>") }
+
+          it "returns error" do
+            post api_crossref_register_path, params: params
+            expect(response).to have_http_status(:bad_request)
+            expect(response.body).not_to match(/SUCCESS/)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using a token and some xml I'm able to use this to post to test.crossref.org using curl.