### PR TITLE
Addresses HELIO-3062 Update citation widget to include citable link.

### DIFF
--- a/app/helpers/hyrax/citations_behavior.rb
+++ b/app/helpers/hyrax/citations_behavior.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehavior
+    include Hyrax::CitationsBehaviors::CommonBehavior
+    include Hyrax::CitationsBehaviors::Formatters
+    include Hyrax::CitationsBehaviors::PublicationBehavior
+    include Hyrax::CitationsBehaviors::NameBehavior
+    include Hyrax::CitationsBehaviors::TitleBehavior
+
+    def export_as_apa_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::ApaFormatter.new(self).format(work)
+    end
+
+    def export_as_chicago_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::ChicagoFormatter.new(self).format(work)
+    end
+
+    def export_as_mla_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::MlaFormatter.new(self).format(work)
+    end
+
+    # MIME type: 'application/x-openurl-ctx-kev'
+    def export_as_openurl_ctx_kev(work)
+      Hyrax::CitationsBehaviors::Formatters::OpenUrlFormatter.new(self).format(work)
+    end
+  end
+end

--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: false
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class ApaFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+          text << authors_text_for(work)
+          text << pub_date_text_for(work)
+          text << add_title_text_for(work)
+          text << add_publisher_text_for(work)
+          text.html_safe # rubocop:disable Rails/OutputSafety
+        end
+
+        private
+
+          def authors_text_for(work)
+            # setup formatted author list
+            authors_list = author_list(work).reject(&:blank?)
+            author_text = format_authors(authors_list)
+            if author_text.blank?
+              author_text
+            else
+              "<span class=\"citation-author\">#{author_text}</span> "
+            end
+          end
+
+        public
+
+        def format_authors(authors_list = [])
+          authors_list = Array.wrap(authors_list).map { |name| abbreviate_name(surname_first(name)).strip }
+          text = ''
+          text << authors_list.first if authors_list.first
+          authors_list[1..-1].each do |author|
+            if author == authors_list.last # last
+              text << ", &amp; " << author
+            else # all others
+              text << ", " << author
+            end
+          end
+          text << "." unless text =~ /\.$/
+          text
+        end
+
+        private
+
+          def pub_date_text_for(work)
+            # Get Pub Date
+            pub_date = setup_pub_date(work)
+            format_date(pub_date)
+          end
+
+          def add_title_text_for(work)
+            # setup title info
+            title_info = setup_title_info(work)
+            format_title(title_info)
+          end
+
+          def add_publisher_text_for(work)
+            pub_info = nil
+            if work.doi?
+              pub_info = work.citable_link
+            else
+              pub_info = "Retrieved from #{work.citable_link}"
+            end
+            if pub_info.nil?
+              ''
+            else
+              pub_info + "."
+            end
+          end
+
+        public
+
+        def format_date(pub_date)
+          pub_date.blank? ? "" : "(" + pub_date + "). "
+        end
+
+        def format_title(title_info)
+          title_info.nil? ? "" : "<i class=\"citation-title\">#{title_info}</i> "
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: false
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class ChicagoFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+        def format(work)
+          text = ""
+          # setup formatted author list
+          authors_list = all_authors(work)
+          text << format_authors(authors_list)
+          text = "<span class=\"citation-author\">#{text}</span>" if text.present?
+          text << format_title(work.to_s)
+          pub_info = setup_pub_info(work, true)
+          text << " #{whitewash(pub_info)}." if pub_info.present?
+          text << " #{work.citable_link}."
+          text << (work.pdf_ebook? ? ' PDF.' : ' EPUB.')
+          text.html_safe # rubocop:disable Rails/OutputSafety
+        end
+
+        def format_authors(authors_list = [])
+          return '' if authors_list.blank?
+          text = ''
+          text << surname_first(authors_list.first) if authors_list.first
+          authors_list[1..6].each_with_index do |author, index|
+            text << if index + 2 == authors_list.length # we've skipped the first author
+                      ", and #{given_name_first(author)}."
+                    else
+                      ", #{given_name_first(author)}"
+                    end
+          end
+          text << " et al." if authors_list.length > 7
+          # if for some reason the first author ended with a comma
+          text.gsub!(',,', ',')
+          text << "." unless text =~ /\.$/
+          whitewash(text)
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def format_date(pub_date); end
+
+        def format_title(title_info)
+          return "" if title_info.blank?
+          title_text = chicago_citation_title(title_info)
+          title_text << '.' unless title_text =~ /\.$/
+          title_text = whitewash(title_text)
+          " <i class=\"citation-title\">#{title_text}</i>"
+        end
+
+        private
+
+          def whitewash(text)
+            Loofah.fragment(text.to_s).scrub!(:whitewash).to_s
+          end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: false
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class MlaFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+          # setup formatted author list
+          authors = author_list(work).reject(&:blank?)
+          text << "<span class=\"citation-author\">#{format_authors(authors)}</span>"
+          # setup title
+          title_info = setup_title_info(work)
+          text << format_title(title_info)
+          # Publication
+          text << add_publisher_text_for(work)
+          text.html_safe # rubocop:disable Rails/OutputSafety
+        end
+
+        def format_authors(authors_list = [])
+          return '' if authors_list.blank?
+          authors_list = Array.wrap(authors_list)
+          text = concatenate_authors_from(authors_list)
+          if text.present?
+            text << '.' unless text =~ /\.$/
+            text << ' '
+          end
+          text
+        end
+
+        def concatenate_authors_from(authors_list)
+          text = ''
+          text << surname_first(authors_list.first)
+          if authors_list.length > 1
+            if authors_list.length < 4
+              authors_list[1...-1].each do |author|
+                text << ", " << given_name_first(author)
+              end
+              text << ", and #{given_name_first(authors_list.last)}"
+            else
+              text << ', et al'
+            end
+          end
+          text
+        end
+        private :concatenate_authors_from
+
+        def format_date(pub_date)
+          pub_date
+        end
+
+        def format_title(title_info)
+          title_info.blank? ? '' : "<i class=\"citation-title\">#{mla_citation_title(title_info)}</i> "
+        end
+
+        def add_publisher_text_for(work)
+          pub_info = clean_end_punctuation(setup_pub_info(work, true)) || ''
+          pub_info = pub_info + ', ' if pub_info.length
+          pub_info = 'E-book, ' + pub_info + "#{work.citable_link}."
+          pub_info + " Accessed #{Time.now.getlocal.strftime('%e %b %Y').strip}."
+        end
+      end
+    end
+  end
+end

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -173,11 +173,11 @@ describe 'Create a monograph' do
       expect(page).to have_content '<identifier>'
 
       # MLA citation
-      expect(page).to have_content 'Johns, Jimmy, and Sub Way. #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.'
+      expect(page).to have_content 'Johns, Jimmy, and Sub Way. #hashtag Test Monograph Title with MD Italics and HTML Italics. E-book, Ann Arbor, MI.'
       # APA citation
-      expect(page).to have_content 'Johns, J., & Way, S. (2001). #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
+      expect(page).to have_content 'Johns, J., & Way, S. (2001). #hashtag Test Monograph Title with MD Italics and HTML Italics. https://doi.org/'
       # Chicago citation
-      expect(page).to have_content 'Johns, Jimmy, and Sub Way. 2001. #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co.'
+      expect(page).to have_content 'Johns, Jimmy, and Sub Way. #hashtag Test Monograph Title with MD Italics and HTML Italics. Ann Arbor, MI.: Blah Press, Co., 2001'
     end
   end
 end

--- a/spec/helpers/hyrax/citations_behavior_spec.rb
+++ b/spec/helpers/hyrax/citations_behavior_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::CitationsBehavior do
+  describe 'when a monograph has enough information to generate citations' do
+    context 'PDF with DOI' do
+      let(:doc) do
+        SolrDocument.new(id: '111111111',
+                         creator_tesim: ['Pugner, Mark'],
+                         title_tesim: ['The Complete Book of Everything'],
+                         location_tesim: ['Ann Arbor, MI'],
+                         publisher_tesim: ['University of Michigan Press'],
+                         has_model_ssim: ['Monograph'],
+                         date_created_tesim: ['2001'],
+                         doi_ssim: ['10.0000/mpub.111111'])
+      end
+      let(:rep) { create(:featured_representative, work_id: '111111111', file_set_id: '123456789', kind: 'epub') }
+      let(:presenter) { Hyrax::MonographPresenter.new(doc, nil) }
+
+      it 'returns the correct APA citation' do
+        expect(export_as_apa_citation(presenter)).to eq('<span class="citation-author">Pugner, M.</span> (2001). <i class="citation-title">The Complete Book of Everything.</i> https://doi.org/10.0000/mpub.111111.')
+      end
+      it 'returns the correct Chicago citation' do
+        expect(export_as_chicago_citation(presenter)).to eq('<span class="citation-author">Pugner, Mark.</span> <i class="citation-title">The Complete Book of Everything.</i> Ann Arbor, MI: University of Michigan Press, 2001. https://doi.org/10.0000/mpub.111111. EPUB.')
+      end
+      it 'returns the correct MLA citation' do
+        expect(export_as_mla_citation(presenter)).to eq('<span class="citation-author">Pugner, Mark. </span><i class="citation-title">The Complete Book of Everything.</i> E-book, Ann Arbor, MI: University of Michigan Press, 2001, https://doi.org/10.0000/mpub.111111. Accessed ' + "#{Time.now.getlocal.strftime('%e %b %Y').strip}.")
+      end
+    end
+
+    context 'EBOOK without DOI' do
+      let(:doc) do
+        SolrDocument.new(id: '111111111',
+                         creator_tesim: ['Pugner, Mark'],
+                         title_tesim: ['The Complete Book of Everything'],
+                         location_tesim: ['Ann Arbor, MI'],
+                         publisher_tesim: ['University of Michigan Press'],
+                         has_model_ssim: ['Monograph'],
+                         date_created_tesim: ['2001'])
+      end
+      let!(:rep) { create(:featured_representative, work_id: '111111111', file_set_id: '123456789', kind: 'pdf_ebook') } # rubocop:disable RSpec/LetSetup
+      let(:presenter) { Hyrax::MonographPresenter.new(doc, nil) }
+
+      it 'returns the correct APA citation' do
+        expect(export_as_apa_citation(presenter)).to eq('<span class="citation-author">Pugner, M.</span> (2001). <i class="citation-title">The Complete Book of Everything.</i> Retrieved from https://hdl.handle.net/2027/fulcrum.111111111.')
+      end
+      it 'returns the correct Chicago citation' do
+        expect(export_as_chicago_citation(presenter)).to eq('<span class="citation-author">Pugner, Mark.</span> <i class="citation-title">The Complete Book of Everything.</i> Ann Arbor, MI: University of Michigan Press, 2001. https://hdl.handle.net/2027/fulcrum.111111111. PDF.')
+      end
+      it 'returns the correct MLA citation' do
+        expect(export_as_mla_citation(presenter)).to eq('<span class="citation-author">Pugner, Mark. </span><i class="citation-title">The Complete Book of Everything.</i> E-book, Ann Arbor, MI: University of Michigan Press, 2001, https://hdl.handle.net/2027/fulcrum.111111111. Accessed ' + "#{Time.now.getlocal.strftime('%e %b %Y').strip}.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is mostly code appropriated from Hyrax and fixed up. Rubocop warns against use of html_safe but I found that omitting it interfered in unpredictable ways with tests in create_monograph_spec.rb. It's nothing that wasn't already happening inside Hyrax.