### PR TITLE
Resolves HELIO-2453: Add FileSet actions to Monograph catalog page

### DIFF
--- a/app/controllers/featured_representatives_controller.rb
+++ b/app/controllers/featured_representatives_controller.rb
@@ -21,7 +21,7 @@ class FeaturedRepresentativesController < ApplicationController
     if Sighrax.factory(params[:work_id]).is_a?(Sighrax::Score)
       redirect_to score_show_path(params[:work_id])
     else
-      redirect_to monograph_show_path(params[:work_id])
+      redirect_to monograph_catalog_path(params[:work_id])
     end
   end
 
@@ -31,7 +31,7 @@ class FeaturedRepresentativesController < ApplicationController
     if Sighrax.factory(params[:work_id]).is_a?(Sighrax::Score)
       redirect_to score_show_path(params[:work_id])
     else
-      redirect_to monograph_show_path(params[:work_id])
+      redirect_to monograph_catalog_path(params[:work_id])
     end
   end
 end

--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -67,6 +67,16 @@ class MonographCatalogController < ::CatalogController
     super
   end
 
+  def representative
+    if params[:representative_id].present? && current_ability.can?(:edit, params[:id])
+      monograph = Monograph.find(params[:id])
+      monograph.thumbnail_id = params[:representative_id]
+      monograph.representative_id = params[:representative_id]
+      monograph.save!
+    end
+    redirect_to monograph_catalog_path(params[:id])
+  end
+
   private
 
     def load_presenter

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -47,6 +47,16 @@ module Hyrax
              :label, :redirect_to, :has_model, :date_modified, :visibility,
              to: :solr_document
 
+    def asset?
+      return false if representative?
+      return false if featured_representative?
+      true
+    end
+
+    def representative?
+      (id == parent.thumbnail_id) || (id == parent.representative_id)
+    end
+
     def monograph_id
       Array(solr_document['monograph_id_ssim']).first
     end

--- a/app/presenters/hyrax/presenter.rb
+++ b/app/presenters/hyrax/presenter.rb
@@ -12,8 +12,9 @@ module Hyrax
 
     private
 
-      def initialize(noid)
+      def initialize(noid, current_ability = nil)
         @noid = noid
+        @ability = current_ability
       end
   end
 

--- a/app/services/sighrax.rb
+++ b/app/services/sighrax.rb
@@ -45,15 +45,15 @@ module Sighrax # rubocop:disable Metrics/ModuleLength
       end
     end
 
-    def hyrax_presenter(entity)
+    def hyrax_presenter(entity, current_ability = nil)
       if entity.is_a?(Sighrax::Monograph)
-        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::MonographPresenter, presenter_args: nil)&.first
+        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability)&.first
       elsif entity.is_a?(Sighrax::Score)
-        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::ScorePresenter, presenter_args: nil)&.first
+        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::ScorePresenter, presenter_args: current_ability)&.first
       elsif entity.is_a?(Sighrax::Asset)
-        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil)&.first
+        Hyrax::PresenterFactory.build_for(ids: [entity.noid], presenter_class: Hyrax::FileSetPresenter, presenter_args: current_ability)&.first
       else
-        Hyrax::Presenter.send(:new, entity.noid)
+        Hyrax::Presenter.send(:new, entity.noid, current_ability)
       end
     end
 

--- a/app/views/hyrax/monographs/show.html.erb
+++ b/app/views/hyrax/monographs/show.html.erb
@@ -28,7 +28,6 @@
 <div class="row">
   <div class="col-sm-12">
     <%= render 'csb_hyrax_citations', presenter: @presenter %>
-    <%= render 'items', presenter: @presenter %>
     <% if @presenter.workflow.state != "deposited" %>
       <%= render 'workflow_actions_widget', presenter: @presenter %>
     <% end %>

--- a/app/views/monograph_catalog/_index_featured_representatives.html.erb
+++ b/app/views/monograph_catalog/_index_featured_representatives.html.erb
@@ -1,0 +1,23 @@
+<% if can? :edit, presenter.id %>
+  <% if presenter.representative_presenter.present? %>
+    <div>
+      <h4>Representative</h4>
+      <hr/>
+      <h4 class="index_title"><%= link_to presenter.representative_presenter %></h4>
+      <%= render partial: 'index_file_set_footer', locals: { document: presenter.representative_presenter } %>
+      <div>&nbsp;</div>
+    </div>
+  <% end %>
+  <% if presenter.featured_representatives.present? %>
+    <div>
+      <h4>Featured Representative(s)</h4>
+      <% presenter.featured_representatives.each do |fr| %>
+        <hr/>
+        <% file_set_presenter = Sighrax.hyrax_presenter(Sighrax.factory(fr.file_set_id), current_ability) %>
+        <h4 class="index_title"><%= link_to file_set_presenter %></h4>
+        <%= render partial: 'index_file_set_footer', locals: { document: file_set_presenter } %>
+      <% end %>
+      <div>&nbsp;</div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/monograph_catalog/_index_file_set_footer.html.erb
+++ b/app/views/monograph_catalog/_index_file_set_footer.html.erb
@@ -1,0 +1,17 @@
+<%
+  if can? :edit, document.id
+    presenter = Sighrax.hyrax_presenter(Sighrax.factory(document.id), current_ability)
+%>
+  <div>
+    <%= presenter.id %>
+    <%= presenter.permission_badge %>
+    <%= render "hyrax/file_sets/actions", file_set: presenter %>
+    <%= render "featured_representatives/form", member: presenter %>
+    <% if presenter.asset? %>
+      <%= form_tag(monograph_catalog_representative_path, method: "post") do %>
+        <%= hidden_field_tag(:representative_id, presenter.id) %>
+        <%= submit_tag("Set as Representative", class: 'btn btn-default') %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/monograph_catalog/_index_gallery_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_gallery_file_set.html.erb
@@ -1,1 +1,2 @@
+<%= render partial: 'index_file_set_footer', locals: { document: document } %>
 </div>

--- a/app/views/monograph_catalog/_index_list_file_set.html.erb
+++ b/app/views/monograph_catalog/_index_list_file_set.html.erb
@@ -9,4 +9,5 @@
     <% end -%>
 
   </div>
+  <%= render partial: 'index_file_set_footer', locals: { document: document } %>
 </div>

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -114,6 +114,7 @@
 
   </div><!-- /.monograph-metadata -->
 </div><!-- /.monograph-info-epub -->
+<%= render partial: 'index_featured_representatives', locals: { presenter: @presenter } %>
 
 <div class="row monograph-assets-toc-epub">
   <div class="col-sm-12" id="tabs">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Rails.application.routes.draw do
   get 'concern/monographs/:id/show', controller: 'hyrax/monographs', action: :show, as: :monograph_show
   patch 'concern/monographs/:id/reindex', controller: 'hyrax/monographs', action: :reindex, as: :monograph_reindex
   get 'monograph_catalog/facet/:id', controller: :monograph_catalog, action: :facet, as: :monograph_catalog_facet
+  post 'concern/monographs/:id/representative', controller: :monograph_catalog, action: :representative, as: :monograph_catalog_representative
 
   get 'concern/scores/new', controller: 'hyrax/scores', action: :new
   get 'concern/scores/:id', controller: :score_catalog, action: :index, as: :score_catalog

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -18,6 +18,54 @@ RSpec.describe Hyrax::FileSetPresenter do
     it { is_expected.to be_a FeaturedRepresentatives::FileSetPresenter }
   end
 
+  describe '#asset?' do
+    subject { presenter.asset? }
+
+    let(:fileset_doc) { SolrDocument.new(id: 'file_set_id', has_model_ssim: ['FileSet']) }
+
+    before do
+      allow(presenter).to receive(:representative?).and_return(false)
+      allow(presenter).to receive(:featured_representative?).and_return(false)
+    end
+
+    it { is_expected.to be true }
+
+    context 'representative' do
+      before { allow(presenter).to receive(:representative?).and_return(true) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'featured_representative' do
+      before { allow(presenter).to receive(:featured_representative?).and_return(true) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#representative?' do
+    subject { presenter.representative? }
+
+    let(:fileset_doc) { SolrDocument.new(id: 'file_set_id', has_model_ssim: ['FileSet']) }
+    let(:parent) { instance_double(Hyrax::MonographPresenter, 'parent', thumbnail_id: 'thumbnail_id', representative_id: 'representative_id') }
+
+    before { allow(presenter).to receive(:parent).and_return(parent) }
+
+    it { is_expected.to be false }
+
+    context 'thumbnail' do
+      let(:parent) { instance_double(Hyrax::MonographPresenter, 'parent', thumbnail_id: 'file_set_id', representative_id: 'representative_id') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'representative' do
+      let(:parent) { instance_double(Hyrax::MonographPresenter, 'parent', thumbnail_id: 'thumbnail_id', representative_id: 'file_set_id') }
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe '#tombstone?' do
     subject { presenter.tombstone? }
 

--- a/spec/requests/monograph_catalog_spec.rb
+++ b/spec/requests/monograph_catalog_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Monograph Catalog", type: :request do
+  describe '#representative' do
+    let(:monograph) { create(:monograph) }
+    let(:file_set) { create(:file_set) }
+
+    before { allow(monograph).to receive(:save!).and_call_original }
+
+    context 'anonymous' do
+      describe "POST /concern/monographs/:id/representitive" do
+        it do
+          post monograph_catalog_representative_path(monograph), params: { representative_id: file_set.id }
+          expect(response).to redirect_to(monograph_catalog_url(monograph))
+          expect(monograph).not_to have_received(:save!)
+          monograph.reload
+          expect(monograph.thumbnail).not_to eq(file_set)
+          expect(monograph.representative).not_to eq(file_set)
+        end
+      end
+    end
+
+    context 'user' do
+      before { sign_in(current_user) }
+
+      context 'unauthorized' do
+        let(:current_user) { create(:user) }
+
+        describe "POST /concern/monographs/:id/representitive" do
+          it do
+            post monograph_catalog_representative_path(monograph), params: { representative_id: file_set.id }
+            expect(response).to redirect_to(monograph_catalog_url(monograph))
+            expect(monograph).not_to have_received(:save!)
+            monograph.reload
+            expect(monograph.thumbnail).not_to eq(file_set)
+            expect(monograph.representative).not_to eq(file_set)
+          end
+        end
+      end
+
+      context 'authorized' do
+        let(:current_user) { create(:platform_admin) }
+
+        describe "POST /concern/monographs/:id/representitive" do
+          it do
+            post monograph_catalog_representative_path(monograph), params: { representative_id: file_set.id }
+            expect(response).to redirect_to(monograph_catalog_url(monograph))
+            expect(monograph).not_to have_received(:save!)
+            monograph.reload
+            expect(monograph.thumbnail).to eq(file_set)
+            expect(monograph.representative).to eq(file_set)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/views/monograph_catalog/index.html.erb_spec.rb
+++ b/spec/views/monograph_catalog/index.html.erb_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe "monograph_catalog/index.html.erb", type: :view do
   before do
     stub_template "catalog/_search_sidebar" => "<!-- render-template-catalog/_search_sidebar -->"
     stub_template "catalog/_search_results" => "<!-- render-template-catalog/_search_results -->"
+    stub_template "monograph_catalog/_index_file_set_footer" => "<!-- render-template-monograph_catalog/_index_file_set_footer -->"
+    stub_template "monograph_catalog/_index_featured_representatives" => "<!-- render-template-monograph_catalog/_index_featured_representatives -->"
     assign(:presenter, presenter)
     assign(:ebook_download_presenter, ebook_download_presenter)
     allow(view).to receive(:t).with(any_args) { |value| value }


### PR DESCRIPTION
Probably the best thing to do after all that is to make sub-tasks to move other elements from the show page if they are useful (like the "Publish Monograph" button). I don't think we need to rush to do this. We can discuss.