### PR TITLE
Added customizable Press site navigation block

### DIFF
--- a/app/controllers/presses_controller.rb
+++ b/app/controllers/presses_controller.rb
@@ -40,6 +40,6 @@ class PressesController < ApplicationController
   private
 
     def press_params
-      params.require(:press).permit(:subdomain, :name, :logo_path, :description, :press_url, :google_analytics, :typekit, :footer_block_a, :footer_block_b, :footer_block_c, :remove_logo_path, :parent_id, :restricted_message, :twitter, :location, :google_analytics_url, :readership_map_url, :share_links, :watermark, :doi_creation)
+      params.require(:press).permit(:subdomain, :name, :logo_path, :description, :press_url, :google_analytics, :typekit, :footer_block_a, :footer_block_b, :footer_block_c, :remove_logo_path, :parent_id, :restricted_message, :twitter, :location, :google_analytics_url, :readership_map_url, :share_links, :watermark, :doi_creation, :navigation_block)
     end
 end

--- a/app/helpers/press_helper.rb
+++ b/app/helpers/press_helper.rb
@@ -53,6 +53,12 @@ module PressHelper
     press.footer_block_c.presence || parent_press(press)&.footer_block_c.presence
   end
 
+  def navigation_block(subdomain)
+    press = Press.where(subdomain: subdomain)&.first
+    return if press.blank?
+    press.navigation_block.presence || parent_press(press)&.navigation_block.presence
+  end
+
   def google_analytics(subdomain)
     press = Press.where(subdomain: subdomain)&.first
     return if press.blank?

--- a/app/views/presses/_form.html.erb
+++ b/app/views/presses/_form.html.erb
@@ -34,6 +34,7 @@
   <%= f.input :footer_block_a %>
   <%= f.input :footer_block_b %>
   <%= f.input :footer_block_c %>
+  <%= f.input :navigation_block %>
   <%= f.input :parent_id, collection: Press.parent_presses, include_blank: true, prompt: "Choose a parent press (optional)" %>
   <%= f.input :restricted_message, label: 'Message for restricted works (if any). HTML is ok' %>
   <%= f.input :share_links, label: 'Allow "share links" for temporary access of restricted materials?', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>

--- a/app/views/shared/_brand_press_bar.html.erb
+++ b/app/views/shared/_brand_press_bar.html.erb
@@ -26,6 +26,9 @@
 
     <div class="collapse navbar-collapse" id="brand-bar-nav">
       <div class="navbar-right">
+        <% if navigation_block(press_subdomain).present? %>
+          <%= navigation_block(press_subdomain).html_safe %>
+        <% end %>
         <% if current_user && show_site_actions? %>
           <%= render 'shared/my_actions' %>
         <% elsif current_institutions? %>

--- a/app/views/shared/_brand_press_jumbotron.html.erb
+++ b/app/views/shared/_brand_press_jumbotron.html.erb
@@ -1,4 +1,5 @@
 <!-- Main jumbotron for a primary heading image -->
+    <% unless @press.navigation_block.present? %>
     <div class="jumbotron">
       <h1 class="sr-only"><%= @press.name %></h1>
       <div class="container">
@@ -28,3 +29,4 @@
         <% end %>
       </div>
     </div>
+    <% end %>

--- a/db/migrate/20200113154152_add_navigation_to_presses.rb
+++ b/db/migrate/20200113154152_add_navigation_to_presses.rb
@@ -1,0 +1,5 @@
+class AddNavigationToPresses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :presses, :navigation_block, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191118141530) do
+ActiveRecord::Schema.define(version: 20200113154152) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -370,6 +370,7 @@ ActiveRecord::Schema.define(version: 20191118141530) do
     t.boolean "watermark", default: false
     t.boolean "doi_creation", default: false
     t.string "readership_map_url"
+    t.text "navigation_block"
     t.index ["parent_id"], name: "index_presses_on_parent_id"
   end
 


### PR DESCRIPTION
If the nav block exists, don't show the jumbotron

HELIO-3102, HELIO-3103

I think I'd like to merge this now so we can put it on preview and iterate on it. If we need to put it into production via a hotfix (which we might not even have to do) we can cherry-pick out the commit.