### PR TITLE
HELIO-2813 - Implement fulcrum enhanced resources display for EBC

### DIFF
--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -125,6 +125,9 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
           useArchive: <%= @use_archive %>,
           download_links: <%= @ebook_download_presenter.csb_download_links.to_json.html_safe %>,
           loader_template: '<div class="fulcrum-loading"><div class="rect rect1"></div><div class="circle circ1"></div><div class="rect rect2"></div><div class="circle circ2"></div></div>',
+          <% if %w[michigan].include? @subdomain %>
+          injectStylesheet: '/css/fulcrum_enhanced_display.css',
+          <% end %>
           metadata: {
             doi: '<%= @citable_link %>',
             location: 'Ann Arbor, MI'

--- a/fulcrum/css/fulcrum_enhanced_display.css
+++ b/fulcrum/css/fulcrum_enhanced_display.css
@@ -1,0 +1,15 @@
+/* SPECIAL STYLESHEET USED TO DISPLAY EMBEDDED 
+   MEDIA in U-M PRESS EPUB FILES on FULCRUM */
+
+/* Hide default media blocks, such as image thumbnails */
+.default-media-display {
+    display: none !important;
+}
+/* Display enhanced media blocks, such as Fulcrum embedded audio/video/images */
+.enhanced-media-display {
+    display: block !important;
+}
+/* Display enhanced media inline, such as links to Fulcrum resource pages */
+span.enhanced-media-display {
+    display: inline !important;
+}


### PR DESCRIPTION
Adds an external stylesheet to the fulcrum public folder that can be referenced by CSB; modifies CSB to inject stylesheet if the EPUB is from Michigan/EBC