### PR TITLE
Addresses HELIO-2809 Generate TOC from representative PDF's outline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,9 @@ gem "loofah", ">= 2.2.3"
 # Use MySQL as the database for Active Record
 gem 'mysql2', '~> 0.4.10'
 
+# Read PDF ToC
+gem 'origami'
+
 # Force epub search results to be sentences
 gem 'pragmatic_segmenter', '~> 0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    colorize (0.8.1)
     combine_pdf (1.0.16)
       ruby-rc4 (>= 0.1.5)
     commonjs (0.2.7)
@@ -598,6 +599,8 @@ GEM
       rack (>= 1.2, < 3)
     openseadragon (0.5.0)
       rails (> 3.2.0)
+    origami (2.1.0)
+      colorize (~> 0.7)
     orm_adapter (0.5.0)
     os (1.0.1)
     parallel (1.12.1)
@@ -1004,6 +1007,7 @@ DEPENDENCIES
   mysql2 (~> 0.4.10)
   oauth
   oauth2 (~> 1.2)
+  origami
   pragmatic_segmenter (~> 0.3)
   prawn (~> 2.2)
   pry-rails (~> 0.3.4)

--- a/app/presenters/concerns/featured_representatives/monograph_presenter.rb
+++ b/app/presenters/concerns/featured_representatives/monograph_presenter.rb
@@ -97,8 +97,17 @@ module FeaturedRepresentatives
       featured_representatives.map(&:kind).include? 'pdf_ebook'
     end
 
+    def pdf_ebook
+      ordered_member_docs.find { |doc| doc.id == pdf_ebook_id }
+    end
+
     def pdf_ebook_id
       featured_representatives.map { |fr| fr.file_set_id if fr.kind == 'pdf_ebook' }.compact.first
+    end
+
+    def pdf_ebook_presenter
+      entity = Sighrax.factory(pdf_ebook_id)
+      @pdf_ebook_presenter ||= PDFEbookPresenter.new(PDFEbook::Publication.from_string_id(entity.content, pdf_ebook_id))
     end
 
     def mobi?

--- a/app/presenters/pdf_ebook_presenter.rb
+++ b/app/presenters/pdf_ebook_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PDFEbookPresenter < ApplicationPresenter
+  def initialize(pdf_ebook)
+    @pdf_ebook = pdf_ebook
+  end
+
+  def id
+    @pdf_ebook.id
+  end
+
+  def multi_rendition?
+    false
+  end
+
+  def intervals?
+    @pdf_ebook.intervals.count.positive?
+  end
+
+  def intervals
+    @pdf_ebook.intervals.map { |interval| EPubIntervalPresenter.new(interval) }
+  end
+end

--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -1,6 +1,6 @@
 <%
   level = 0
-  epub_presenter = @monograph_presenter.epub_presenter
+  epub_presenter = @monograph_presenter.epub? ? @monograph_presenter.epub_presenter : @monograph_presenter.pdf_ebook_presenter
   epub_policy = @monograph_policy.epub_policy
 %>
   <% epub_presenter.intervals.each do |interval| %>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -125,7 +125,7 @@
       <li role="presentation"><a id="tab-stats" href="#stats" role="tab" data-toggle="tab" aria-controls="stats" aria-selected="false" tabindex="-1">Stats</a></li>
     </ul>
     <div id="tabs-content" class="tab-content monograph-assets-toc-epub-content" aria-live="polite">
-      <% if @monograph_presenter.epub? %>
+      <% if @monograph_presenter.epub? || @monograph_presenter.pdf_ebook? %>
         <section id="toc" class="tab-pane active fade in toc row" role="tabpanel" aria-hidden="false" aria-labelledby="tab-toc" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Table of Contents</h2>

--- a/lib/pdf_ebook.rb
+++ b/lib/pdf_ebook.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PDFEbook
+  #
+  # Logger
+  #
+  require 'logger'
+  # mattr_accessor :logger
+  @logger = Logger.new(STDOUT)
+
+  def self.logger
+    @logger
+  end
+
+  def self.logger=(logger)
+    @logger = logger
+  end
+
+  #
+  # Configure
+  #
+  @configured = false
+
+  # spec helper
+  def self.reset_configured_flag
+    @configured = false
+  end
+
+  def self.configured?
+    @configured
+  end
+
+  def self.configure
+    @configured = true
+    yield self
+  end
+end
+
+#
+# Require Dependencies
+#
+require 'origami'
+
+#
+# Require Relative
+#
+require_relative './pdf_ebook/interval'
+require_relative './pdf_ebook/publication'

--- a/lib/pdf_ebook/interval.rb
+++ b/lib/pdf_ebook/interval.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module PDFEbook
+  class Interval
+    private_class_method :new
+
+    # Class Methods
+    def self.from_title_level_cfi(title, level, cfi)
+      return null_object unless title&.instance_of?(String) && cfi&.instance_of?(String)
+      new(title: title, depth: level, cfi: cfi)
+    end
+
+    def self.null_object
+      IntervalNullObject.send(:new)
+    end
+
+    # Instance Methods
+
+    def title
+      @args[:title] || ''
+    end
+
+    def level
+      @args[:depth] || 0
+    end
+
+    def cfi
+      @args[:cfi] || ''
+    end
+
+    def downloadable?
+      false
+    end
+
+    def pages
+      []
+    end
+
+    def downloadable_pages
+      []
+    end
+
+    private
+
+      def initialize(args)
+        @args = args
+      end
+  end
+
+  class IntervalNullObject < Interval
+    private_class_method :new
+
+    private
+
+      def initialize
+        super({})
+      end
+  end
+end

--- a/lib/pdf_ebook/publication.rb
+++ b/lib/pdf_ebook/publication.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module PDFEbook
+  class Publication
+    private_class_method :new
+    attr_reader :id
+
+    # Class Method
+    def self.from_string_id(string, id)
+      new(string, id)
+    rescue StandardError => e
+      ::PDFEbook.logger.info("Publication.from_string_id(#{string[0..30]}) raised #{e} #{e.backtrace}")
+      nil
+    end
+
+    # Public method
+    def intervals
+      @intervals ||= extract_intervals
+    end
+
+    private
+
+      def initialize(string, id)
+        file = StringIO.new(string)
+        @pdf = Origami::PDF.read file
+        @id = id
+        @obj_to_page = {}
+      end
+
+      def extract_intervals
+        # Map of PDF page object number to 0-based linear page number
+        if @obj_to_page.empty?
+          @pdf.pages.each_with_index do |p, i|
+            @obj_to_page[p.no] = i
+          end
+        end
+        iterate_outlines(@pdf.Catalog.Outlines[:First]&.solve, 1)
+      end
+
+      # Takes Origami::OutlineItem and 1-based depth
+      def iterate_outlines(outline, depth)
+        intervals = []
+        until outline.nil?
+          page = nil
+          page = outline&.[](:A)&.solve&.[](:D)&.[](0)&.solve # Origami::Page
+          page ||= outline[:Dest]&.solve&.[](0)&.solve
+          unless page.nil?
+            page_number = @obj_to_page[page.no] || 0
+            intervals << PDFEbook::Interval.from_title_level_cfi(outline[:Title].to_utf8, depth, "page=#{page_number}")
+          end
+          unless outline[:First]&.solve.nil? # Child outline
+            intervals += iterate_outlines(outline[:First].solve, depth + 1)
+          end
+          outline = outline[:Next]&.solve
+        end
+        intervals
+      end
+  end
+end

--- a/spec/presenters/pdf_ebook_presenter_spec.rb
+++ b/spec/presenters/pdf_ebook_presenter_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PDFEbookPresenter do
+  subject(:presenter) { described_class.new(pdf_ebook) }
+
+  let(:pdf_ebook) { instance_double(PDFEbook::Publication, 'pdf_ebook', id: 'id', intervals: intervals) }
+  let(:intervals) { [] }
+
+  describe '#id' do
+    subject { presenter.id }
+
+    it { is_expected.to eq(pdf_ebook.id) }
+  end
+
+  describe '#intervals?' do
+    subject { presenter.intervals? }
+
+    it { is_expected.to be false }
+
+    context 'intervals' do
+      let(:intervals) { [interval] }
+      let(:interval) { double('interval') }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#intervals' do
+    subject { presenter.intervals.first }
+
+    it { is_expected.to be_nil }
+
+    context 'intervals' do
+      let(:intervals) { [interval] }
+      let(:interval) { double('interval') }
+
+      it { is_expected.to be_an_instance_of(EPubIntervalPresenter) }
+    end
+  end
+end


### PR DESCRIPTION
There is one major flaw with this implementation (that I know of, anyway LOL): the use of epub_path() in _index_epub_toc.html.erb for ToC links into the PDF reader. They will need to be fixed when we know what our PDF reader URLs are going to look like.