### PR TITLE
Addresses HELIO-3000 Include Parent Press GA ID on Sub Press pages.

### DIFF
--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -115,6 +115,12 @@ module PressHelper
     controller.is_a?(PressCatalogController) ? 'press_catalog.banner' : 'monograph_catalog.banner'
   end
 
+  def all_google_analytics(subdomain)
+    press = Press.where(subdomain: subdomain)&.first
+    return [] if press.blank?
+    [press.google_analytics, parent_press(press)&.google_analytics].compact
+  end
+
   private
 
     def parent_press(child_press)

--- a/app/views/shared/_ga.html.erb
+++ b/app/views/shared/_ga.html.erb
@@ -1,5 +1,4 @@
-
-<% ga_id = google_analytics(press_subdomain) %>
+<% ga_ids = all_google_analytics(press_subdomain) %>
 
 <% ga_url = 'https://www.google-analytics.com/analytics.js' %>
 <% if Rails.env.development? %>
@@ -22,7 +21,7 @@
 
     ga('create', '<%= Rails.application.secrets.google_analytics_id %>', 'auto');
     ga('send', 'pageview');
-    <% unless ga_id.nil? %>
+    <% ga_ids.each do |ga_id| %>
       ga('create', '<%= ga_id %>', 'auto', 'pressTracker')
       ga('pressTracker.send', 'pageview')
     <% end %>

--- a/spec/helpers/press_helper_spec.rb
+++ b/spec/helpers/press_helper_spec.rb
@@ -119,6 +119,15 @@ describe PressHelper do
     end
   end
 
+  describe "#all_google_analytics with two GA ids" do
+    let(:press) { create(:press, subdomain: "blue", google_analytics: "GA-ID-BLUE") }
+    let(:child) { create(:press, subdomain: "maize", google_analytics: "GA-ID-MAIZE", parent_id: press.id) }
+
+    it "returns both Google analytics ids" do
+      expect(all_google_analytics(child.subdomain)).to match_array [press.google_analytics, child.google_analytics]
+    end
+  end
+
   describe "#show_banner?" do
     subject { show_banner?(actor, subdomain) }
 


### PR DESCRIPTION
Add new helper method all_ga_analytics to return GA ids as an array (almost always an array of one but an array of two for Gabii) for the GA JS to iterate on.