### PR TITLE
adjust hero font weight for BAR

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -900,7 +900,7 @@ $barpublishing-white: #fafafa;
 
   // jumbotron
   .jumbotron {
-    font-weight: 300;
+    font-weight: 400;
     padding-top: 1.5em;
     padding-bottom: 1em;
 


### PR DESCRIPTION
Based on feedback during Steering demo, make the font weight of BAR's hero area heavier so it is easier to read.