### PR TITLE
pdf_ebooks unpacked onto /derivatives are linearized

### DIFF
--- a/spec/jobs/unpack_job_spec.rb
+++ b/spec/jobs/unpack_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe UnpackJob, type: :job do
 
       it "makes the pdf_ebook derivative" do
         described_class.perform_now(pdf_ebook.id, 'pdf_ebook')
-        expect(File.exist?("#{root_path}.pdf"))
+        expect(File.exist?("#{root_path}.pdf")).to be true
       end
     end
 


### PR DESCRIPTION
HELIO-3165

Put this branch on staging, ran the heliotrope:unpack_pdf_ebooks task and the resulting pdfs are linearized. Seems to work ok.