### PR TITLE
Addresses HELIO-1988 Fix display of filters when zooming only text.

### DIFF
--- a/app/assets/stylesheets/application/blacklight_facets.scss
+++ b/app/assets/stylesheets/application/blacklight_facets.scss
@@ -1,3 +1,5 @@
+// facet-pivot-count is no longer used (replaced by facet-count in HELIO-1988)
+// so this item may not do anything.
 .facet-values {
   .facet-pivot-count {
     display: table-cell;

--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -150,7 +150,7 @@ module FacetHelper
   # @option options [Array<String>]  an array of classes to add to count span.
   # @return [String]
   def render_facet_pivot_count(num, options = {})
-    classes = (options[:classes] || []) << "facet-pivot-count"
+    classes = (options[:classes] || []) << "facet-count"
     content_tag("span", t('blacklight.search.facets.count', number: number_with_delimiter(num)), class: classes)
   end
 

--- a/app/views/monograph_catalog/_facet_pivot.html.erb
+++ b/app/views/monograph_catalog/_facet_pivot.html.erb
@@ -22,13 +22,11 @@
             </div>
           </div>
         <% else %>
-          <span class="facet-values">
-            <% if facet_in_params?(item.field, item) %>
-              <%= render_selected_facet_pivot_value(item.field, item) %>
-            <% else %>
-              <%= render_facet_pivot_value(item.field, item, display_facet) %>
-            <% end -%>
-          </span>
+          <% if facet_in_params?(item.field, item) %>
+            <%= render_selected_facet_pivot_value(item.field, item) %>
+          <% else %>
+            <%= render_facet_pivot_value(item.field, item, display_facet) %>
+          <% end -%>
         <% end %>
       </li>
     <% end %>


### PR DESCRIPTION
Found that (reverting to) use of the facet-count class rather than facet-pivot-count class allows the (e.g.,) format facets to display like the reasonably well-behaved section facets.