### PR TITLE
Addresses HELIO-2983 make analytics world-visible.

### DIFF
--- a/app/controllers/press_statistics_controller.rb
+++ b/app/controllers/press_statistics_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PressStatisticsController < ApplicationController
+  before_action :load_press
+
+  def index
+    render :index
+  end
+
+  private
+
+    def load_press
+      @press = Press.find_by(subdomain: params['press'])
+      return @press if @press.present?
+      render file: Rails.root.join('public', '404.html'), status: :not_found, layout: false
+    end
+end

--- a/app/controllers/presses_controller.rb
+++ b/app/controllers/presses_controller.rb
@@ -40,6 +40,6 @@ class PressesController < ApplicationController
   private
 
     def press_params
-      params.require(:press).permit(:subdomain, :name, :logo_path, :description, :press_url, :google_analytics, :typekit, :footer_block_a, :footer_block_b, :footer_block_c, :remove_logo_path, :parent_id, :restricted_message, :twitter, :location, :google_analytics_url, :share_links, :watermark, :doi_creation)
+      params.require(:press).permit(:subdomain, :name, :logo_path, :description, :press_url, :google_analytics, :typekit, :footer_block_a, :footer_block_b, :footer_block_c, :remove_logo_path, :parent_id, :restricted_message, :twitter, :location, :google_analytics_url, :readership_map_url, :share_links, :watermark, :doi_creation)
     end
 end

--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -65,6 +65,12 @@ module PressHelper
     press.google_analytics_url.presence || parent_press(press)&.google_analytics_url
   end
 
+  def readership_map_url(subdomain)
+    press = Press.where(subdomain: subdomain)&.first
+    return if press.blank?
+    press.readership_map_url.presence || parent_press(press)&.readership_map_url
+  end
+
   def typekit(subdomain)
     press = Press.where(subdomain: subdomain)&.first
     return if press.blank?

--- a/app/views/hyrax/admin/stats/_analytics.html.erb
+++ b/app/views/hyrax/admin/stats/_analytics.html.erb
@@ -2,7 +2,7 @@
   <h1><span class="fa fa-google"></span> Google Analytics</h1>
 <% end %>
 
-<% presses = current_user.admin_presses.where.not(google_analytics_url: nil).sort_by(&:name) %>
+<% presses = current_user.admin_presses.where.not(google_analytics_url: [nil, '']).sort_by(&:name) %>
 <% if presses.size > 1 %>
   <label class="sr-only" for="publisher_report">Select Publisher for Google Analytics Report</label>
   <select id="publisher_report" onchange="document.getElementById('ga_iframe').src=this.value;">

--- a/app/views/press_statistics/index.html.erb
+++ b/app/views/press_statistics/index.html.erb
@@ -1,0 +1,48 @@
+<% provide :page_title, "#{@press.name} Statistics" %>
+<% provide :page_class, 'press' %>
+<% ga_url = @press.google_analytics_url %>
+<% map_url = @press.readership_map_url %>
+
+<div class="row monograph-assets-toc-epub">
+  <div class="col-sm-12" id="tabs">
+    <ul class="nav nav-tabs" role="tablist">
+      <% if ga_url.present? %>
+        <li role="presentation">
+          <a id="tab-analytics" href="#analytics" aria-controls="toc" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Google Analytics</a>
+        </li>
+      <% end %>
+      <% if map_url.present? %>
+        <li role="presentation">
+          <a id="tab-map" href="#map" aria-controls="resources" role="tab" data-toggle="tab" aria-selected="false" tabindex="-1">Readership Map</a>
+        </li>
+      <% end %>
+    </ul>
+    <div id="tabs-content" class="tab-content monograph-assets-toc-epub-content" aria-live="polite">
+      <% if ga_url.present? %>
+        <section id="analytics" class="tab-pane fade toc row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-toc" tabindex="0">
+          <div class="col-sm-12">
+            <h2 class="sr-only">Google Analytics</h2>
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <div class="iframe-container">
+                  <iframe src="<%= ga_url %>" id="ga_iframe" class=".embed-responsive-item"></iframe>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      <% end %>
+      <% if map_url.present? %>
+        <section id="map" class="tab-pane fade resources row" role="tabpanel" aria-hidden="true" aria-labelledby="tab-resources" tabindex="0">
+          <h2 class="sr-only">Readership Map</h2>
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <div class="iframe-container">
+                <iframe src="<%= map_url %>" id="map_iframe" class=".embed-responsive-item"></iframe>
+              </div>
+            </div>
+          </div>
+        </section>
+      <% end %>
+  </div>
+</div>

--- a/app/views/presses/_form.html.erb
+++ b/app/views/presses/_form.html.erb
@@ -27,6 +27,7 @@
   <%= f.input :press_url, label: 'Publisher\'s Current Website Address', required: true %>
   <%= f.input :google_analytics, label: 'Google Analytics Tracking ID' %>
   <%= f.input :google_analytics_url, label: 'Google Analytics Data Studio URL' %>
+  <%= f.input :readership_map_url, label: '(MPub) Readership Map URL' %>
   <%= f.input :typekit, label: 'Typekit ID' %>
   <%= f.input :twitter, label: 'Twitter Handle' %>
   <%= f.input :location, label: 'Publisher Location' %>

--- a/app/views/shared/_brand_press_jumbotron.html.erb
+++ b/app/views/shared/_brand_press_jumbotron.html.erb
@@ -19,5 +19,13 @@
           <% end %>
         </p>
         <% end %>
+        <% # Don't show jumbotron link to stats page when on the stats page. %>
+        <% if request.original_url != press_statistics_url(@press) %>
+          <% if @press.google_analytics_url.present? || @press.readership_map_url.present? %>
+            <p class="lead">
+              <%= link_to 'Publisher Statistics', press_statistics_path(@press) %>
+            </p>
+          <% end %>
+        <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,7 @@ Rails.application.routes.draw do
 
   get ':press', controller: :press_catalog, action: :index, as: :press_catalog
   get ':press/facet', controller: :press_catalog, action: :facet
+  get ':press/statistics', controller: :press_statistics, action: :index, as: :press_statistics
 
   root 'presses#index'
 

--- a/db/migrate/20191025183154_add_readership_map_url_to_presses.rb
+++ b/db/migrate/20191025183154_add_readership_map_url_to_presses.rb
@@ -1,0 +1,5 @@
+class AddReadershipMapUrlToPresses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :presses, :readership_map_url, :string
+  end
+end

--- a/spec/controllers/press_statistics_controller_spec.rb
+++ b/spec/controllers/press_statistics_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PressStatisticsController, type: :controller do
+  describe '#index' do
+    context 'a press' do
+      let(:press) { create :press }
+
+      before do
+        get :index, params: { press: press.subdomain }
+      end
+
+      it 'is successful' do
+        expect(response).to be_success
+        expect(response).to render_template('press_statistics/index')
+      end
+    end
+  end
+end

--- a/spec/helpers/press_helper_spec.rb
+++ b/spec/helpers/press_helper_spec.rb
@@ -64,6 +64,16 @@ describe PressHelper do
     end
   end
 
+  describe "#readership_map_url" do
+    context "when a press has a readership map URL" do
+      let(:press) { create(:press, subdomain: "ReadReadRead", readership_map_url: 'https://www.example.com/Map/ReadReadRead') }
+
+      it "returns the map URL" do
+        expect(readership_map_url(press.subdomain)).to eq('https://www.example.com/Map/ReadReadRead')
+      end
+    end
+  end
+
   describe "#restricted_message" do
     let(:press) { create(:press, subdomain: "blah", restricted_message: "<b>No. Just No.</b>") }
 

--- a/spec/views/shared/_brand_press_jumbotron.html.erb_spec.rb
+++ b/spec/views/shared/_brand_press_jumbotron.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'shared/_brand_press_jumbotron.html.erb' do
+  context 'when a press has an Analytics URL' do
+    let(:press) { create(:press, subdomain: 'na', name: 'No Agenda Press', google_analytics_url: 'https://www.example.com') }
+    it 'renders link to statistics page' do
+      assign(:press, press)
+      render
+      expect(rendered).to have_link('Publisher Statistics', href: press_statistics_path(press))
+    end
+  end
+
+  context 'when a press has a readership map URL' do
+    let(:press) { create(:press, subdomain: 'na', name: 'No Agenda Press', readership_map_url: 'https://www.example.com') }
+    it 'renders link to statistics page' do
+      assign(:press, press)
+      render
+      expect(rendered).to have_link('Publisher Statistics', href: press_statistics_path(press))
+    end
+  end
+
+  context 'when a press has neither Analytics nor readership map URLs' do
+    let(:press) { create(:press, subdomain: 'na', name: 'No Agenda Press') }
+    it 'suppresses link to statistics page' do
+      assign(:press, press)
+      render
+      expect(rendered).not_to have_link('Publisher Statistics', href: press_statistics_path(press))
+    end
+  end
+end


### PR DESCRIPTION
Adds a new route to a branded stats page with two tabs: Analytics and readership map. Right now this is linked from the press jumbotron.

Note:  app/views/hyrax/admin/stats/_analytics.html.erb  is a (semi-random) bug fix. The admin-only analytics/reports pages duplicated under /app/views/hyrax/admin are kind of a dud now with this revision and maybe we should just blow them away. That's for another time, tho.