### PR TITLE
Crossref mime_types for file_sets that are 'text/csv'

### DIFF
--- a/app/services/crossref/file_set_metadata.rb
+++ b/app/services/crossref/file_set_metadata.rb
@@ -49,7 +49,7 @@ module Crossref
         fragment = Nokogiri::XML.fragment(@component_file)
         fragment.at_css('title').content = presenter.page_title
         fragment.at_css('description').content = description(presenter)
-        fragment.at_css('format').attribute('mime_type').value = presenter.mime_type
+        fragment.at_css('format').attribute('mime_type').value = mime_type(presenter.mime_type)
         fragment.at_css('doi').content = doi(presenter, index)
         fragment.at_css('resource').content = presenter.handle_url
         document.at_css('component_list') << fragment
@@ -76,6 +76,16 @@ module Crossref
       file_set_doi = "#{work.doi}.cmp.#{index + 1}"
       file_sets_to_save[presenter.id] = { doi: file_set_doi }
       file_set_doi
+    end
+
+    def mime_type(mime)
+      # Why can't you have "text/csv" as a valid mime_type in crossref?
+      # Who knows? But you can't, sadly.
+      # http://data.crossref.org/reports/help/schema_doc/doi_resources4.3.6/4_3_6.html#mime_type.atts
+      # https://tools.lib.umich.edu/jira/browse/HELIO-3163
+      # This is of course not right, but what can you do?
+      return "application/vnd.ms-excel" if mime == "text/csv"
+      mime
     end
 
     private

--- a/spec/services/crossref/file_set_metadata_spec.rb
+++ b/spec/services/crossref/file_set_metadata_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Crossref::FileSetMetadata do
                        creator_tesim: ["Last, First"],
                        contributor_tesim: ["First Last", "A Place", "Actor, An (actor)"],
                        caption_tesim: ["FS 3 Caption"],
-                       mime_type_ssi: "image/jpg")
+                       mime_type_ssi: "text/csv")
   end
 
   # will be skipped: no dois for epubs
@@ -134,10 +134,12 @@ RSpec.describe Crossref::FileSetMetadata do
         expect(subject.xpath("//component_list/component")[i].at_css('title').content).to eq fs.title.first
         if i == 2
           expect(subject.xpath("//component_list/component")[i].at_css('description').content).to eq fs.caption.first + " #{names}"
+          expect(subject.xpath("//component_list/component")[i].at_css('format').attribute('mime_type').value).to eq "application/vnd.ms-excel"
         else
           expect(subject.xpath("//component_list/component")[i].at_css('description').content).to eq fs.description.first + " #{names}"
+          expect(subject.xpath("//component_list/component")[i].at_css('format').attribute('mime_type').value).to eq fs.mime_type
         end
-        expect(subject.xpath("//component_list/component")[i].at_css('format').attribute('mime_type').value).to eq fs.mime_type
+
         expect(subject.xpath("//component_list/component")[i].at_css('doi').content).to eq "#{monograph.doi}.cmp.#{i + 1}"
         expect(subject.xpath("//component_list/component")[i].at_css('resource').content).to eq "https://hdl.handle.net/2027/fulcrum.#{fs.id}"
       end


### PR DESCRIPTION
has to be 'application/vnd.ms-excel' for submissions.
HELIO-3163

I've submitted a "fixed" xml file to crossref with the new mime_type and it works fine. Should be fine to just merge this.