### PR TITLE
2404_aptrust_clean_up8

### DIFF
--- a/lib/tasks/bag_updated_monographs.rake
+++ b/lib/tasks/bag_updated_monographs.rake
@@ -108,7 +108,7 @@ namespace :aptrust do
       heads["X-Pharos-API-Key"] = @aptrust['AptrustApiKey']
 
       base_apt_url = @aptrust['AptrustApiUrl']
-      bag_name = "#{record['press']}-#{record['id']}.tar"
+      bag_name = "fulcrum.org.#{record['press']}-#{record['id']}.tar"
 
       updated_after = Time.parse(record['date_uploaded'].to_s) - (60 * 60 * 24)
       updated_after = updated_after.iso8601


### PR DESCRIPTION
Cleaning up the bag name by adding fulcrum.org. to beginning of name in the method that checks if the bag is deposited (update_db_aptrust_status(record)).