### PR TITLE
Resolves HELIO-3130 Changes to API to support find component by noid.

### DIFF
--- a/app/controllers/api/v1/components_controller.rb
+++ b/app/controllers/api/v1/components_controller.rb
@@ -6,13 +6,25 @@ module API
     class ComponentsController < API::ApplicationController
       before_action :set_component, only: %i[show update destroy]
 
-      # Get component by identifier
-      # @example
-      #   get /api/component?identifier=String
-      # @param [Hash] params { identifier: String }
-      # @return [ActionDispatch::Response] {Greensub::Component} (see {show})
+      # @overload find
+      #   Get component by identifier
+      #   @example
+      #     get /api/component?identifier=String
+      #   @param [Hash] params { identifier: String }
+      #   @return [ActionDispatch::Response] {Greensub::Component} (see {show})
+      # @overload find
+      #   Get component by noid
+      #   @example
+      #     get /api/component?noid=String
+      #   @param [Hash] params { noid: String }
+      #   @return [ActionDispatch::Response] {Greensub::Component} (see {show})
       def find
-        @component = Greensub::Component.find_by(identifier: params[:identifier])
+        if params[:identifier].present? && params[:noid].present?
+          @component = Greensub::Component.find_by(identifier: params[:identifier], noid: params[:noid])
+        else
+          @component = Greensub::Component.find_by(identifier: params[:identifier]) if params[:identifier].present?
+          @component ||= Greensub::Component.find_by(noid: params[:noid]) if params[:noid].present?
+        end
         return head :not_found if @component.blank?
         render :show
       end

--- a/spec/requests/api/v1/components_spec.rb
+++ b/spec/requests/api/v1/components_spec.rb
@@ -38,16 +38,55 @@ RSpec.describe "Components", type: :request do
     before { allow_any_instance_of(API::ApplicationController).to receive(:authorize_request).and_return(nil) }
 
     describe 'GET /api/v1/component' do
-      it 'non existing not_found' do
-        get api_find_component_path, params: { identifier: 'identifier' }, headers: headers
+      it 'non existing find by identifier not_found' do
+        get api_find_component_path, params: { identifier: 'identifier', noid: 'noid' }, headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:not_found)
         expect(response.body).to be_empty
         expect(Greensub::Component.count).to eq(0)
       end
 
-      it 'existing ok' do
+      it 'non existing find by noid not_found' do
+        get api_find_component_path, params: { noid: 'noid' }, headers: headers
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to be_empty
+        expect(Greensub::Component.count).to eq(0)
+      end
+
+      it 'existing find by identifier and noid ok' do
+        get api_find_component_path, params: { identifier: component.identifier, noid: component.noid }, headers: headers
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response_body).to eq(component_obj(component: component))
+        expect(Greensub::Component.count).to eq(1)
+      end
+
+      it 'existing find by identifier and wrong noid not_found' do
+        get api_find_component_path, params: { identifier: component.identifier, noid: 'noid' }, headers: headers
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to be_empty
+        expect(Greensub::Component.count).to eq(1)
+      end
+
+      it 'existing find by wrong identifier and noid not_found' do
+        get api_find_component_path, params: { identifier: 'identifier', noid: component.noid }, headers: headers
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to be_empty
+        expect(Greensub::Component.count).to eq(1)
+      end
+
+      it 'existing find by identifier ok' do
         get api_find_component_path, params: { identifier: component.identifier }, headers: headers
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response_body).to eq(component_obj(component: component))
+        expect(Greensub::Component.count).to eq(1)
+      end
+
+      it 'existing find by noid ok' do
+        get api_find_component_path, params: { noid: component.noid }, headers: headers
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
         expect(response_body).to eq(component_obj(component: component))


### PR DESCRIPTION
If identifier and noid are both given then find component by both fields a.k.a. both must match for component to be found.