### PR TITLE
Resolve HELIO-2896: Keyboard navigation to 3D Model or Stats Tab does…

### DIFF
--- a/app/assets/javascripts/application/tabs.js
+++ b/app/assets/javascripts/application/tabs.js
@@ -1,63 +1,6 @@
 $(document).on('turbolinks:load', function() {
-  // Store the monograph ID and tab ID last used on the monograph catalog page
-  // Amend the tab ID to URL if it exists.
-  storeTab();
   // Improve accessibility and keyboard functionality of tabs
   // For monograph and asset pages
-  accessibleTabs();
-
-function storeTab() {
-  // If monograph page, store the last used tab
-  if ($('#main.monograph').length > 0) {
-    // https://stackoverflow.com/a/10524697
-    var page_url = window.location.pathname.split( '/' );
-    // getting the monograph id from the URL path is not as reliable as using the
-    // monograph presenter
-    var monograph_id = page_url[3];
-    var previous_monograph_id = sessionStorage.getItem('monograph_id');
-    sessionStorage.setItem('monograph_id', monograph_id);
-
-    if (monograph_id !== previous_monograph_id) {
-      sessionStorage.removeItem('lastTab');
-    }
-
-    // for bootstrap 3 use 'shown.bs.tab', for bootstrap 2 use 'shown' in the next line
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-      // save the latest tab; use cookies if you like 'em better:
-      sessionStorage.setItem('lastTab', $(e.target).attr('href'));
-    });
-
-    // go to the latest tab, apply aria semantics, if it exists in sessionStorage
-    // if not the first tab, unset aria semantics for first tab
-    var lastTab = sessionStorage.getItem('lastTab');
-    // If there is a value in the search field, heavy-handedly override
-    // stored value so the resources tab is visible on load.
-    if ($('#resources_search').val() !== undefined) {
-      lastTab = '#resources';
-    }
-
-    // If the monograph page URL has an anchor (like the CSB Media button)
-    // then we override with similar heavy-handedness.
-    // https://stackoverflow.com/a/4108277
-    var stripped = document.location.href.split("#");
-    if (stripped.length > 1) {
-      lastTab = '#' + stripped[1];
-    }
-
-    var firstTab = $('ul[role="tablist"]').children().first().children('a[role="tab"]').attr('href');
-    if (lastTab) {
-      $('a[href="' + lastTab + '"]').tab('show');
-      $(lastTab).attr("aria-hidden", false);
-      $('a[href="' + lastTab + '"]').attr("aria-selected", true);
-      if (lastTab !== firstTab) {
-        $(firstTab).attr("aria-hidden", true);
-        $('a[href="' + firstTab + '"]').attr("aria-selected", false);
-      }
-    }
-  }
-}
-
-function accessibleTabs() {
   if ($('#tabs').length > 0) {
     // Adapted from https://codepen.io/heydon/pen/veeaEa
     var tabbed = document.querySelector('#tabs');
@@ -65,45 +8,42 @@ function accessibleTabs() {
     var tabs = tablist.querySelectorAll('a');
     var panels = tabbed.querySelectorAll('.tab-pane');
 
-    // The tab switching function
-    var switchTab = function switchTab(oldTab, newTab) {
-      $(newTab).tab('show');
-      newTab.focus();
+    var selectTab = function selectTab(tab) {
+      $(tab).tab('show');
       // Make the active tab focusable by the user (Tab key)
-      newTab.removeAttribute('tabindex');
+      tab.removeAttribute('tabindex');
       // Set the selected state
-      newTab.setAttribute('aria-selected', 'true');
-      newTab.parentNode.setAttribute('class', 'active');
-      oldTab.setAttribute('aria-selected', 'false');
-      oldTab.parentNode.removeAttribute('class', 'active');
-      oldTab.setAttribute('tabindex', '-1');
-      // Get the indices of the new and old tabs to find the correct
-      // tab panels to show and hide
-      var index = Array.prototype.indexOf.call(tabs, newTab);
-      var oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
-      panels[oldIndex].setAttribute('aria-hidden', 'true');
-      $(panels[index]).tab('show');
+      tab.setAttribute('aria-selected', 'true');
+      tab.parentNode.setAttribute('class', 'active');
+      var index = Array.prototype.indexOf.call(tabs, tab);
+      // $(panels[index]).tab('show');
       panels[index].setAttribute('aria-hidden', 'false');
-      //('class', 'active');
     };
 
-    // Add the tablist role to the first <ul> in the .tabbed container
-    tablist.setAttribute('role', 'tablist');
-
-    // Add aria semantics - remove user focusability for each tab
-    Array.prototype.forEach.call(tabs, function (tab, i) {
-      tab.setAttribute('role', 'tab');
-      //tab.setAttribute('id', 'tab' + (i + 1));
+    var unselectTab = function unselectTab(tab, index) {
       tab.setAttribute('tabindex', '-1');
-      tab.parentNode.setAttribute('role', 'presentation');
+      tab.setAttribute('aria-selected', 'false');
+      tab.parentNode.removeAttribute('class', 'active');
+      panels[index].setAttribute('aria-hidden', 'true');
+    };
 
+    var unselectTabs = function unselectTabs() {
+      Array.prototype.forEach.call(tabs, function (tab, index) {
+        unselectTab(tab, index);
+      });
+    };
+
+    var clickTab = function clickTab(tab) {
+      unselectTabs();
+      selectTab(tab);
+      tab.focus();
+    };
+
+    Array.prototype.forEach.call(tabs, function (tab, i) {
       // Handle clicking of tabs for mouse users
       tab.addEventListener('click', function (e) {
         e.preventDefault();
-        var currentTab = tablist.querySelector('[aria-selected]');
-        if (e.currentTarget !== currentTab) {
-          switchTab(currentTab, e.currentTarget);
-        }
+        clickTab(e.currentTarget);
       });
 
       // Handle keydown events for keyboard users
@@ -117,14 +57,74 @@ function accessibleTabs() {
           e.preventDefault();
           // If the down key is pressed, move focus to the open panel,
           // otherwise switch to the adjacent tab
-          dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
+          if (dir === 'down') {
+            panels[index].focus();
+          } else if (tabs[dir]) {
+            tabs[dir].click();
+          }
         }
       });
     });
 
-    // Initially activate the first tab and reveal the first tab panel
-    tabs[0].removeAttribute('tabindex');
-  }
-}
+    var lastTab = $(tabs[0]).attr('href');
 
+    // Store the monograph ID and tab ID last used on the monograph catalog page
+    // Amend the tab ID to URL if it exists.
+    // If monograph page, store the last used tab
+    if ($('#main.monograph').length > 0) {
+      // https://stackoverflow.com/a/10524697
+      var page_url = window.location.pathname.split('/');
+      // getting the monograph id from the URL path is not as reliable as using the
+      // monograph presenter
+      var monograph_id = page_url[3];
+      var previous_monograph_id = sessionStorage.getItem('monograph_id');
+      sessionStorage.setItem('monograph_id', monograph_id);
+
+      if (monograph_id !== previous_monograph_id) {
+        sessionStorage.removeItem('lastTab');
+      }
+
+      // for bootstrap 3 use 'shown.bs.tab', for bootstrap 2 use 'shown' in the next line
+      $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+        // save the latest tab; use cookies if you like 'em better:
+        sessionStorage.setItem('lastTab', $(e.target).attr('href'));
+      });
+
+      // go to the latest tab, apply aria semantics, if it exists in sessionStorage
+      // if not the first tab, unset aria semantics for first tab
+      lastTab = sessionStorage.getItem('lastTab');
+
+      // If there is a value in the search field, heavy-handedly override
+      // stored value so the resources tab is visible on load.
+      if ($('#resources_search').val() !== undefined) {
+        lastTab = '#resources';
+      }
+
+      // If the monograph page URL has an anchor (like the CSB Media button)
+      // then we override with similar heavy-handedness.
+      // https://stackoverflow.com/a/4108277
+      var stripped = document.location.href.split("#");
+      if (stripped.length > 1) {
+        lastTab = '#' + stripped[1];
+      }
+
+      if (lastTab === undefined) {
+        lastTab = $(tabs[0]).attr('href');
+      }
+
+      if ($('a[href="' + lastTab + '"]').val() === undefined) {
+        lastTab = $(tabs[0]).attr('href');
+      }
+    }
+
+    var tab = $('a[href="' + lastTab + '"]')[0];
+    selectTab(tab);
+
+    var index = Array.prototype.indexOf.call(tabs, tab);
+    if ((index + 1) === tabs.length) {
+      // #stats tab
+      throttleHeliotropeStatFlot(250);
+      heliotropeStatsAlreadyDrawn = true;
+    }
+  }
 });

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -133,39 +133,52 @@
   </div><!-- /.monograph-metadata -->
 </div><!-- /.monograph-info-epub -->
 
+<!-- See app/assets/javascripts/application/tabs.js -->
 <div class="row monograph-assets-toc-epub">
   <div class="col-sm-12" id="tabs">
     <ul class="nav nav-tabs" role="tablist">
-      <% if @presenter.reader_ebook? %>
-        <li role="presentation" class="active"><a id="tab-toc" href="#toc" data-toggle="tab" role="tab" aria-controls="toc" aria-selected="true" tabindex="0">Table of Contents</a></li>
+      <% if @presenter.toc? %>
+        <li role="presentation">
+          <a id="tab-toc" href="#toc" aria-controls="toc" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Table of Contents</a>
+        </li>
       <% end %>
       <% if @presenter.assets? %>
-        <% if @presenter.reader_ebook? %>
-          <li role="presentation"><a id="tab-resources" href="#resources" role="tab" data-toggle="tab" aria-controls="resources" aria-selected="false" tabindex="-1">Resources</a></li>
-        <% else %>
-          <li role="presentation" class="active"><a id="tab-resources" href="#resources" data-toggle="tab" role="tab" aria-controls="resources" aria-selected="true"  tabindex="0">Resources</a></li>
-        <% end %>
+        <li role="presentation">
+          <a id="tab-resources" href="#resources" aria-controls="resources" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Resources</a>
+        </li>
       <% end %>
       <% if @presenter.reviews? %>
-        <li role="presentation"><a id="tab-reviews" href="#reviews" role="tab" data-toggle="tab" aria-controls="reviews" aria-selected="false" tabindex="-1">Reviews</a></li>
+        <li role="presentation">
+          <a id="tab-reviews" href="#reviews" aria-controls="reviews" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Reviews</a>
+        </li>
       <% end %>
       <% if @presenter.related? %>
-        <li role="presentation"><a id="tab-related" href="#related" role="tab" data-toggle="tab" aria-controls="related" aria-selected="false" tabindex="-1">Related Titles</a></li>
+        <li role="presentation">
+          <a id="tab-related" href="#related" aria-controls="related" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Related Titles</a>
+        </li>
       <% end %>
       <% if @presenter.webgl? %>
-        <li role="presentation"><a id="tab-webgl" href="#webgl" role="tab" data-toggle="tab" aria-controls="webgl" aria-selected="false" tabindex="-1">3-D Model</a></li>
+        <li role="presentation">
+          <a id="tab-webgl" href="#webgl" aria-controls="webgl" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">3-D Model</a>
+        </li>
       <% end %>
       <% if @presenter.database? %>
-        <li role="presentation"><a id="tab-database" href="#database" role="tab" data-toggle="tab" aria-controls="database" aria-selected="false" tabindex="-1">Database</a></li>
+        <li role="presentation">
+          <a id="tab-database" href="#database" aria-controls="database" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Database</a>
+        </li>
       <% end %>
       <% if @presenter.aboutware? %>
-        <li role="presentation"><a id="tab-aboutware" href="#aboutware" role="tab" data-toggle="tab" aria-controls="aboutware" aria-selected="false" tabindex="-1">About</a></li>
+        <li role="presentation">
+          <a id="tab-aboutware" href="#aboutware" aria-controls="aboutware" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">About</a>
+        </li>
       <% end %>
-      <li role="presentation"><a id="tab-stats" href="#stats" role="tab" data-toggle="tab" aria-controls="stats" aria-selected="false" tabindex="-1">Stats</a></li>
+        <li role="presentation">
+          <a id="tab-stats" href="#stats" aria-controls="stats" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Stats</a>
+        </li>
     </ul>
     <div id="tabs-content" class="tab-content monograph-assets-toc-epub-content" aria-live="polite">
-      <% if @presenter.reader_ebook? %>
-        <section id="toc" class="tab-pane active fade in toc row" role="tabpanel" aria-hidden="false" aria-labelledby="tab-toc" tabindex="0">
+      <% if @presenter.toc? %>
+        <section id="toc" class="tab-pane fade toc row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-toc" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Table of Contents</h2>
             <%= render 'index_epub_toc' %>
@@ -173,11 +186,7 @@
         </section>
       <% end %>
       <% if @presenter.assets? %>
-        <% if @presenter.reader_ebook? %>
-        <section id="resources" class="tab-pane fade in resources row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-resources" tabindex="0">
-        <% else %>
-        <section id="resources" class="tab-pane fade in active resources row" role="tabpanel" aria-hidden="false" aria-labelledby="tab-resources" tabindex="0">
-        <% end %>
+        <section id="resources" class="tab-pane fade resources row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-resources" tabindex="0">
           <h2 class="sr-only">Resources</h2>
           <div class="col-sm-3 fulcrum_sidebar">
             <%= render 'catalog/search_sidebar' %>
@@ -190,7 +199,7 @@
         </section>
       <% end %>
       <% if @presenter.webgl? %>
-        <section id="webgl" class="tab-pane fade in webgl row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-webgl" tabindex="0">
+        <section id="webgl" class="tab-pane fade webgl row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-webgl" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">3D Model</h2>
             <%= render 'webgls/tab' %>
@@ -198,7 +207,7 @@
         </section>
       <% end %>
       <% if @presenter.database? %>
-        <section id="database" class="tab-pane fade in database row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-database" tabindex="0">
+        <section id="database" class="tab-pane fade database row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-database" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Database</h2>
             <a href="<%= @presenter&.database&.external_resource_url %>" target="_blank">Click to open external database <span class="glyphicon glyphicon-share" aria-hidden="true" aria-label="Link to external database"></span></a>
@@ -206,7 +215,7 @@
         </section>
       <% end %>
       <% if @presenter.aboutware? %>
-        <section id="aboutware" class="tab-pane fade in aboutware row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-aboutware" tabindex="0">
+        <section id="aboutware" class="tab-pane fade aboutware row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-aboutware" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">About</h2>
             <%# this assumes that the "aboutware" FileSet is an html doc %>
@@ -215,7 +224,7 @@
         </section>
       <% end %>
       <% if @presenter.reviews? %>
-        <section id="reviews" class="tab-pane fade in reviews row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-reviews" tabindex="0">
+        <section id="reviews" class="tab-pane fade reviews row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-reviews" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Reviews</h2>
             <%# this assumes that the "reviews" FileSet is an html doc %>
@@ -224,7 +233,7 @@
         </section>
       <% end %>
       <% if @presenter.related? %>
-        <section id="related" class="tab-pane fade in related row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-related" tabindex="0">
+        <section id="related" class="tab-pane fade related row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-related" tabindex="0">
           <div class="col-sm-12">
             <h2 class="sr-only">Related Titles</h2>
             <%# this assumes that the "related" FileSet is an html doc %>
@@ -232,10 +241,10 @@
           </div>
         </section>
       <% end %>
-      <section id="stats" class="tab-pane fade in stats row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-stats" tabindex="0">
-        <h2 class="sr-only">Stats</h2>
-        <%= render 'stats' %>
-      </section>
+        <section id="stats" class="tab-pane fade stats row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-stats" tabindex="0">
+          <h2 class="sr-only">Stats</h2>
+          <%= render 'stats' %>
+        </section>
     </div>
   </div>
 </div><!-- /.monograph-assets-toc-epub -->


### PR DESCRIPTION
… not activate the content in those panels

    // If there is a value in the search field, heavy-handedly override
    // stored value so the resources tab is visible on load.
    if ($('#resources_search').val() !== undefined) {
      lastTab = '#resources';
    }

    // If the monograph page URL has an anchor (like the CSB Media button)
    // then we override with similar heavy-handedness.
    // https://stackoverflow.com/a/4108277
    var stripped = document.location.href.split("#");
    if (stripped.length > 1) {
      lastTab = '#' + stripped[1];
    }

Verify I didn't break the above functionality before merging.