### PR TITLE
PDFReader.gotoPage should be setting currentPageNumber

### DIFF
--- a/app/views/e_pubs/show_pdf.html.erb
+++ b/app/views/e_pubs/show_pdf.html.erb
@@ -705,7 +705,7 @@
           cfi = { start: cfi.replace('epubcfi(', '').replace(')','') };
         }
         var pageNum = cfi.start;
-        this.pdfViewer.currentPageLabel = pageNum;
+        this.pdfViewer.currentPageNumber = pageNum;
       },
 
       reopen: function(options) {


### PR DESCRIPTION
Stops the reader from going to the wrong page when there's front matter.