### PR TITLE
Resolves HELIO-2763 Components should default sort by created_at desc…

### DIFF
--- a/app/views/fulcrum/_components.html.erb
+++ b/app/views/fulcrum/_components.html.erb
@@ -1,4 +1,4 @@
-<% components = Greensub::Component.filter(identifier_like: params[:identifier_like], name_like: params[:name_like], noid_like: params[:noid_like]).order(identifier: :asc).page(params[:page]) %>
+<% components = Greensub::Component.filter(identifier_like: params[:identifier_like], name_like: params[:name_like], noid_like: params[:noid_like]).order(created_at: :desc).page(params[:page]) %>
 <h1>Components</h1>
 <form name="filter" method="get" action="<%= fulcrum_partials_path(:components) %>">
   <table class="table table-striped" summary="Components List">


### PR DESCRIPTION
… instead of noid

Fulcrum Dashboard Components 