### PR TITLE
HELIO-2740 Minted DOIs cannot be updated in the UI

### DIFF
--- a/app/assets/javascripts/application/freeze_dois.js.erb
+++ b/app/assets/javascripts/application/freeze_dois.js.erb
@@ -1,0 +1,26 @@
+$(document).on('turbolinks:load', function() {
+  // If a DOI is registered, we need to disable the DOI input field.
+  // DOIs should never by edited once registered.
+  if (window.location.href.match(/edit/)) {
+    var doi_field = $('#monograph_doi');
+    if (doi_field.length === 0) {
+      doi_field = $('#file_set_doi');
+    }
+    //console.log(doi_field);
+    //console.log(doi_field.val());
+    if (doi_field !== undefined && doi_field.val() !== undefined) {
+      encoded_doi = encodeURIComponent(doi_field.val())
+      var url = "<%=  Crossref::Config.load_config['search_url'] %>" + "/" + encoded_doi;
+      console.log(url);
+      $.get(url)
+        .done(function(data) {
+          // Success means we disable the field
+          console.log("The doi", doi_field.val(), "is registered")
+          doi_field.prop('disabled', true);
+        })
+        .fail(function() {
+          console.log("The doi", doi_field.val(), "is not registered");
+        });
+    }
+  }
+});

--- a/config/crossref.yml.sample
+++ b/config/crossref.yml.sample
@@ -1,5 +1,6 @@
 crossref:
   deposit_url: https://test.crossref.org/servlet/deposit
   check_url:  https://test.crossref.org/servlet/submissionDownload
+  search_url: https://api.crossref.org/works
   login_id: id
   login_passwd: passwd

--- a/spec/services/crossref/config_spec.rb
+++ b/spec/services/crossref/config_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Crossref::Config do
       it "has the correct fields" do
         expect(subject['deposit_url']).not_to be nil
         expect(subject['check_url']).not_to be nil
+        expect(subject['search_url']).not_to be nil
         expect(subject['login_id']).not_to be nil
         expect(subject['login_passwd']).not_to be nil
       end


### PR DESCRIPTION
This works in preview for both monographs and file_sets. Examples:

Registered:
https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/hm50tr93z/edit?locale=en
https://heliotrope-preview.hydra.lib.umich.edu/concern/file_sets/d504rk45z/edit?locale=en
(it can take a few seconds for the ajax call to come back)

Unregistered:
https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/41687h652/edit?locale=en
https://heliotrope-preview.hydra.lib.umich.edu/concern/file_sets/0v838086x/edit?locale=en