### PR TITLE
HELIO-3052 make fewer solr calls

### DIFF
--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -76,6 +76,8 @@ class MonographCatalogController < ::CatalogController
       @monograph_policy = MonographPolicy.new(current_actor, Sighrax.factory(monograph_id))
       @press_policy = PressPolicy.new(current_actor, Press.find_by(subdomain: @presenter.subdomain))
       @ebook_download_presenter = EBookDownloadPresenter.new(@presenter, current_ability, current_actor)
+      # This can be used if you need see something in the solr log... this is pretty noticable
+      # ActiveFedora::SolrService.query("{!terms f=id},,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,", rows: 99_999)
     end
 
     def add_counter_stat

--- a/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph_wrapper.html.erb
@@ -1,5 +1,4 @@
 <% # container for document in index gallery view -%>
-<% presenter = Hyrax::PresenterFactory.build_for(ids: [document.id], presenter_class: Hyrax::MonographPresenter, presenter_args: current_ability).first %>
+<% presenter = Hyrax::MonographPresenter.new(document, current_ability) %>
 <% counter = document_counter_with_offset(document_counter) %>
 <%= render partial: "index_gallery", locals: { document: document, counter: counter, presenter: presenter } %>
-

--- a/app/views/press_catalog/_index_gallery_score_wrapper.html.erb
+++ b/app/views/press_catalog/_index_gallery_score_wrapper.html.erb
@@ -1,6 +1,4 @@
 <% # container for document in index gallery view -%>
-<% presenter = Hyrax::PresenterFactory.build_for(ids: [document.id], presenter_class: Hyrax::ScorePresenter, presenter_args: current_ability).first %>
+<% presenter = Hyrax::ScorePresenter.new(document, current_ability) %>
 <% counter = document_counter_with_offset(document_counter) %>
 <%= render partial: "index_gallery", locals: { document: document, counter: counter, presenter: presenter } %>
-
-

--- a/config/initializers/riiif_initializer.rb
+++ b/config/initializers/riiif_initializer.rb
@@ -13,6 +13,7 @@ end
 # each image. If you are using hydra-file_characterization, you have the height & width
 # cached in Solr. The following block directs the info_service to return those values:
 Riiif::Image.info_service = lambda do |id, _file|
+  Rails.logger.debug("[RIIIF] H/W CHECK FOR #{id}")
   doc = ActiveFedora::SolrService.query("{!terms f=id}#{id}", rows: 1).first
   { height: doc["height_is"], width: doc["width_is"] }
 end
@@ -20,8 +21,10 @@ end
 module Riiif
   def Image.cache_key(id, options)
     str = options.to_h.merge(id: id).delete_if { |_, v| v.nil? }.to_s
-    # Add a timestamp to "expire" image tiles if a file_set is updated with a new image
-    'riiif:' + Digest::MD5.hexdigest(str) + ActiveFedora::SolrService.query("{!terms f=id}#{id}", rows: 1).first["timestamp"]
+    # add md5 of the file itself to invalidate the cache if the file has been changed (by reversioning or whatever)
+    filemd5 = Digest::MD5.file(Riiif::Image.file_resolver.find(id).path)
+    Rails.logger.debug("[RIIIF] FILE MD5: #{filemd5}")
+    'riiif:' + Digest::MD5.hexdigest(str) + filemd5.to_s
   end
 end
 

--- a/spec/services/sighrax_spec.rb
+++ b/spec/services/sighrax_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Sighrax do
-  describe '#facotry' do
+  describe '#factory' do
     subject { described_class.factory(noid) }
 
     let(:noid) { 'validnoid' }
@@ -86,6 +86,120 @@ RSpec.describe Sighrax do
               it { is_expected.to be_an_instance_of(Sighrax::PortableDocumentFormat) }
             end
           end
+        end
+      end
+    end
+  end
+
+  describe '#solr_factory' do
+    subject { described_class.solr_factory(document) }
+
+    context 'Monograph' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['Monograph']) }
+
+      it { is_expected.to be_an_instance_of(Sighrax::Monograph) }
+    end
+
+    context 'Score' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['Score']) }
+
+      it { is_expected.to be_an_instance_of(Sighrax::Score) }
+    end
+
+    context 'Asset' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['FileSet']) }
+      let(:featured_representatitve) { }
+
+      before do
+        allow(FeaturedRepresentative).to receive(:find_by).with(file_set_id: document['id']).and_return(featured_representatitve)
+      end
+
+      it { is_expected.to be_an_instance_of(Sighrax::Asset) }
+
+      context 'FeaturedRepresentative' do
+        let(:featured_representatitve) { double('featured_representatitve', kind: kind) }
+        let(:kind) { 'unknown' }
+
+        it { is_expected.to be_an_instance_of(Sighrax::Asset) }
+
+        context 'ElectronicPublication' do
+          let(:kind) { 'epub' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::ElectronicPublication) }
+        end
+
+        context 'Mobipocket' do
+          let(:kind) { 'mobi' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::Mobipocket) }
+        end
+
+        context 'PortableDocumentFormat' do
+          let(:kind) { 'pdf_ebook' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::PortableDocumentFormat) }
+        end
+      end
+    end
+  end
+
+  describe '#presenter_factory' do
+    subject { described_class.presenter_factory(presenter) }
+
+    before do
+      ActiveFedora::SolrService.add([document.to_h])
+      ActiveFedora::SolrService.commit
+    end
+
+    context 'Monograph' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['Monograph']) }
+      let(:presenter) { Hyrax::MonographPresenter.new(document, nil) }
+
+      it { is_expected.to be_an_instance_of(Sighrax::Monograph) }
+    end
+
+    context 'Score' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['Score']) }
+      let(:presenter) { Hyrax::ScorePresenter.new(document, nil) }
+
+      it { is_expected.to be_an_instance_of(Sighrax::Score) }
+    end
+
+    context 'Asset' do
+      let(:document) { ::SolrDocument.new(id: 'validnoid', has_model_ssim: ['FileSet']) }
+      let(:presenter) { Hyrax::FileSetPresenter.new(document, nil) }
+      let(:featured_representatitve) { }
+
+      before do
+        ActiveFedora::SolrService.add([document.to_h])
+        ActiveFedora::SolrService.commit
+        allow(FeaturedRepresentative).to receive(:find_by).with(file_set_id: document['id']).and_return(featured_representatitve)
+      end
+
+      it { is_expected.to be_an_instance_of(Sighrax::Asset) }
+
+      context 'FeaturedRepresentative' do
+        let(:featured_representatitve) { double('featured_representatitve', kind: kind) }
+        let(:kind) { 'unknown' }
+
+        it { is_expected.to be_an_instance_of(Sighrax::Asset) }
+
+        context 'ElectronicPublication' do
+          let(:kind) { 'epub' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::ElectronicPublication) }
+        end
+
+        context 'Mobipocket' do
+          let(:kind) { 'mobi' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::Mobipocket) }
+        end
+
+        context 'PortableDocumentFormat' do
+          let(:kind) { 'pdf_ebook' }
+
+          it { is_expected.to be_an_instance_of(Sighrax::PortableDocumentFormat) }
         end
       end
     end


### PR DESCRIPTION
The reason for this branch was from some excessive solr calls for cache key generation for IIIF tiling as talked about in a comment in HELIO-3052 that we there to make sure re-versioned/replaced FileSets were getting new/updated tiles. That works now with md5, not solr. This branch is on staging and I've tested re-versioning image FileSets and IIIF/Leaflet a few times.

Other then that some work was done in "Sighrax" in consultation with Greg before he went on vacation to reduce the number of (redundant) solr calls. And then a few bits of removing other unnecessary solr calls in a few other places.

In the end this branch shouldn't change any functionality but has the potential to greatly reduce the number of solr calls pages make.
