### PR TITLE
fixup gabii CSS

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -1947,8 +1947,6 @@ $gabii-link-hover:    #1e5667;
 
     .cozy-panel-header > .cozy-panel-right {
 
-      justify-content: flex-end;
-
       .alert {
         padding: 12.5px;
         margin: 0;


### PR DESCRIPTION
Remove gabii specific rule that overrode positioning of altmetric/dimensions badges.

Change this:
![Screen Shot 2019-05-17 at 8 20 55 AM](https://user-images.githubusercontent.com/1686111/57927756-00bad480-787d-11e9-8e0a-c72d9944c999.png)


To this:
![Screen Shot 2019-05-17 at 8 20 29 AM](https://user-images.githubusercontent.com/1686111/57927766-087a7900-787d-11e9-9d5c-83be2cb76f1a.png)
