### PR TITLE
Addresses HELIO-2450 EPUB Search does not work for numbers.

### DIFF
--- a/lib/e_pub/search.rb
+++ b/lib/e_pub/search.rb
@@ -21,7 +21,7 @@ module EPub
       # node.content.index(/#{query}\W/i, offset)
       # Allowing regexes really messes up CFIs and highlighting and isn't really
       # appropriate for this simple search feature
-      node.content.index(/#{Regexp.escape(query)}\W/i, offset)
+      node.content.index(/#{Regexp.escape(query)}($|\W)/i, offset)
     end
 
     private
@@ -31,7 +31,7 @@ module EPub
         offset = 0
 
         while node_query_match(node, query, offset)
-          pos0 = node.content.index(/#{Regexp.escape(query)}\W/i, offset)
+          pos0 = node.content.index(/#{Regexp.escape(query)}($|\W)/i, offset)
           pos1 = pos0 + query.length
 
           result = OpenStruct.new


### PR DESCRIPTION
Add end-of-string anchor in addition to \W non-word at end. Searching for e.g., "1390" in Gabii now returns results.