### PR TITLE
CSB-242 - update with the latest version of CSB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'combine_pdf', '~> 1.0'
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '9c9696bb0cf03fa5b0d7b01cda939a95bf4e33dc'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'b5b8da0513d3f44afbf0d2cfe67c8dc930be262c'
 
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 9c9696bb0cf03fa5b0d7b01cda939a95bf4e33dc
-  ref: 9c9696bb0cf03fa5b0d7b01cda939a95bf4e33dc
+  revision: b5b8da0513d3f44afbf0d2cfe67c8dc930be262c
+  ref: b5b8da0513d3f44afbf0d2cfe67c8dc930be262c
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Patched version of CSB resolves CSB-242, which now waits for updateLocations event before using locations in search results.