### PR TITLE
title handling improvements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,12 +39,14 @@ Naming/HeredocDelimiterCase:
 Naming/HeredocDelimiterNaming:
   Exclude:
     - 'app/presenters/concerns/embed_code_presenter.rb'
+    - 'app/presenters/concerns/social_share_widget_presenter.rb'
     - 'lib/spec/e_pub/bridge_to_webgl_spec.rb'
     - 'lib/spec/e_pub/cfi_spec.rb'
     - 'lib/spec/e_pub/chapter_spec.rb'
     - 'lib/spec/e_pub/chapter_presenter_spec.rb'
     - 'lib/spec/e_pub/snippet_spec.rb'
     - 'spec/presenters/concerns/embed_code_presenter_spec.rb'
+    - 'spec/presenters/concerns/social_share_widget_presenter_spec.rb'
 
 Naming/MemoizedInstanceVariableName:
   Exclude:

--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -7,7 +7,7 @@ class EPubsController < CheckpointController
   def show
     return redirect_to epub_access_url unless @policy.show?
 
-    @title = @presenter.parent.present? ? @presenter.parent.title : @presenter.title
+    @title = @presenter.parent.present? ? @presenter.parent.page_title : @presenter.page_title
     @citable_link = @presenter.citable_link
     @back_link = params[:publisher].present? ? URI.join(main_app.root_url, params[:publisher]).to_s : main_app.monograph_catalog_url(@presenter.monograph_id)
     @subdomain = @presenter.monograph.subdomain

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -19,7 +19,7 @@ module BreadcrumbsHelper
       return [] if press.blank?
 
       crumbs = possible_parent(press)
-      crumbs << { href: "", text: presenter.page_title, class: "active" }
+      crumbs << { href: "", text: presenter.title, class: "active" }
     end
 
     def breadcrumbs_for_monograph_show_page(subdomain, presenter)
@@ -27,7 +27,7 @@ module BreadcrumbsHelper
       return [] if press.blank?
 
       crumbs = possible_parent(press)
-      crumbs << { href: main_app.monograph_catalog_path(presenter.id), text: presenter.page_title, class: "" }
+      crumbs << { href: main_app.monograph_catalog_path(presenter.id), text: presenter.title, class: "" }
       crumbs << { href: "", text: 'Show', class: "active" }
     end
 
@@ -36,8 +36,8 @@ module BreadcrumbsHelper
       return [] if press.blank?
 
       crumbs = possible_parent(press)
-      crumbs << { href: main_app.monograph_catalog_path(presenter.monograph_id), text: presenter.monograph.page_title, class: "" }
-      crumbs << { href: "", text: presenter.page_title, class: "active" }
+      crumbs << { href: main_app.monograph_catalog_path(presenter.monograph_id), text: presenter.monograph.title, class: "" }
+      crumbs << { href: "", text: presenter.title, class: "active" }
     end
 
     def possible_parent(press)

--- a/app/presenters/concerns/social_share_widget_presenter.rb
+++ b/app/presenters/concerns/social_share_widget_presenter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SocialShareWidgetPresenter
+  extend ActiveSupport::Concern
+
+  def social_share_widget_template_content
+    <<~END
+      <div class="btn-group">
+        <button class="button--sm dropdown-toggle" data-toggle="dropdown" aria-label="Promote on social media and share this book" aria-haspopup="true" aria-expanded="false">
+          <i id="share" class="icon-share-boxed oi" data-glyph="share-boxed" title="Promote on social media and share this book" aria-hidden="true"></i>
+        </button>
+        <ul class="dropdown-menu">
+          <li>#{social_share_link(:twitter)}</li>
+          <li>#{social_share_link(:facebook)}</li>
+          <li>#{social_share_link(:google)}</li>
+          <li>#{social_share_link(:reddit)}</li>
+          <li>#{social_share_link(:mendeley)}</li>
+          <li>#{social_share_link(:citeulike)}</li>
+        </ul>
+      </div>
+    END
+  end
+
+  def social_share_widget_template
+    social_share_widget_template_content.gsub(/(?:\n\r?|\r\n?)/, '').html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def social_share_link(platform = nil) # rubocop:disable Metrics/CyclomaticComplexity
+    case platform
+    when :twitter
+      "<a href=\"http://twitter.com/intent/tweet?text=#{url_title}&url=#{citable_link}\" target=\"_blank\">Twitter</a>"
+    when :facebook
+      "<a href=\"http://www.facebook.com/sharer.php?u=#{citable_link}&t=#{url_title}\" target=\"_blank\">Facebook</a>"
+    when :google
+      "<a href=\"https://plus.google.com/share?url=#{citable_link}\" target=\"_blank\">Google+</a>"
+    when :reddit
+      "<a href=\"http://www.reddit.com/submit?url=#{citable_link}\" target=\"_blank\">Reddit</a>"
+    when :mendeley
+      "<a href=\"http://www.mendeley.com/import/?url=#{citable_link}\" target=\"_blank\">Mendeley</a>"
+    when :citeulike
+      "<a href=\"http://www.citeulike.org/posturl?url=#{citable_link}&title=#{url_title}\" target=\"_blank\">Cite U Like</a>"
+    end
+  end
+end

--- a/app/presenters/concerns/title_presenter.rb
+++ b/app/presenters/concerns/title_presenter.rb
@@ -4,12 +4,17 @@ module TitlePresenter
   extend ActiveSupport::Concern
 
   # used as a title starting point by Hyrax::CitationsBehaviors, strip Markdown and HTML tags
+  # but note that we purposefully pass a presenter to Hyrax::CitationsBehaviors rather than a Work/Monograph
   def to_s
     MarkdownService.markdown_as_text(md_title, true)
   end
 
   def page_title
-    to_s
+    MarkdownService.markdown_as_text(md_title, true)
+  end
+
+  def url_title
+    CGI.escape(page_title)
   end
 
   def title

--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -6,6 +6,7 @@ module Hyrax
     include CitableLinkPresenter
     include OpenUrlPresenter
     include TitlePresenter
+    include SocialShareWidgetPresenter
     include FeaturedRepresentatives::MonographPresenter
     include ActionView::Helpers::UrlHelper
 

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -407,7 +407,7 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         // Share widget
         cozy.control.widget.button({
           region: 'top.toolbar.left',
-          template: '<div class="btn-group"><button class="button--sm dropdown-toggle" data-toggle="dropdown" aria-label="Promote on social media and share this book" aria-haspopup="true" aria-expanded="false"><i id="share" class="icon-share-boxed oi" data-glyph="share-boxed" title="Promote on social media and share this book" aria-hidden="true"></i></button><ul class="dropdown-menu"><li><a href="http://twitter.com/intent/tweet?text=<%= @monograph_presenter.page_title %>&amp;url=<%= @citable_link %>" target="_blank">Twitter</a></li><li><a href="http://www.facebook.com/sharer.php?u=<%= @citable_link %>&amp;t=<%= @monograph_presenter.page_title %>" target="_blank">Facebook</a></li><li><a href="https://plus.google.com/share?url=<%= @citable_link %>" target="_blank">Google+</a></li><li><a href="http://www.reddit.com/submit?url=<%= @citable_link %>" target="_blank">Reddit</a></li><li><a href="http://www.mendeley.com/import/?url=<%= @citable_link %>" target="_blank">Mendeley</a></li><li><a href="http://www.citeulike.org/posturl?url=<%= @citable_link %>&amp;title=<%= @monograph_presenter.page_title %>" target="_blank">Cite U Like</a></li></ul></div>'
+          template: '<%= @monograph_presenter.social_share_widget_template %>'
         }).addTo(reader);
 
         // Download widget

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -29,12 +29,12 @@
   <div class="btn-group share">
     <button type="button" class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Share <span class="caret"></span></button>
       <ul class="dropdown-menu">
-        <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter.page_title %>&amp;url=<%= @presenter.citable_link %>">Twitter</a></li>
-        <li><a href="http://www.facebook.com/sharer.php?u=<%= @presenter.citable_link %>&amp;t=<%= @presenter.page_title %>">Facebook</a></li>
+        <li><a href="http://twitter.com/intent/tweet?text=<%= @presenter.url_title %>&url=<%= @presenter.citable_link %>">Twitter</a></li>
+        <li><a href="http://www.facebook.com/sharer.php?u=<%= @presenter.citable_link %>&t=<%= @presenter.url_title %>">Facebook</a></li>
         <li><a href="https://plus.google.com/share?url=<%= @presenter.citable_link %>">Google+</a></li>
         <li><a href="http://www.reddit.com/submit?url=<%= @presenter.citable_link %>">Reddit</a></li>
         <li><a href="http://www.mendeley.com/import/?url=<%= @presenter.citable_link %>">Mendeley</a></li>
-        <li><a href="http://www.citeulike.org/posturl?url=<%= @presenter.citable_link %>&amp;title=<%= @presenter.page_title %>">Cite U Like</a></li>
+        <li><a href="http://www.citeulike.org/posturl?url=<%= @presenter.citable_link %>&title=<%= @presenter.url_title %>">Cite U Like</a></li>
       </ul>
   </div>
 </div><!-- form-actions -->

--- a/app/views/monograph_catalog/_index_header_gallery_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_header_gallery_file_set.html.erb
@@ -3,6 +3,6 @@
   <div class="documentHeader">
     <h4 class="index_title">
       <% counter = document_counter_with_offset(document_counter) %>
-      <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+      <%= render_markdown link_to_document document, render_markdown(document.title.first), counter: counter %>
     </h4>
   </div>

--- a/app/views/monograph_catalog/_index_header_list_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_header_list_file_set.html.erb
@@ -3,7 +3,7 @@
   <div class="documentHeader">
     <h4 class="index_title">
       <% counter = document_counter_with_offset(document_counter) %>
-      <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+      <%= link_to_document document, render_markdown(document.title.first), counter: counter %>
     </h4>
     <% if document.section_title.present? %>
       <p>From <%= render_markdown @monograph_presenter.display_section_titles document.section_title %></p>

--- a/app/views/press_catalog/_index_header_gallery_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_gallery_monograph.html.erb
@@ -3,6 +3,6 @@
   <div class="documentHeader">
     <h3 class="index_title">
       <% counter = document_counter_with_offset(document_counter) %>
-      <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+      <%= render_markdown link_to_document document, render_markdown(document.title.first), counter: counter %>
     </h3>
   </div>

--- a/app/views/press_catalog/_index_header_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_header_list_monograph.html.erb
@@ -5,7 +5,7 @@
     <div class="col-sm-12">
       <h3 class="index_title">
         <% counter = document_counter_with_offset(document_counter) %>
-        <%= render_markdown link_to_document document, document_show_link_field(document), counter: counter %>
+        <%= render_markdown link_to_document document, render_markdown(document.title.first), counter: counter %>
       </h3>
       <% if presenter.authors? %>
         <span class="authors"><%= render_markdown presenter.authors %></span>

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EPubsController, type: :controller do
       end
 
       context 'file epub' do
-        let(:monograph) { create(:public_monograph) }
+        let(:monograph) { create(:public_monograph, title: ['A book with _emphasis_ n <em>stuff</em>']) }
         let(:file_set) { create(:public_file_set, content: File.open(File.join(fixture_path, 'fake_epub01.epub'))) }
         let!(:fr) { create(:featured_representative, monograph_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
 
@@ -53,6 +53,7 @@ RSpec.describe EPubsController, type: :controller do
 
         it do
           get :show, params: { id: file_set.id }
+          expect(assigns(:title)).to eq('A book with emphasis n stuff')
           expect(response).to have_http_status(:success)
           expect(response.body.empty?).to be true
         end

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -17,7 +17,7 @@ describe 'Create a monograph' do
 
       # Monograph form
       # Basic Metadata
-      fill_in 'monograph[title]', with: '#hashtag Test monograph with _MD Italics_ and <em>HTML Italics</em>'
+      fill_in 'monograph[title]', with: '#hashtag Test Monograph Title with _MD Italics_ and <em>HTML Italics</em>'
       select press.name, from: 'Publisher'
       fill_in 'Description', with: 'Blahdy blah description works'
       expect(page).to have_css('input.monograph_subject', count: 1)
@@ -57,8 +57,8 @@ describe 'Create a monograph' do
       click_button 'Save'
 
       # Monograph catalog page
-      expect(page.title).to eq '#hashtag Test monograph with MD Italics and HTML Italics'
-      expect(page).to have_content '#hashtag Test monograph with MD Italics and HTML Italics'
+      expect(page.title).to eq '#hashtag Test Monograph Title with MD Italics and HTML Italics'
+      expect(page).to have_content '#hashtag Test Monograph Title with MD Italics and HTML Italics'
       # get text inside <em> tags
       italicized_text = page.first('.col-sm-9.monograph-metadata h1 em').text
       expect(italicized_text).to eq 'MD Italics'
@@ -73,6 +73,16 @@ describe 'Create a monograph' do
       expect(page).to have_css("img[src*='https://i.creativecommons.org/p/mark/1.0/80x15.png']", count: 1)
       expect(page).to have_link(nil, href: 'https://creativecommons.org/publicdomain/mark/1.0/')
       expect(page.find(:css, 'a[href="https://creativecommons.org/publicdomain/mark/1.0/"]')[:target]).to eq '_blank'
+
+      # check breadcrumbs
+      linked_crumbs = page.all('ol.breadcrumb li a')
+      expect(linked_crumbs.count).to eq 1
+      expect(linked_crumbs[0]).to have_content 'Home'
+      unlinked_crumb = page.all('ol.breadcrumb li.active')
+      expect(unlinked_crumb.count).to eq 1
+      expect(unlinked_crumb.first).to have_content '#hashtag Test Monograph Title with MD Italics and HTML Italics'
+      expect(unlinked_crumb.first).to have_css('em', text: 'MD Italics')
+      expect(unlinked_crumb.first).to have_css('em', text: 'HTML Italics')
 
       click_link 'Edit Monograph'
 
@@ -109,10 +119,10 @@ describe 'Create a monograph' do
       click_link 'Manage Monograph and Files'
 
       # On Monograph show page
-      expect(page.title).to eq '#hashtag Test monograph with MD Italics and HTML Italics'
+      expect(page.title).to eq '#hashtag Test Monograph Title with MD Italics and HTML Italics'
       # Basic Metadata
       # title
-      expect(page).to have_content '#hashtag Test monograph with MD Italics and HTML Italics'
+      expect(page).to have_content '#hashtag Test Monograph Title with MD Italics and HTML Italics'
       # get text inside <em> tags
       italicized_text = page.first('.col-xs-12 header h1 em').text
       expect(italicized_text).to eq 'MD Italics'
@@ -163,11 +173,11 @@ describe 'Create a monograph' do
       expect(page).to have_content '<identifier>'
 
       # MLA citation
-      expect(page).to have_content 'Johns, Jimmy, and Sub Way. #hashtag Test Monograph with MD Italics and HTML Italics. Ann Arbor, MI.'
+      expect(page).to have_content 'Johns, Jimmy, and Sub Way. #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.'
       # APA citation
-      expect(page).to have_content 'Johns, J., & Way, S. (2001). #hashtag Test monograph with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
+      expect(page).to have_content 'Johns, J., & Way, S. (2001). #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
       # Chicago citation
-      expect(page).to have_content 'Johns, Jimmy, and Sub Way. 2001. #hashtag Test Monograph with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
+      expect(page).to have_content 'Johns, Jimmy, and Sub Way. 2001. #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
     end
   end
 end

--- a/spec/presenters/concerns/social_share_widget_presenter_spec.rb
+++ b/spec/presenters/concerns/social_share_widget_presenter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SocialShareWidgetPresenter do
+  let(:mono_doc) {
+    SolrDocument.new(id: '999999999',
+                     title_tesim: ['#hashtag Test monograph with _MD Italics_ and <em>HTML Italics</em>'])
+  }
+
+  let(:presenter) { Hyrax::MonographPresenter.new(mono_doc, nil) }
+
+  let(:expected_widget_template_content) {
+    <<~END
+      <div class="btn-group">
+        <button class="button--sm dropdown-toggle" data-toggle="dropdown" aria-label="Promote on social media and share this book" aria-haspopup="true" aria-expanded="false">
+          <i id="share" class="icon-share-boxed oi" data-glyph="share-boxed" title="Promote on social media and share this book" aria-hidden="true"></i>
+        </button>
+        <ul class="dropdown-menu">
+          <li>#{presenter.social_share_link(:twitter)}</li>
+          <li>#{presenter.social_share_link(:facebook)}</li>
+          <li>#{presenter.social_share_link(:google)}</li>
+          <li>#{presenter.social_share_link(:reddit)}</li>
+          <li>#{presenter.social_share_link(:mendeley)}</li>
+          <li>#{presenter.social_share_link(:citeulike)}</li>
+        </ul>
+      </div>
+    END
+  }
+
+  describe "#social_share_widget_template" do
+    it "has the correct HTML for the EPUB reader" do
+      expect(presenter.social_share_widget_template).to eq(expected_widget_template_content.gsub(/(?:\n\r?|\r\n?)/, ''))
+    end
+  end
+
+  describe "#social_share_link" do
+    it "provides the correct link for each platform" do
+      expect(presenter.social_share_link(:twitter)).to eq("<a href=\"http://twitter.com/intent/tweet?text=%23hashtag+Test+monograph+with+MD+Italics+and+HTML+Italics&url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Twitter</a>")
+      expect(presenter.social_share_link(:facebook)).to eq("<a href=\"http://www.facebook.com/sharer.php?u=https://hdl.handle.net/2027/fulcrum.999999999&t=%23hashtag+Test+monograph+with+MD+Italics+and+HTML+Italics\" target=\"_blank\">Facebook</a>")
+      expect(presenter.social_share_link(:google)).to eq("<a href=\"https://plus.google.com/share?url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Google+</a>")
+      expect(presenter.social_share_link(:reddit)).to eq("<a href=\"http://www.reddit.com/submit?url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Reddit</a>")
+      expect(presenter.social_share_link(:mendeley)).to eq("<a href=\"http://www.mendeley.com/import/?url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Mendeley</a>")
+      expect(presenter.social_share_link(:citeulike)).to eq("<a href=\"http://www.citeulike.org/posturl?url=https://hdl.handle.net/2027/fulcrum.999999999&title=%23hashtag+Test+monograph+with+MD+Italics+and+HTML+Italics\" target=\"_blank\">Cite U Like</a>")
+    end
+  end
+end

--- a/spec/presenters/concerns/title_presenter_spec.rb
+++ b/spec/presenters/concerns/title_presenter_spec.rb
@@ -101,4 +101,15 @@ RSpec.describe TitlePresenter do
       is_expected.to eq markup_and_tag_free_title
     end
   end
+
+  describe '#url_title' do
+    subject { presenter.url_title }
+
+    let(:markdown_title) { '#hashtag: A subtitle and _markdown_ and <em>HTML Tags</em> and stuff' }
+    let(:urlable_markup_free_title) { '%23hashtag%3A+A+subtitle+and+markdown+and+HTML+Tags+and+stuff' }
+
+    it 'CGI escapes and strips Markdown and HTML tags' do
+      is_expected.to eq urlable_markup_free_title
+    end
+  end
 end

--- a/spec/views/monograph_catalog/index.html.erb_spec.rb
+++ b/spec/views/monograph_catalog/index.html.erb_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "monograph_catalog/index.html.erb", type: :view do
     let!(:press) { create(:press, subdomain: subdomain) }
 
     before do
-      allow(monograph_presenter).to receive(:page_title).and_return(page_title)
+      allow(monograph_presenter).to receive(:title).and_return(page_title)
       allow(monograph_presenter).to receive(:subdomain).and_return(subdomain)
       render
     end


### PR DESCRIPTION
HELIO-2699, HELIO-2710, HELIO-2712
- CGI escape for URLs, i.e. hashtags
- break huge CSB share link widget template value into methods
- tests for title-based (and other) social media share links
- more title-base links allow Markdown/HTML emphasis, e.g.
  breadcrumbs, file_set links on catalog page
- fix regression where Markdown syntax is showing
- remove HTML from page title for EPUB reader
- improve test coverage around breadcrumbs and...
  Markdown in titles