### PR TITLE
HELIO-2949 Save GA data to the database, not cache

### DIFF
--- a/app/models/google_analytics_history.rb
+++ b/app/models/google_analytics_history.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class GoogleAnalyticsHistory < ApplicationRecord
+  validates :noid, uniqueness: { scope: %i[original_date page_path pageviews],
+                                 message: "date, page_path and pageviews must all be unique" }
+end

--- a/db/migrate/20190916160819_create_google_analytics_history.rb
+++ b/db/migrate/20190916160819_create_google_analytics_history.rb
@@ -1,0 +1,12 @@
+class CreateGoogleAnalyticsHistory < ActiveRecord::Migration[5.1]
+  def change
+    create_table :google_analytics_histories do |t|
+      t.string :noid, index: true
+      t.string :original_date
+      t.text :page_path
+      t.integer :pageviews
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190909175832) do
+ActiveRecord::Schema.define(version: 20190916160819) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -223,6 +223,16 @@ ActiveRecord::Schema.define(version: 20190909175832) do
     t.integer "user_id"
     t.index ["file_id"], name: "index_file_view_stats_on_file_id"
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
+  end
+
+  create_table "google_analytics_histories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "noid"
+    t.string "original_date"
+    t.text "page_path"
+    t.integer "pageviews"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["noid"], name: "index_google_analytics_histories_on_noid"
   end
 
   create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/add_ga_history.rake
+++ b/lib/tasks/add_ga_history.rake
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+desc "save google analytics data"
+namespace :heliotrope do
+  task :add_ga_history, [:start_date, :end_date] => :environment do |_t, args|
+    # Usage: bundle exec rails "heliotrope:add_ga_history[2018-01-01, 2018-03-31]"
+
+    # Or: don't supply dates and just get yesterday's data
+    start_date = args.start_date || Date.yesterday
+    end_date = args.end_date || Date.yesterday
+
+    # You can run this over and over on old data without adding duplicates to the table
+    # because of a uniqueness validation in the model
+
+    ga_id = Rails.application.secrets.google_analytics_id
+    if ga_id.present?
+      begin
+        profile = AnalyticsService.profile(ga_id)
+        if profile.present?
+          total_results = Pageview.results(profile, start_date: start_date, end_date: end_date).total_results
+          offset = 1
+          while total_results.positive?
+            begin
+              # p "total_results: #{total_results}, offset: #{offset}"
+              # If you don't give a date range, you get one month by default
+              # If you don't give a limit, you get 1000 rows by default
+              # Also: GA will only return up to 10_000 rows for any request
+              Pageview.results(profile, start_date: start_date, end_date: end_date, limit: 10_000, offset: offset).each do |entry|
+                page_path = entry.pagePath.gsub(/\?.*$/, "")
+                noid = find_match(page_path)
+                next if noid.nil?
+
+                ga = GoogleAnalyticsHistory.new
+                ga.noid = noid
+                ga.original_date = entry.date
+                ga.page_path = entry.pagePath
+                ga.pageviews = entry.pageviews.to_i
+                ga.save! if ga.valid? # only save if it's new data
+              end
+              offset += 10_000
+              total_results -= 10_000
+            rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+              # we're just going to try again by not incrementing/decrementing the offset/total_results
+            end
+          end
+        end
+      rescue OAuth2::Error => e
+        p "OAUTH ERROR: #{e.code["message"]}"
+      end
+    end
+  end
+end
+
+def regex_mapping
+  [
+    Regexp.new("^/concern/file_sets/([a-z0-9]{9})$"),
+    Regexp.new("^/concern/monographs/([a-z0-9]{9})$"),
+    Regexp.new("^/epub/([a-z0-9]{9})$"),
+    Regexp.new("^/epubs_download_.*?/([a-z0-9]{9})$"),
+    Regexp.new("^/concern/scores/([a-z0-9]{9})$")
+  ]
+end
+
+def find_match(url)
+  regex_mapping.each do |regex|
+    if regex.match?(url)
+      return regex.match(url)[1]
+    end
+  end
+  return nil
+end

--- a/lib/tasks/ga_cache.rake
+++ b/lib/tasks/ga_cache.rake
@@ -11,32 +11,7 @@ namespace :heliotrope do
         # To change this we'd need to add the "account_id" (not GA id) in a config file somewhere
         profile = AnalyticsService.profile(ga_id)
         if profile.present?
-          # If you don't give a date range, you get one month by default
-          # If you don't give a limit, you get 1000 rows by default
-          # Also: GA will only return up to 10_000 rows for any request
-          pageviews = {}
-          total_results = Pageview.results(profile, start_date: '2016-01-01', end_date: Date.yesterday).total_results
-          offset = 1
-
-          while total_results.positive?
-            Pageview.results(profile, start_date: '2016-01-01', end_date: Date.yesterday, limit: 10_000, offset: offset).each do |entry|
-              page_path = entry.pagePath.gsub(/\?.*$/, "")
-              noid = find_match(page_path)
-              next if noid.nil?
-
-              pageviews[noid] = {} unless pageviews[noid].is_a? Hash
-              if pageviews[noid][entry.date].present?
-                pageviews[noid][entry.date] = pageviews[noid][entry.date] + entry.pageviews.to_i
-              else
-                pageviews[noid][entry.date] = entry.pageviews.to_i
-              end
-            end
-            offset += 10_000
-            total_results -= 10_000
-          end
-
-          Rails.cache.write('ga_pageviews', pageviews)
-          Rails.logger.info("Wrote ga_pageviews to cache")
+          # Pageviews used to be here but are now in their own task, add_ga_history.rake
 
           GASessions.results(profile, start_date: '2016-01-01', end_date: Date.today, limit: 1).each do |entry|
             Rails.cache.write('ga_sessions', entry.sessions)
@@ -78,22 +53,4 @@ namespace :heliotrope do
       end
     end
   end
-end
-
-def regex_mapping
-  [
-    Regexp.new("^/concern/file_sets/([a-z0-9]{9})$"),
-    Regexp.new("^/concern/monographs/([a-z0-9]{9})$"),
-    Regexp.new("^/epub/([a-z0-9]{9})$"),
-    Regexp.new("^/epubs_download_.*?/([a-z0-9]{9})$")
-  ]
-end
-
-def find_match(url)
-  regex_mapping.each do |regex|
-    if regex.match?(url)
-      return regex.match(url)[1]
-    end
-  end
-  return nil
 end

--- a/spec/factories/google_analytics_histories.rb
+++ b/spec/factories/google_analytics_histories.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :google_analytics_history do
+    noid { "MyString" }
+    original_date { "MyString" }
+    page_path { "/concern/thing" }
+    pageviews { 4 }
+  end
+end

--- a/spec/models/google_analytics_history_spec.rb
+++ b/spec/models/google_analytics_history_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoogleAnalyticsHistory, type: :model do
+  describe "uniqueness" do
+    before do
+      create(:google_analytics_history, noid: '1',
+                                        original_date: '20180101',
+                                        page_path: '/concern/thing/1',
+                                        pageviews: 1)
+    end
+
+    it "all fields together must be unique" do
+      expect(described_class.create(noid: '1',
+                                    original_date: '20180101',
+                                    page_path: '/concern/thing/1',
+                                    pageviews: 1)).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
this is on preview now. I've run the add_ga_history.rake task and it's matching up with what we have in the cache.
```
irb(main):011:0> Rails.cache.read('ga_pageviews')['3n203z11f'].map{|date, pageviews| pageviews }.sum
=> 180
irb(main):012:0> GoogleAnalyticsHistory.where(noid: '3n203z11f').map(&:pageviews).sum
  GoogleAnalyticsHistory Load (0.7ms)  SELECT `google_analytics_histories`.* FROM `google_analytics_histories` WHERE `google_analytics_histories`.`noid` = '3n203z11f'
=> 180
irb(main):013:0> 
```
I've added a nightly cron to add yesterdays stats. Everything seems to be right....
