### PR TITLE
HELIO-2720 CSB Permalink widget uses parent citation_link, not FileSet

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -8,9 +8,10 @@ class EPubsController < CheckpointController
     return redirect_to epub_access_url unless @policy.show?
 
     @title = @presenter.parent.present? ? @presenter.parent.page_title : @presenter.page_title
-    @citable_link = @presenter.citable_link
-    @subdomain = @presenter.parent.subdomain
     @parent_presenter = @presenter.parent
+    @citable_link = @parent_presenter.citable_link
+    @subdomain = @presenter.parent.subdomain
+
     @back_link = if params[:publisher].present?
                    URI.join(main_app.root_url, params[:publisher]).to_s
                  else

--- a/lib/tasks/handles_file_sets_since.rake
+++ b/lib/tasks/handles_file_sets_since.rake
@@ -12,14 +12,7 @@ namespace :heliotrope do
 
     FileSet.all.each do |f|
       next if f.parent.blank? || f.date_uploaded < cutoff_time
-      # in the long run I think all EPUB handles should point to the epub_path (CSB viewer), but right now that...
-      # only works for the monograph's representative EPUB (https://github.com/mlibrary/heliotrope/issues/1702)
-      featured_representative = FeaturedRepresentative.where(work_id: f.parent.id, file_set_id: f.id).first
-      if featured_representative&.kind == 'epub'
-        puts "#{f.id},#{Rails.application.routes.url_helpers.epub_path(f.id)}"
-      else
-        puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
-      end
+      puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
     end
   end
 end

--- a/lib/tasks/handles_monographs_since.rake
+++ b/lib/tasks/handles_monographs_since.rake
@@ -15,14 +15,7 @@ namespace :heliotrope do
       puts "#{m.id},#{Rails.application.routes.url_helpers.hyrax_monograph_path(m.id)}"
 
       m.ordered_members.to_a.each do |f|
-        # in the long run I think all EPUB handles should point to the epub_path (CSB viewer), but right now that...
-        # only works for the monograph's representative EPUB (https://github.com/mlibrary/heliotrope/issues/1702)
-        featured_representative = FeaturedRepresentative.where(work_id: m.id, file_set_id: f.id).first
-        if featured_representative&.kind == 'epub'
-          puts "#{f.id},#{Rails.application.routes.url_helpers.epub_path(f.id)}"
-        else
-          puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
-        end
+        puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
       end
     end
   end

--- a/lib/tasks/handles_publisher.rake
+++ b/lib/tasks/handles_publisher.rake
@@ -26,12 +26,7 @@ namespace :heliotrope do
       end
 
       m['ordered_member_ids_ssim']&.each do |f| # f is just a string, each FileSet's NOID
-        featured_representative = FeaturedRepresentative.where(work_id: m.id, file_set_id: f).first
-        if featured_representative&.kind == 'epub'
-          puts "#{f},#{Rails.application.routes.url_helpers.epub_path(f)}"
-        else
-          puts "#{f},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f)}"
-        end
+        puts "#{f},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f)}"
       end
     end
 

--- a/lib/tasks/handles_single_monograph.rake
+++ b/lib/tasks/handles_single_monograph.rake
@@ -13,14 +13,7 @@ namespace :heliotrope do
 
     m.ordered_members.to_a.each do |f|
       next unless f.file_set?
-      # in the long run I think all EPUB handles should point to the epub_path (CSB viewer), but right now that...
-      # only works for the monograph's representative EPUB (https://github.com/mlibrary/heliotrope/issues/1702)
-      featured_representative = FeaturedRepresentative.where(work_id: m.id, file_set_id: f.id).first
-      if featured_representative&.kind == 'epub'
-        puts "#{f.id},#{Rails.application.routes.url_helpers.epub_path(f.id)}"
-      else
-        puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
-      end
+      puts "#{f.id},#{Rails.application.routes.url_helpers.hyrax_file_set_path(f.id)}"
     end
   end
 end


### PR DESCRIPTION
and Social Media Share Links in CSB point to the catalog page, not the
epub/pdf_ebook.
HELIO-2981 No special handles for FeaturedRepresentatives

Tested all the handle rake tasks in dev
Tested the Social Media Share Links to verify that they go to the monograph

#done