### PR TITLE
Resolves HELIO-3216 Display facets for admin/editor users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,10 +71,6 @@ class User < ApplicationRecord
     Guest.new(user_key: user_key)
   end
 
-  def role?
-    roles.any?
-  end
-
   # Override Hydra
   # current_user.groups is used in lot of places like
   # blacklight-access-controls, hydra-access-controls, hyrax.
@@ -97,12 +93,20 @@ class User < ApplicationRecord
     end
   end
 
+  def role?
+    roles.any?
+  end
+
   def press_roles
     roles.where(resource_type: 'Press')
   end
 
   def admin_roles
     press_roles.where(role: 'admin')
+  end
+
+  def editor_roles
+    press_roles.where(role: 'editor')
   end
 
   # Presses for which this user is an admin

--- a/app/services/sighrax.rb
+++ b/app/services/sighrax.rb
@@ -99,8 +99,20 @@ module Sighrax # rubocop:disable Metrics/ModuleLength
       ability.can?(action, target.noid)
     end
 
+    # Role Helpers
+
     def platform_admin?(actor)
       actor.is_a?(User) && actor.platform_admin? && Incognito.allow_platform_admin?(actor)
+    end
+
+    def press_admin?(actor, press)
+      return false unless actor.is_a?(User)
+      actor.admin_roles.where(resource: press).any?
+    end
+
+    def press_editor?(actor, press)
+      return false unless actor.is_a?(User)
+      actor.editor_roles.where(resource: press).any?
     end
 
     # Entity Helpers

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
       end
     end
 
-    factory :editor do
+    factory :press_editor do
       after(:create) do |user, evaluator|
         user.roles.create role: 'editor', resource: evaluator.press
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -141,8 +141,8 @@ describe Ability do
     end
 
     describe "RolePresenter" do
-      let(:my_press_user) { create(:editor, press: my_press) }
-      let(:other_press_user) { create(:editor, press: other_press) }
+      let(:my_press_user) { create(:press_editor, press: my_press) }
+      let(:other_press_user) { create(:press_editor, press: other_press) }
 
       it { is_expected.to     be_able_to(:read, RolePresenter.new(current_user.roles.first, current_user, current_user)) }
       it { is_expected.to     be_able_to(:read, RolePresenter.new(my_press_user.roles.first, my_press_user, current_user)) }
@@ -157,8 +157,8 @@ describe Ability do
     end
 
     describe "UserPresenter" do
-      let(:my_press_user) { create(:editor, press: my_press) }
-      let(:other_press_user) { create(:editor, press: other_press) }
+      let(:my_press_user) { create(:press_editor, press: my_press) }
+      let(:other_press_user) { create(:press_editor, press: other_press) }
 
       it { is_expected.to     be_able_to(:read, UserPresenter.new(current_user, current_user)) }
       it { is_expected.to     be_able_to(:read, UserPresenter.new(my_press_user, current_user)) }
@@ -172,7 +172,7 @@ describe Ability do
 
   describe 'a press editor' do
     let(:my_press) { create(:press) }
-    let(:current_user) { create(:editor, press: my_press) }
+    let(:current_user) { create(:press_editor, press: my_press) }
     let(:monograph_for_my_press) { Monograph.new(press: my_press.subdomain) }
 
     it do
@@ -187,8 +187,8 @@ describe Ability do
     end
 
     describe "RolePresenter" do
-      let(:my_press_user) { create(:editor, press: my_press) }
-      let(:other_press_user) { create(:editor, press: create(:press)) }
+      let(:my_press_user) { create(:press_editor, press: my_press) }
+      let(:other_press_user) { create(:press_editor, press: create(:press)) }
 
       it { is_expected.to     be_able_to(:read, RolePresenter.new(current_user.roles.first, current_user, current_user)) }
       it { is_expected.not_to be_able_to(:read, RolePresenter.new(my_press_user.roles.first, my_press_user, current_user)) }
@@ -203,8 +203,8 @@ describe Ability do
     end
 
     describe "UserPresenter" do
-      let(:my_press_user) { create(:editor, press: my_press) }
-      let(:other_press_user) { create(:editor, press: create(:press)) }
+      let(:my_press_user) { create(:press_editor, press: my_press) }
+      let(:other_press_user) { create(:press_editor, press: create(:press)) }
 
       it { is_expected.to     be_able_to(:read, UserPresenter.new(current_user, current_user)) }
       it { is_expected.not_to be_able_to(:read, UserPresenter.new(my_press_user, current_user)) }
@@ -282,7 +282,7 @@ describe Ability do
     end
 
     describe "RolePresenter" do
-      let(:another_user) { create(:editor, press: create(:press)) }
+      let(:another_user) { create(:press_editor, press: create(:press)) }
 
       it { is_expected.to     be_able_to(:read, RolePresenter.new(current_user.roles.first, current_user, current_user)) }
       it { is_expected.not_to be_able_to(:read, RolePresenter.new(another_user.roles.first, another_user, current_user)) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,24 +35,6 @@ RSpec.describe User do
     it { is_expected.to eq 0 }
   end
 
-  describe '#role?' do
-    subject { user.role? }
-
-    let(:user) { create(:user) }
-
-    before { Role.delete_all }
-
-    it { is_expected.to be false }
-
-    context 'role' do
-      let(:role) { create(:role, user: user) }
-
-      before { role }
-
-      it { is_expected.to be true }
-    end
-  end
-
   describe '#presses' do
     subject { user.presses }
 
@@ -67,6 +49,76 @@ RSpec.describe User do
     end
 
     it { is_expected.to eq [press1, press2] }
+  end
+
+  describe '#guest' do
+    subject { described_class.guest(user_key: email) }
+
+    let(:email) { 'wolverine@umich.edu' }
+
+    it { is_expected.to be_a_kind_of(described_class) }
+
+    it { is_expected.to be_an_instance_of(Guest) }
+
+    it { expect(subject.email).to eq(email) }
+  end
+
+  describe '#groups' do
+    let(:press1) { create(:press, subdomain: 'red') }
+    let(:press2) { create(:press, subdomain: 'blue') }
+
+    let(:admin) { create(:user) }
+    let(:editor) { create(:user) }
+    let(:platform_admin) { create(:platform_admin) }
+
+    before do
+      Press.delete_all
+      Role.delete_all
+      create(:role, resource: press1, user: admin, role: 'admin')
+      create(:role, resource: press2, user: editor, role: 'editor')
+    end
+
+    it "returns the right groups for users" do
+      expect(admin.groups).to eq ["red_admin"]
+      expect(editor.groups).to eq ["blue_editor"]
+      expect(platform_admin.groups).to eq ["blue_admin", "blue_editor", "red_admin", "red_editor", "admin"]
+    end
+  end
+
+  context 'roles' do
+    let(:user) { create(:user) }
+
+    before { Role.delete_all }
+
+    it { expect(user.role?).to be false }
+
+    context 'role' do
+      let(:user) { create(:platform_admin) }
+
+      it { expect(user.role?).to be true }
+
+      context '#press_roles' do
+        it { expect(user.press_roles).to be_empty }
+        it { expect(user.admin_roles).to be_empty }
+        it { expect(user.editor_roles).to be_empty }
+
+        context '#admin_roles' do
+          let(:user) { create(:press_admin) }
+
+          it { expect(user.press_roles).not_to be_empty }
+          it { expect(user.admin_roles).not_to be_empty }
+          it { expect(user.editor_roles).to be_empty }
+        end
+
+        context '#editor_roles' do
+          let(:user) { create(:press_editor) }
+
+          it { expect(user.press_roles).not_to be_empty }
+          it { expect(user.admin_roles).to be_empty }
+          it { expect(user.editor_roles).not_to be_empty }
+        end
+      end
+    end
   end
 
   describe '#admin_presses' do
@@ -105,28 +157,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#groups' do
-    let(:press1) { create(:press, subdomain: 'red') }
-    let(:press2) { create(:press, subdomain: 'blue') }
-
-    let(:admin) { create(:user) }
-    let(:editor) { create(:user) }
-    let(:platform_admin) { create(:platform_admin) }
-
-    before do
-      Press.delete_all
-      Role.delete_all
-      create(:role, resource: press1, user: admin, role: 'admin')
-      create(:role, resource: press2, user: editor, role: 'editor')
-    end
-
-    it "returns the right groups for users" do
-      expect(admin.groups).to eq ["red_admin"]
-      expect(editor.groups).to eq ["blue_editor"]
-      expect(platform_admin.groups).to eq ["blue_admin", "blue_editor", "red_admin", "red_editor", "admin"]
-    end
-  end
-
   describe '#token' do
     subject { user.token }
 
@@ -144,30 +174,6 @@ RSpec.describe User do
       expect(user.token).not_to eq(old_token)
       expect(user.token).to eq(JsonWebToken.encode(email: user.email, pin: user.encrypted_password))
     end
-  end
-
-  describe '#guest' do
-    subject { described_class.guest(user_key: email) }
-
-    let(:email) { 'wolverine@umich.edu' }
-
-    it { is_expected.to be_a_kind_of(described_class) }
-
-    it { is_expected.to be_an_instance_of(Guest) }
-
-    it { expect(subject.email).to eq(email) }
-  end
-
-  it '#grants?' do
-    user = create(:user)
-    product = create(:product)
-    expect(user.grants?).to be false
-
-    Greensub.subscribe(subscriber: user, target: product)
-    expect(user.grants?).to be true
-
-    Greensub.unsubscribe(subscriber: user, target: product)
-    expect(user.grants?).to be false
   end
 
   describe '#identifier' do
@@ -193,22 +199,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#agent_type' do
-    subject { user.agent_type }
-
-    let(:user) { build(:user) }
-
-    it { is_expected.to eq :User }
-  end
-
-  describe '#agent_id' do
-    subject { user.agent_id }
-
-    let(:user) { build(:user) }
-
-    it { is_expected.to be user.id }
-  end
-
   describe '#institutions' do
     subject { user.institutions }
 
@@ -223,5 +213,33 @@ RSpec.describe User do
     let(:user) { build(:user) }
 
     it { is_expected.to be nil }
+  end
+
+  it '#grants?' do
+    user = create(:user)
+    product = create(:product)
+    expect(user.grants?).to be false
+
+    Greensub.subscribe(subscriber: user, target: product)
+    expect(user.grants?).to be true
+
+    Greensub.unsubscribe(subscriber: user, target: product)
+    expect(user.grants?).to be false
+  end
+
+  describe '#agent_type' do
+    subject { user.agent_type }
+
+    let(:user) { build(:user) }
+
+    it { is_expected.to eq :User }
+  end
+
+  describe '#agent_id' do
+    subject { user.agent_id }
+
+    let(:user) { build(:user) }
+
+    it { is_expected.to be user.id }
   end
 end

--- a/spec/services/sighrax_spec.rb
+++ b/spec/services/sighrax_spec.rb
@@ -398,7 +398,9 @@ RSpec.describe Sighrax do
         end
       end
     end
+  end
 
+  context 'Role Helpers' do
     describe '#platform_admin?' do
       subject { described_class.platform_admin?(actor) }
 
@@ -430,6 +432,70 @@ RSpec.describe Sighrax do
 
             it { is_expected.to be false }
           end
+        end
+      end
+    end
+
+    describe '#press_admin?' do
+      subject { described_class.press_admin?(actor, press) }
+
+      let(:actor) { double('actor') }
+      let(:press) { instance_double(Press, 'press') }
+      let(:user) { false }
+      let(:admins) { instance_double(ActiveRecord::Relation, 'admins') }
+      let(:press_admins) { instance_double(ActiveRecord::Relation, 'press_admins') }
+      let(:any_press_admins) { false }
+
+      before do
+        allow(actor).to receive(:is_a?).with(User).and_return(user)
+        allow(actor).to receive(:admin_roles).and_return(admins)
+        allow(admins).to receive(:where).with(resource: press).and_return(press_admins)
+        allow(press_admins).to receive(:any?).and_return(any_press_admins)
+      end
+
+      it { is_expected.to be false }
+
+      context 'user' do
+        let(:user) { true }
+
+        it { is_expected.to be false }
+
+        context 'press_admin' do
+          let(:any_press_admins) { true }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#press_editor?' do
+      subject { described_class.press_editor?(actor, press) }
+
+      let(:actor) { double('actor') }
+      let(:press) { instance_double(Press, 'press') }
+      let(:user) { false }
+      let(:editors) { instance_double(ActiveRecord::Relation, 'editors') }
+      let(:press_editors) { instance_double(ActiveRecord::Relation, 'press_editors') }
+      let(:any_press_editors) { false }
+
+      before do
+        allow(actor).to receive(:is_a?).with(User).and_return(user)
+        allow(actor).to receive(:editor_roles).and_return(editors)
+        allow(editors).to receive(:where).with(resource: press).and_return(press_editors)
+        allow(press_editors).to receive(:any?).and_return(any_press_editors)
+      end
+
+      it { is_expected.to be false }
+
+      context 'user' do
+        let(:user) { true }
+
+        it { is_expected.to be false }
+
+        context 'press_editor' do
+          let(:any_press_editors) { true }
+
+          it { is_expected.to be true }
         end
       end
     end

--- a/spec/views/shared/_my_actions.html.erb_spec.rb
+++ b/spec/views/shared/_my_actions.html.erb_spec.rb
@@ -74,7 +74,7 @@ describe 'shared/_my_actions.html.erb' do
   end # specific press admin user
 
   context 'a press editor' do
-    let(:user) { create(:editor) }
+    let(:user) { create(:press_editor) }
 
     context 'within the scope of their press' do
       before do


### PR DESCRIPTION
Easier to verify in your dev environment by creating users with roles for press admin and press editor and a no role user.

By tweaking this line: 

https://github.com/mlibrary/heliotrope/blob/ad51f5c0ce810ecebeaed36285af7187184b1fb0/app/controllers/press_catalog_controller.rb#L78

You can lower the threshold before the facets are displayed.  Make sure you have some draft works and some published works.