### PR TITLE
pdf_ebooks should be "unpacked" when re-versioned

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -55,7 +55,7 @@ class CharacterizeJob < ApplicationJob
     if kind.blank? && file_set.parent&.press == 'heb'
       kind = maybe_set_featured_representative(file_set)
     end
-    if kind.present? && ['epub', 'webgl'].include?(kind)
+    if kind.present? && ['epub', 'webgl', 'pdf_ebook'].include?(kind)
       UnpackJob.perform_later(file_set.id, kind)
     elsif /^interactive map$/i.match?(file_set.resource_type.first)
       UnpackJob.perform_later(file_set.id, 'interactive_map')

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -137,7 +137,7 @@ describe CharacterizeJob do
           create(:featured_representative, work_id: monograph.id, file_set_id: file_set.id, kind: kind)
           described_class.perform_now(file_set, file.id)
           case kind
-          when 'epub', 'webgl'
+          when 'epub', 'webgl', 'pdf_ebook'
             expect(UnpackJob).to have_received(:perform_later).with(file_set.id, kind)
           else
             expect(UnpackJob).not_to have_received(:perform_later).with(file_set.id, kind)


### PR DESCRIPTION
~Browsers should use the new version, not their cached version.~
(not sure if the client caching stuff is working right yet. let's get this obvious fix into production at least)

HELIO-3196