### PR TITLE
re-enable clamav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,8 @@ gem 'checkpoint', '~> 1.1.0'
 
 # clamav only in production
 # 2019-11-26: temporary remove -sethajoh
-# gem 'clamav', group: :production
+# And put it back, 2019-02-24, see HELIO-3230
+gem 'clamav', group: :production
 
 # Watermark/Stamp Existing PDF
 gem 'combine_pdf', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
       sequel (~> 5.6)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    clamav (0.4.1)
     clipboard-rails (1.7.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -985,6 +986,7 @@ DEPENDENCIES
   capybara (~> 2.18)
   carrierwave (~> 1.1.0)
   checkpoint (~> 1.1.0)
+  clamav
   coffee-rails (~> 4.2)
   combine_pdf (~> 1.0)
   config


### PR DESCRIPTION
HELIO-3230

This deploys fine on both preview and staging. I *think* we're good, but I've requested that @conorom take a look and merge it (if it's ok) since he was involved when we originally took clamav out.