### PR TITLE
HELIO-2851 

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -800,7 +800,7 @@ footer.press {
 
 }
 ///////////////////////////////////
-// ASSET PAGES
+// ASSET/RESOURCE PAGES
 ///////////////////////////////////
 .asset-navigation {
   a.previous span {
@@ -862,6 +862,17 @@ footer.press {
     overflow:hidden;
   }
 
+  // MAPS
+
+  .map {
+    h1 {
+      margin-bottom: 1em;
+    }
+
+    iframe {
+      border: 0;
+    }
+  }
 
   // AUDIO and VIDEO - Able Player
   .able-wrapper {

--- a/app/views/hyrax/file_sets/_side_by_side_layout.html.erb
+++ b/app/views/hyrax/file_sets/_side_by_side_layout.html.erb
@@ -1,0 +1,25 @@
+    <!-- file_sets metadata and actions -->
+    <div class="col-sm-6 col-sm-push-6">
+      <div class="row asset-attributes">
+        <div class="col-sm-12">
+          <h1 id="asset-title"><%= @presenter.title %></h1>
+          <div class="skip"><a href="#media" data-turbolinks="false">Skip to media</a></div>
+          <span class="section">From <em><%= link_to @presenter.parent.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
+            <% if @presenter.parent.authors? %>
+              by <%= render_markdown @presenter.parent.authors %>
+            <% end %>
+          </span>
+          <br />
+          <%= render "attributes", presenter: @presenter %>
+        </div>
+      </div> <!-- /.asset-attributes -->
+      <div class="row asset-actions">
+        <div class="col-sm-12">
+          <%= render "show_actions", presenter: @presenter, parent: @presenter.parent %>
+        </div>
+      </div> <!-- /.asset-actions -->
+    </div> <!-- / file_sets metadata and actions -->
+    <!-- file_sets _media -->
+    <div id="media" class="col-sm-6 col-sm-pull-6">
+      <%= render "media", presenter: @presenter %>
+    </div> <!-- / file_sets _media -->

--- a/app/views/hyrax/file_sets/_stacked_layout.html.erb
+++ b/app/views/hyrax/file_sets/_stacked_layout.html.erb
@@ -1,0 +1,29 @@
+    <!-- file_sets title and _media -->
+    <div class="col-sm-12 map">
+        <div class="row asset-attributes">
+            <div class="col-sm-12">
+                <h1 id="asset-title"><%= @presenter.title %></h1>
+            </div>
+        </div> <!-- /.asset-attributes -->
+        <!-- file_sets _media -->
+        <div id="media" class="row">
+            <%= render "media", presenter: @presenter %>
+        </div>
+    </div> <!-- / file_sets title and _media -->
+    <!-- file_sets metadata and actions -->
+    <div class="col-sm-12 map">
+        <div class="row asset-attributes">
+            <span class="section">From <em><%= link_to @presenter.parent.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
+            <% if @presenter.parent.authors? %>
+              by <%= render_markdown @presenter.parent.authors %>
+            <% end %>
+          </span>
+          <br />
+          <%= render "attributes", presenter: @presenter %>
+        </div> <!-- /.asset-attributes -->
+        <div class="row asset-actions">
+            <div class="col-sm-12">
+                <%= render "show_actions", presenter: @presenter, parent: @presenter.parent %>
+            </div>
+        </div> <!-- /.asset-actions -->
+    </div> <!-- / file_sets metadata and actions -->

--- a/app/views/hyrax/file_sets/media_display/_map.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_map.html.erb
@@ -2,6 +2,6 @@
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
-<iframe height=600px width=100% src=<%= "#{main_app.map_file_url(file_set.id, file: 'index', format: 'html')}" %> allowfullscreen>
+<iframe title="<%= @presenter.title %>" height="600px" width="100%" src="<%= "#{main_app.map_file_url(file_set.id, file: 'index', format: 'html')}" %>" allow="fullscreen">
   Your browser doesn't support iframes!
 </iframe>

--- a/app/views/hyrax/file_sets/media_display_embedded/_map.html.erb
+++ b/app/views/hyrax/file_sets/media_display_embedded/_map.html.erb
@@ -1,3 +1,3 @@
-<iframe height=600px width=100% src="<%= main_app.map_file_url(file_set.id, file: 'index', format: 'html') %>">
+<iframe title="<%= @presenter.title %>" height="600px" width="100%" src="<%= main_app.map_file_url(file_set.id, file: 'index', format: 'html') %>">
   Your browser doesn't support iframes!
 </iframe>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -31,30 +31,14 @@
     <% if defined? @presenter.file_set_coins_title %>
       <span class="Z3988" title="<%= @presenter.file_set_coins_title %>"></span>
     <% end %>
-    <!-- file_sets metadata and actions -->
-    <div class="col-sm-6 col-sm-push-6">
-      <div class="row asset-attributes">
-        <div class="col-sm-12">
-          <h1 id="asset-title"><%= @presenter.title %></h1>
-          <div class="skip"><a href="#media" data-turbolinks="false">Skip to media</a></div>
-          <span class="section">From <em><%= link_to @presenter.parent.title, main_app.monograph_catalog_path(@presenter.monograph_id) %></em>
-            <% if @presenter.parent.authors? %>
-              by <%= render_markdown @presenter.parent.authors %>
-            <% end %>
-          </span>
-          <br />
-          <%= render "attributes", presenter: @presenter %>
-        </div>
-      </div> <!-- /.asset-attributes -->
-      <div class="row asset-actions">
-        <div class="col-sm-12">
-          <%= render "show_actions", presenter: @presenter, parent: @presenter.parent %>
-        </div>
-      </div> <!-- /.asset-actions -->
-    </div> <!-- / file_sets metadata and actions -->
-    <!-- file_sets _media -->
-    <div id="media" class="col-sm-6 col-sm-pull-6">
-      <%= render "media", presenter: @presenter %>
-    </div> <!-- / file_sets _media -->
+    
+    <% if @presenter.map? %>
+      <!-- map file_set --> 
+      <%= render "stacked_layout", presenter: @presenter %> 
+    <% else %>
+      <!-- image, a/v, doc, or external resource file_set -->
+      <%= render "side_by_side_layout", presenter: @presenter %>
+    <% end %>
+
   </div> <!-- /.asset -->
 <% end %>


### PR DESCRIPTION
Modify show page partials for file sets to create two layout options: stacked and side-by-side (the current).

The stacked layout places the media content on top of the metadata, supporting the display of maps which tend to require more width than audio/video players and images. This new stacked layout is currently only being applied to map resource types. All other resource types receive the "traditional" side-by-side layout, which have media on the left and metadata on the right.

Screen shot of stacked layout:
![Screen Shot 2019-08-26 at 4 44 56 PM](https://user-images.githubusercontent.com/1686111/63722445-3595da80-c821-11e9-99c4-d92d52a7521a.png)
