### PR TITLE
HELIO-2587 - add hypothes.is annotation widget

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -1125,6 +1125,23 @@ footer.press {
     font-size: .9em !important;
 }
 
+.cozy-control button.button--sm.annotation i {
+  font-size: 1.1em !important;
+  margin-top: 1px;
+}
+
+.cozy-control .annotation-count {
+  position: relative;
+  right: 14px;
+  color: #fff;
+  top: 1px;
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  display: block;
+  font-size: .7em;
+}
+
 .cozy-container input[type="radio"] {
   margin: 7px 7px 0 2em;
 }
@@ -1150,6 +1167,12 @@ footer.press {
   display: none;
 }
 
+.cozy-panel-header {
+  .cozy-panel-right {
+    flex-direction: row-reverse;
+    
+  }
+}
 
 .cozy-control .btn-group {
   display: flex;
@@ -1210,6 +1233,7 @@ footer.press {
 .panel-open.panel-right .cozy-module-book-cover {
   width: 50vw
 }
+
 .panel-open.panel-right .cozy-module-right {
   right: 50vw;
 }
@@ -1226,6 +1250,17 @@ footer.press {
   right: 0;
   top: 0;
   bottom: 0;
+}
+
+.special-panel.cozy-module-annotator {
+  left: 50vw;
+
+  .hypothesis-panel iframe.h-sidebar-iframe {
+    height: 100%;
+    width: 100%;
+    border: 0;
+  }
+
 }
 
 #gameContainer {

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -6,6 +6,28 @@
   <% if @monograph_presenter.doi.present? %>
     <script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
   <% end %>
+  <% if defined? @subdomain %>
+    <%# only include hypothes.is for leverpress at this point %>
+    <% if %w[leverpress].include? @subdomain %>
+    <!-- hypothes.is -->
+      <script type="text/javascript">
+        window.hypothesisConfig = function () {
+          return {
+            openSidebar: false,
+            theme: 'classic', // "clean" or "classic"
+            enableMultiFrameSupport: true,
+            onLayoutChange: function(state) {
+              var $frame = $('.annotator-frame');
+              var $reader = $("#reader");
+            },
+            externalContainerSelector: '.hypothesis-panel',
+            enableExperimentalNewNoteButton: true
+          };
+        };
+      </script>
+      <script src="https://cdn.hypothes.is/hypothesis"></script>
+    <% end %>
+  <% end %>
   <% if @monograph_presenter.webgl? %>
     <%
 # load what we need to show the webgl/3-d model if needed
@@ -33,9 +55,70 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
   <div id="epub" class="<%= @subdomain %>">
     <div id="reader"></div>
 
+    <% if %w[leverpress].include? @subdomain %>
+    <%# annotation widget counter %>
+      <div class="hypothesis-panel" style="display:none;"></div>
+    <% end %>
+
     <script type="text/javascript">
       if ( true ) {
-        //$("body").addClass("reading");
+        
+        <% if %w[leverpress].include? @subdomain %>
+          // Create custom Annotator tool that is aware of its state
+          AnnotationTool = cozy.Control.Widget.Toggle.extend({
+            defaultTemplate: '<button class="button--sm annotation" data-toggle="button" aria-label="Open Annotations"><i class="fa fa-pencil" title="Open and close annotation panel" aria-hidden="true"></i></button><div class="annotation-count" data-hypothesis-annotation-count></div>',
+          
+
+            initialize: function(options) {
+
+              cozy.Control.Widget.Toggle.prototype.initialize.apply(this, arguments);
+
+              this.options.states = [{
+                stateName: 'open-annotator',
+                onClick: this.closeAnnotator.bind(this)
+              },
+              {
+                stateName: 'close-annotator',
+                onClick: this.openAnnotator.bind(this)
+              }];
+            },
+
+            _onAddExtra: function(container) {
+              // super._onAddExtra(container);
+              cozy.Control.Widget.Toggle.prototype._onAddExtra.apply(this, arguments);
+              this.setupHook();
+              return container;
+            },
+
+            openAnnotator: function(self, reader) {
+              this.options.$panel.parents("body").addClass("panel-open");
+              this.options.$panel.show();
+              self.state('open-annotator');
+            },
+
+            closeAnnotator: function(self, reader) {
+              this.options.$panel.hide();
+              this.options.$panel.parents("body").removeClass("panel-open");
+              self.state('close-annotator');
+            },
+
+            setupHook: function() {
+              var reader = this._reader;
+              reader.rendition.hooks.content.register(function(contents, view) {
+                contents.window.addEventListener('scrolltorange', function (e) {
+                  var range = e.detail;
+                  var cfi = new reader.CFI(range, contents.cfiBase).toString();
+                  if (cfi) {
+                    reader.gotoPage(cfi);
+                  }
+                  e.preventDefault();
+                });
+              })
+            } 
+          })
+        <% end %>
+
+        // Configure and initiate reader
         var reader = cozy.reader('reader', {
           href: "<%= "#{main_app.epub_url.gsub!(/\?.*/, '')}/" %>",
           skipLink: '.skip',
@@ -55,21 +138,37 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
           template: '<button class="button--sm cozy-close" data-toggle="button" data-slot="label" aria-label="Close reader"></button>',
           onClick: function() { window.location = "<%= "#{@back_link}" %>"; }
         }).addTo(reader);
+        
         // Press brand widget
-        // TODO: only show logo for publishers that also have CSS overrides. Currently only HEB has this.
+        // TODO: only show logo for publishers that also have CSS overrides.
         <% if defined? @subdomain %>
         // only include logos for heb, nyupress, leverpress, rekihaku and gabii at this point
-        <% if %w[heb nyupress gabii michigan leverpress rekihaku].include? @subdomain %>
-        cozy.control.widget.panel({
-          region: 'top.header.left',
-          template: '<div class="logo"><%= link_to (image_tag logo(@subdomain), role: 'link', alt: @subdomain + ' catalog on Fulcrum'), URI.join(main_app.root_url, @subdomain).to_s %>',
-          data: { title: "<%= @subdomain %>" }
-        }).addTo(reader);
+          <% if %w[heb nyupress gabii michigan leverpress rekihaku].include? @subdomain %>
+            cozy.control.widget.panel({
+              region: 'top.header.left',
+              template: '<div class="logo"><%= link_to (image_tag logo(@subdomain), role: 'link', alt: @subdomain + ' catalog on Fulcrum'), URI.join(main_app.root_url, @subdomain).to_s %>',
+              data: { title: "<%= @subdomain %>" }
+            }).addTo(reader);
+          <% end %>
         <% end %>
-        <% end %>
+        
         // Book/chapter title widget
         cozy.control.title({ region: 'top.header.left' }).addTo(reader);
 
+        // Altmetric and Dimensions widgets
+        cozy.control.widget.panel({
+          region: 'top.header.right',
+          className: 'cozy-container-altmetric',
+          template: '<div data-badge-popover="bottom" data-badge-type="1" data-isbn="<%= @monograph_presenter.isbn_noformat.first %>" data-hide-no-mentions="true" class="altmetric-embed"></div>',
+        }).addTo(reader);
+
+        <% if @monograph_presenter.doi.present? %>
+          cozy.control.widget.panel({
+            region: 'top.header.right',
+            className: 'cozy-container-dimensions',
+            template: '<span class="__dimensions_badge_embed__" data-doi="<%= @monograph_presenter.doi_path %>" data-hide-zero-citations="true" data-legend="hover-bottom" data-style="large_rectangle"></span>',
+          }).addTo(reader);
+        <% end %>
 
         // MOBILE ONLY
         // Close reader/Return to previous screen widget
@@ -312,7 +411,6 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         }
 
         // 3D model toggler
-        var panel_toggle = cozy.control.widget.toggle({
           region: 'top.toolbar.left',
           template: '<button class="button--sm" id="webgl" data-toggle="button" aria-label="3D Model">3D Model</button>',
           states: [{
@@ -457,6 +555,7 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
                 ]
             })
 
+        // Share widget
         cozy.control.widget.button({
           region: 'top.toolbar.left',
           template: '<button id="share-link-btn" class="button--sm cozy-share" data-toggle="button" data-slot="label" aria-label="Share a Readable Version"><i class="oi" data-glyph="link-intact" title="Share a Readable Version" aria-hidden="true"></i></button>',
@@ -471,22 +570,6 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
             });
           }
         }).addTo(reader);
-        <% end %>
-
-
-        // Altmetric and Dimensions widget
-        cozy.control.widget.panel({
-          region: 'top.toolbar.right',
-          className: 'cozy-container-altmetric',
-          template: '<div data-badge-popover="bottom" data-badge-type="1" data-isbn="<%= @monograph_presenter.isbn_noformat.first %>" data-hide-no-mentions="true" class="altmetric-embed"></div>',
-        }).addTo(reader);
-
-        <% if @monograph_presenter.doi.present? %>
-          cozy.control.widget.panel({
-            region: 'top.toolbar.right',
-            className: 'cozy-container-dimensions',
-            template: '<span class="__dimensions_badge_embed__" data-doi="<%= @monograph_presenter.doi_path %>" data-hide-zero-citations="true" data-legend="hover-bottom" data-style="large_rectangle"></span>',
-          }).addTo(reader);
         <% end %>
 
         // Fullscreen widget
@@ -535,14 +618,8 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         <% end %>
 
         // Paging widgets
-        // cozy.control.pageFirst({ region: 'left.sidebar' }).addTo(reader);
         cozy.control.pagePrevious({ region: 'left.sidebar' }).addTo(reader);
         cozy.control.pageNext({ region: 'right.sidebar' }).addTo(reader);
-        // cozy.control.pageLast({ region: 'right.sidebar' }).addTo(reader);
-        // cozy.control.navigator({ region: 'book.navigator' }).addTo(reader);
-
-        // Publisher/copyright widgets
-        // cozy.control.publicationMetadata({ region: 'bottom.footer' }).addTo(reader);
 
         // Feedback widget
         cozy.control.widget.panel({
@@ -558,11 +635,52 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         // Navigator widgets
         cozy.control.navigator({ region: 'bottom.navigator' }).addTo(reader);
 
+        // Annotation widget checks and initialization
+        <% if %w[leverpress].include? @subdomain %>
+          var tm;
+          function checkForAnnotator(cb, w) {
+            if (!w) {
+              w = window;
+            }
+            tm = setTimeout(function () {
+              if (w && w.annotator) {
+                clearTimeout(tm);
+                cb();
+              } else {
+                checkForAnnotator(cb, w);
+              }
+            }, 100);
+          }
+
+          // the panel has to be created first
+          $("body").addClass("panel-open panel-right");
+          var $main = $(".cozy-module-main");
+          var $panel = $('<div class="special-panel cozy-module-annotator"></div>').appendTo($main);
+
+          // pass the reference to the panel
+          var annotation_tool = new AnnotationTool({
+            region: 'top.toolbar.left',
+            $panel: $panel,
+          })
+          annotation_tool.addTo(reader);
+
+        <% end %>
+
         <% if @monograph_presenter.webgl? %>
           open_panel();
         <% end %>
+        
         // Initiate EPUB Reader
-        reader.start(fetch_poi);
+        reader.start(function() {
+          <% if @monograph_presenter.webgl? %>
+            fetch_poi();
+          <% end %>
+          <% if %w[leverpress].include? @subdomain %>
+            var $hypothesis_panel = $(".hypothesis-panel");
+            $hypothesis_panel.css({ display: 'block', height: '100%' });
+            $panel.append($hypothesis_panel);
+          <% end %>
+        });
       }
     </script>
   </div>


### PR DESCRIPTION
Add listeners for annotation; add custom annotation control; adjust CSS and annotation icon; config hypothes.is e-reader show page; configure panel toggle on and off for annotations; add annotation counts to button; moves altmetric and dimensions widgets to the top menu because we are reaching too many widget buttons in the mid menu.

This branch also include some basic cleanup to the e-reader show page.