### PR TITLE
Partially resolves HELIO-478 Use handle service to create handles on creation

### DIFF
--- a/app/controllers/fulcrum_controller.rb
+++ b/app/controllers/fulcrum_controller.rb
@@ -11,12 +11,21 @@ class FulcrumController < ApplicationController
     case params[:cmd]
     when 'ingest'
       ExtractIngestJob.perform_later(params[:token], params[:base], params[:source], params[:target])
+    when 'unpack'
+      UnpackJob.perform_now(params[:noid], params[:kind])
+    when 'handle'
+      case params[:job]
+      when 'create'
+        HandleCreateJob.perform_now(params[:noid])
+      when 'delete'
+        HandleDeleteJob.perform_now(params[:noid])
+      when 'verify'
+        HandleVerifyJob.perform_now(params[:noid])
+      end
     when 'verify'
       AptrustVerifyJob.perform_now(params[:noid])
     when 'deposit'
       AptrustDepositJob.perform_now(params[:noid])
-    when 'unpack'
-      UnpackJob.perform_now(params[:noid], params[:kind])
     when 'reindex_everything'
       ReindexJob.perform_later('everything')
     when 'reindex_monographs'

--- a/app/controllers/handle_deposits_controller.rb
+++ b/app/controllers/handle_deposits_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class HandleDepositsController < ApplicationController
+  def index
+    @handle_deposits = HandleDeposit.filter(filtering_params(params)).order(sigma: :desc, verified: :asc, action: :desc, noid: :asc).page(params[:page])
+  end
+
+  private
+
+    def filtering_params(params)
+      params.slice(:noid_like, :action_like, :verified_like, :sigma_like)
+    end
+end

--- a/app/jobs/handle_create_job.rb
+++ b/app/jobs/handle_create_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class HandleCreateJob < ApplicationJob
+  def perform(model_id)
+    model = Sighrax.from_noid(model_id)
+    Rails.logger.warn("HandleCreateJob #{model_id} is NOT kind of Sighrax::Model") unless model.kind_of?(Sighrax::Model)
+    return false unless model.kind_of?(Sighrax::Model)
+    record = HandleDeposit.find_or_create_by(noid: model_id)
+    record.action = 'create'
+    record.verified = false
+    record.save!
+    create_handle(model)
+  rescue StandardError => e
+    Rails.logger.error("HandleCreateJob #{model_id} #{e}")
+    false
+  end
+
+  def create_handle(model)
+    model_url = Sighrax.url(model) || "https://#{model.noid}"
+    service_url = HandleService.value(model.noid)
+    return service_url if /^#{Regexp.escape(model_url)}$/i.match?(service_url)
+    HandleService.update(model.noid, model_url)
+  end
+end

--- a/app/jobs/handle_delete_job.rb
+++ b/app/jobs/handle_delete_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class HandleDeleteJob < ApplicationJob
+  def perform(model_id)
+    model = Sighrax.from_noid(model_id)
+    Rails.logger.warn("HandleDeleteJob #{model_id} is NOT kind of Sighrax::Model") unless model.kind_of?(Sighrax::Model)
+    record = HandleDeposit.find_or_create_by(noid: model_id)
+    record.action = 'delete'
+    record.verified = false
+    record.save!
+    delete_handle(model)
+  rescue StandardError => e
+    Rails.logger.error("HandleDeleteJob #{model_id} #{e}")
+    false
+  end
+
+  def delete_handle(model)
+    HandleService.delete(model.noid)
+  end
+end

--- a/app/jobs/handle_job.rb
+++ b/app/jobs/handle_job.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class HandleJob < ApplicationJob
+  def perform
+    # Delete all action delete verified records older than 30 days ago
+    HandleDeposit.where("updated_at <= ?", HandleJob.thirty_days_ago).where(action: 'delete', verified: true).delete_all
+
+    # Force create action for all existing models
+    model_docs.each do |model_doc|
+      record = HandleDeposit.find_or_create_by(noid: model_doc['id'])
+      record.touch # rubocop:disable Rails/SkipsModelValidations
+      next if /^create$/.match?(record.action)
+
+      record.action = 'create'
+      record.verified = false
+      record.save
+    end
+
+    # Force delete action for all untouched records older than 30 days ago
+    HandleDeposit.where("updated_at <= ?", HandleJob.thirty_days_ago).where.not(action: 'delete').each do |record|
+      record.action = 'delete'
+      record.verified = false
+      record.save
+    end
+
+    # Create handles for existing models
+    HandleDeposit.where(action: 'create', verified: false).each do |record|
+      HandleCreateJob.perform_now(record.noid)
+    end
+
+    # Delete handles of deleted models
+    HandleDeposit.where(action: 'delete', verified: false).each do |record|
+      HandleDeleteJob.perform_now(record.noid)
+    end
+
+    # Verify creation/deletion of handles
+    HandleDeposit.where(verified: false).each do |record|
+      HandleVerifyJob.perform_now(record.noid)
+    end
+
+    # Return true to simplify unit test a.k.a. it { is_expected.to be true }
+    true
+  end
+
+  def model_docs
+    ActiveFedora::SolrService.query(
+      "+has_model_ssim:[* TO *]",
+      fl: %w[id has_model_ssim],
+      rows: 100_000
+    ) || []
+  end
+
+  # Makes unit test easier to write
+  def self.thirty_days_ago
+    30.days.ago
+  end
+end

--- a/app/jobs/handle_verify_job.rb
+++ b/app/jobs/handle_verify_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class HandleVerifyJob < ApplicationJob
+  def perform(model_id) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    model = Sighrax.from_noid(model_id)
+    Rails.logger.warn("HandleVerifyJob #{model_id} is NOT kind of Sighrax::Model") unless model.kind_of?(Sighrax::Model)
+    record = HandleDeposit.find_by(noid: model_id)
+    Rails.logger.warn("HandleVerifyJob #{model_id} handle deposit record NOT found!") unless record
+    return false unless record
+    return true if record.verified
+    record.verified = rvalue = verify_handle(record.action, model)
+    record.save!
+    rvalue
+  rescue StandardError => e
+    Rails.logger.error("HandleVerifyJob #{model_id} #{e}")
+    false
+  end
+
+  def verify_handle(action, model)
+    case action
+    when 'create'
+      verify_handle_create(model)
+    when 'delete'
+      verify_handle_delete(model)
+    else
+      Rails.logger.error("HandleVerifyJob #{model.noid} action #{action} invalid!!!")
+      false
+    end
+  end
+
+  def verify_handle_create(model)
+    model_url = Sighrax.url(model)
+    model_url ||= "https://www.fulcrum.org/#{model.noid}"
+    service_url = HandleService.value(model.noid)
+    /^#{Regexp.escape(model_url)}$/i.match?(service_url)
+  rescue StandardError => e
+    Rails.logger.error("HandleVerifyJob #{model.noid} verify handle create #{e}")
+    false
+  end
+
+  def verify_handle_delete(model)
+    handle_not_found = "100 : Handle Not Found. (HTTP 404 Not Found)"
+    service_url = HandleService.value(model.noid)
+    /^#{Regexp.escape(handle_not_found)}$/i.match?(service_url)
+  rescue StandardError => e
+    Rails.logger.error("HandleVerifyJob #{model.noid} verify handle delete #{e}")
+    false
+  end
+end

--- a/app/models/handle_deposit.rb
+++ b/app/models/handle_deposit.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HandleDeposit < ApplicationRecord
+  include Filterable
+
+  scope :noid_like, ->(like) { where("noid like ?", "%#{like}%") }
+  scope :action_like, ->(like) { where("action like ?", "%#{like}%") }
+  scope :verified_like, ->(like) { where("verified like ?", "%#{like}%") }
+  scope :sigma_like, ->(like) { where("sigma like ?", "%#{like}%") }
+end

--- a/app/models/sighrax/score.rb
+++ b/app/models/sighrax/score.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 module Sighrax
-  class Score < Model
+  class Score < Work
     private_class_method :new
-
-    def children
-      Array(data['ordered_member_ids_ssim']).map { |noid| Sighrax.from_noid(noid) }
-    end
 
     private
 

--- a/app/models/sighrax/work.rb
+++ b/app/models/sighrax/work.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Sighrax
-  class Monograph < Work
+  class Work < Model
     private_class_method :new
 
-    def epub_featured_representative
-      Sighrax.from_noid(FeaturedRepresentative.find_by(work_id: noid, kind: 'epub')&.file_set_id)
+    def children
+      Array(data['ordered_member_ids_ssim']).map { |noid| Sighrax.from_noid(noid) }
     end
 
     private

--- a/app/services/handle_service.rb
+++ b/app/services/handle_service.rb
@@ -65,4 +65,12 @@ class HandleService
     end
     url
   end
+
+  def self.update(noid, url)
+    "TODO: UPDATE_OR_CREATE HANDLE RECORD"
+  end
+
+  def self.delete(noid)
+    "TODO: DELETE HANDLE RECORD"
+  end
 end

--- a/app/services/sighrax.rb
+++ b/app/services/sighrax.rb
@@ -104,6 +104,19 @@ module Sighrax # rubocop:disable Metrics/ModuleLength
 
     # Entity Helpers
 
+    def url(entity)
+      case entity
+      when Sighrax::Monograph
+        Rails.application.routes.url_helpers.hyrax_monograph_url(entity.noid)
+      when Sighrax::Score
+        Rails.application.routes.url_helpers.hyrax_score_url(entity.noid)
+      when Sighrax::Asset
+        Rails.application.routes.url_helpers.hyrax_file_set_url(entity.noid)
+      else
+        nil
+      end
+    end
+
     def allow_download?(entity)
       return false unless entity.valid?
       return false unless downloadable?(entity)

--- a/app/views/fulcrum/_jobs.html.erb
+++ b/app/views/fulcrum/_jobs.html.erb
@@ -14,6 +14,28 @@
     </form>
   </li>
   <li>
+    <form name="unpack" method="get" action="<%= fulcrum_exec_path(:unpack) %>">
+      <label for="unpack_noid">NOID</label>
+      <input type="text" id="unpack_noid" name="noid" value="validnoid">
+      <label for="unpack_kind">Kind</label>
+      <input type="text" id="unpack_kind" name="kind" value="kind">
+      <button name="submit" type="submit" value="unpack">Unpack</button>
+    </form>
+  </li>
+  <li>
+    <form name="handle" method="get" action="<%= fulcrum_exec_path(:handle) %>">
+      <label for="handle_noid">NOID</label>
+      <input type="text" id="unpack_noid" name="noid" value="validnoid">
+      <label for="job">Action</label>
+      <select name="job" id="job">
+        <option value="create">create</option>
+        <option value="delete">delete</option>
+        <option selected="selected" value="verify">verify</option>
+      </select>
+      <button name="submit" type="submit" value="handle">Handle</button>
+    </form>
+  </li>
+  <li>
     <form name="deposit" method="get" action="<%= fulcrum_exec_path(:deposit) %>">
       <label for="deposit_noid">APTrust Deposit</label>
       <input type="text" id="deposit_noid" name="noid" value="validnoid">
@@ -25,15 +47,6 @@
       <label for="verify_noid">APTrust Verify</label>
       <input type="text" id="verify_noid" name="noid" value="validnoid">
       <button name="submit" type="submit" value="verify">Verify</button>
-    </form>
-  </li>
-  <li>
-    <form name="unpack" method="get" action="<%= fulcrum_exec_path(:unpack) %>">
-      <label for="unpack_noid">NOID</label>
-      <input type="text" id="unpack_noid" name="noid" value="validnoid">
-      <label for="unpack_kind">Kind</label>
-      <input type="text" id="unpack_kind" name="kind" value="kind">
-      <button name="submit" type="submit" value="unpack">Unpack</button>
     </form>
   </li>
   <li>

--- a/app/views/fulcrum/_reports.html.erb
+++ b/app/views/fulcrum/_reports.html.erb
@@ -4,5 +4,6 @@
 <h1>Reports</h1>
 <ul>
   <li><%= link_to "Tombstones", tombstones_path %></li>
+  <li><%= link_to "Handle Deposits", handle_deposits_path %></li>
   <li><%= link_to "COUNTER Reports", customers_path %></li>
 </ul>

--- a/app/views/handle_deposits/index.html.erb
+++ b/app/views/handle_deposits/index.html.erb
@@ -1,0 +1,22 @@
+<p id="notice"><%= notice %></p>
+<div id="maincontent">
+  <h1>Handle Deposits</h1>
+  <div class="col-md-12">
+    <div class="col-md-2">ID</div>
+    <div class="col-md-2">Noid</div>
+    <div class="col-md-3">Action</div>
+    <div class="col-md-3">Verified</div>
+    <div class="col-md-2">Sigma</div>
+  </div>
+  <div class="col-md-12"><hr/></div>
+  <% @handle_deposits.each do |handle_deposit| %>
+    <div class="col-md-12">
+      <div class="col-md-2"><%= "#{handle_deposit.id}" %></div>
+      <div class="col-md-2"><%= "#{handle_deposit.noid}" %></div>
+      <div class="col-md-3"><%= "#{handle_deposit.action}" %></div>
+      <div class="col-md-3"><%= "#{handle_deposit.verified}" %></div>
+      <div class="col-md-2"><%= "#{handle_deposit.sigma}" %></div>
+    </div>
+  <% end %>
+  <div class="col-md-12"><br></div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
       resources :counter_reports, only: %i[index show edit update], constraints: COUNTER_REPORT_ID_CONSTRAINT
     end
     resources :tombstones, only: %i[index]
+    resources :handle_deposits, only: %i[index]
     resource :manifests, path: 'concern/monographs/:id/manifest', only: %i[new edit update create destroy], as: :monograph_manifests
     resource :monograph_manifests, path: 'concern/monographs/:id/manifest', only: [:show] do
       member do

--- a/db/migrate/20200225162723_create_handle_deposits.rb
+++ b/db/migrate/20200225162723_create_handle_deposits.rb
@@ -1,0 +1,11 @@
+class CreateHandleDeposits < ActiveRecord::Migration[5.1]
+  def change
+    create_table :handle_deposits do |t|
+      t.string :noid, unique: true, null: false
+      t.string :action, null: false, default: 'create'
+      t.boolean :verified, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200113154152) do
+ActiveRecord::Schema.define(version: 20200225162723) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -203,6 +203,14 @@ ActiveRecord::Schema.define(version: 20200113154152) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["noid"], name: "index_google_analytics_histories_on_noid"
+  end
+
+  create_table "handle_deposits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "noid", null: false
+    t.string "action", default: "create", null: false
+    t.boolean "verified", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/handle.rake
+++ b/lib/tasks/handle.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+desc 'Update Handle Records'
+namespace :heliotrope do
+  task handle: :environment do
+    HandleJob.perform_later
+    p "HandleJob.perform_later"
+  end
+end

--- a/spec/factories/handle_deposits.rb
+++ b/spec/factories/handle_deposits.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :handle_deposit do
+    sequence(:noid) { |n| format("%09d", n) }
+    sequence(:action) { |n| n.even? ? 'create' : 'delete' }
+  end
+end

--- a/spec/helpers/roles_helper_spec.rb
+++ b/spec/helpers/roles_helper_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RolesHelper, type: :helper do
+  describe "#roles_for_select" do
+    it 'works' do
+      expect(roles_for_select).to eq({ "Admin"=>"admin", "Editor"=>"editor" })
+    end
+  end
+end

--- a/spec/jobs/handle_create_job_spec.rb
+++ b/spec/jobs/handle_create_job_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HandleCreateJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:model_id) { 'validnoid' }
+
+  describe 'job queue' do
+    subject(:job) { described_class.perform_later(model_id) }
+
+    before { allow(Sighrax).to receive(:from_noid).with(model_id).and_call_original }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it 'queues the job' do
+      expect { job }.to have_enqueued_job(described_class).with(model_id).on_queue("default")
+    end
+
+    it 'executes perform' do
+      perform_enqueued_jobs { job }
+      expect(Sighrax).to have_received(:from_noid).with(model_id)
+    end
+  end
+
+  context 'job' do
+    let(:job) { described_class.new }
+
+    describe '#perform' do
+      subject { job.perform(model_id) }
+
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+
+      before do
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn).with("HandleCreateJob #{model_id} is NOT kind of Sighrax::Model")
+        allow(logger).to receive(:error).with("HandleCreateJob #{model_id} StandardError")
+      end
+
+      it 'logs warning' do
+        is_expected.to be false
+        expect(logger).to have_received(:warn).with("HandleCreateJob #{model_id} is NOT kind of Sighrax::Model")
+        expect(logger).not_to have_received(:error).with("HandleCreateJob #{model_id} StandardError")
+      end
+
+      context 'when model' do
+        let(:model) { instance_double(Sighrax::Model, 'model', kind_of?: true, noid: model_id, resource_type: 'Model') }
+        let(:record) { instance_double(HandleDeposit, 'record') }
+        let(:boolean) { double('boolean') }
+
+        before do
+          allow(Sighrax).to receive(:from_noid).with(model_id).and_return(model)
+          allow(HandleDeposit).to receive(:find_or_create_by).with(noid: model_id).and_return(record)
+          allow(record).to receive(:action=).with('create')
+          allow(record).to receive(:verified=).with(false)
+          allow(record).to receive(:save!)
+          allow(job).to receive(:create_handle).with(model).and_return(boolean)
+        end
+
+        it 'returns create handle' do
+          is_expected.to be boolean
+          expect(HandleDeposit).to have_received(:find_or_create_by).with(noid: model_id)
+          expect(record).to have_received(:action=).with('create')
+          expect(record).to have_received(:verified=).with(false)
+          expect(record).to have_received(:save!)
+          expect(logger).not_to have_received(:warn).with("HandleCreateJob #{model_id} is NOT kind of Sighrax::Model")
+          expect(logger).not_to have_received(:error).with("HandleCreateJob #{model_id} StandardError")
+        end
+
+        context 'when standard error' do
+          before { allow(job).to receive(:create_handle).with(model).and_raise(StandardError) }
+
+          it 'logs error' do
+            is_expected.to be false
+            expect(HandleDeposit).to have_received(:find_or_create_by).with(noid: model_id)
+            expect(record).to have_received(:action=).with('create')
+            expect(record).to have_received(:verified=).with(false)
+            expect(record).to have_received(:save!)
+            expect(logger).not_to have_received(:warn).with("HandleCreateJob #{model_id} is NOT kind of Sighrax::Model")
+            expect(logger).to have_received(:error).with("HandleCreateJob #{model_id} StandardError")
+          end
+        end
+      end
+    end
+
+    describe '#create_handle' do
+      subject { job.create_handle(model) }
+
+      let(:model) { instance_double(Sighrax::Model, 'model', noid: model_id) }
+      let(:model_url) { 'model_url' }
+      let(:url) { 'url' }
+      let(:rvalue) { double('rvalue') }
+
+      before do
+        allow(Sighrax).to receive(:url).with(model).and_return(model_url)
+        allow(HandleService).to receive(:value).with(model.noid).and_return(url)
+        allow(HandleService).to receive(:update).with(model.noid, model_url).and_return(rvalue)
+      end
+
+      it 'handle service update' do
+        is_expected.to be rvalue
+        expect(HandleService).to have_received(:value).with(model.noid)
+        expect(HandleService).to have_received(:update).with(model.noid, model_url)
+      end
+
+      context 'handle exist' do
+        let(:url) { model_url }
+
+        it 'handle service value' do
+          is_expected.to eq(model_url)
+          expect(HandleService).to have_received(:value).with(model.noid)
+          expect(HandleService).not_to have_received(:update).with(model.noid, model_url)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/handle_delete_job_spec.rb
+++ b/spec/jobs/handle_delete_job_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HandleDeleteJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:model_id) { 'validnoid' }
+
+  describe 'job queue' do
+    subject(:job) { described_class.perform_later(model_id) }
+
+    before { allow(Sighrax).to receive(:from_noid).with(model_id).and_call_original }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it 'queues the job' do
+      expect { job }.to have_enqueued_job(described_class).with(model_id).on_queue("default")
+    end
+
+    it 'executes perform' do
+      perform_enqueued_jobs { job }
+      expect(Sighrax).to have_received(:from_noid).with(model_id)
+    end
+  end
+
+  context 'job' do
+    let(:job) { described_class.new }
+
+    describe '#perform' do
+      subject { job.perform(model_id) }
+
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+
+      before do
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn).with("HandleDeleteJob #{model_id} is NOT kind of Sighrax::Model")
+        allow(logger).to receive(:error).with("HandleDeleteJob #{model_id} StandardError")
+      end
+
+      it 'logs warning' do
+        is_expected.to eq "TODO: DELETE HANDLE RECORD"
+        expect(logger).to have_received(:warn).with("HandleDeleteJob #{model_id} is NOT kind of Sighrax::Model")
+        expect(logger).not_to have_received(:error).with("HandleDeleteJob #{model_id} StandardError")
+      end
+
+      context 'when model' do
+        let(:model) { instance_double(Sighrax::Model, 'model', kind_of?: true, noid: model_id, resource_type: 'Model') }
+        let(:record) { instance_double(HandleDeposit, 'record') }
+        let(:boolean) { double('boolean') }
+
+        before do
+          allow(Sighrax).to receive(:from_noid).with(model_id).and_return(model)
+          allow(HandleDeposit).to receive(:find_or_create_by).with(noid: model_id).and_return(record)
+          allow(record).to receive(:action=).with('delete')
+          allow(record).to receive(:verified=).with(false)
+          allow(record).to receive(:save!)
+          allow(job).to receive(:delete_handle).with(model).and_return(boolean)
+        end
+
+        it 'returns create handle' do
+          is_expected.to be boolean
+          expect(HandleDeposit).to have_received(:find_or_create_by).with(noid: model_id)
+          expect(record).to have_received(:action=).with('delete')
+          expect(record).to have_received(:verified=).with(false)
+          expect(record).to have_received(:save!)
+          expect(logger).not_to have_received(:warn).with("HandleDeleteJob #{model_id} is NOT kind of Sighrax::Model")
+          expect(logger).not_to have_received(:error).with("HandleDeleteJob #{model_id} StandardError")
+        end
+
+        context 'when standard error' do
+          before { allow(job).to receive(:delete_handle).with(model).and_raise(StandardError) }
+
+          it 'logs error' do
+            is_expected.to be false
+            expect(HandleDeposit).to have_received(:find_or_create_by).with(noid: model_id)
+            expect(record).to have_received(:action=).with('delete')
+            expect(record).to have_received(:verified=).with(false)
+            expect(record).to have_received(:save!)
+            expect(logger).not_to have_received(:warn).with("HandleDeleteJob #{model_id} is NOT kind of Sighrax::Model")
+            expect(logger).to have_received(:error).with("HandleDeleteJob #{model_id} StandardError")
+          end
+        end
+      end
+    end
+
+    describe '#delete_handle' do
+      subject { job.delete_handle(model) }
+
+      let(:model) { instance_double(Sighrax::Model, 'model', noid: model_id) }
+      let(:rvalue) { double('rvalue') }
+
+      before do
+        allow(HandleService).to receive(:delete).with(model.noid).and_return(rvalue)
+      end
+
+      it 'handle service delete' do
+        is_expected.to be rvalue
+        expect(HandleService).to have_received(:delete).with(model.noid)
+      end
+    end
+  end
+end

--- a/spec/jobs/handle_job_spec.rb
+++ b/spec/jobs/handle_job_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HandleJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:model_doc) { { 'id' => 'model_id' } }
+
+  before do
+    allow(HandleDeleteJob).to receive(:perform_now).with(model_doc['id'])
+    allow(HandleCreateJob).to receive(:perform_now).with(model_doc['id'])
+    allow(HandleVerifyJob).to receive(:perform_now).with(model_doc['id'])
+  end
+
+  describe '#thirty_days_ago' do
+    it { expect(described_class.thirty_days_ago < 29.days.ago).to be true }
+    it { expect(described_class.thirty_days_ago > 31.days.ago).to be true }
+  end
+
+  describe 'job queue' do
+    subject(:job) { described_class.perform_later }
+
+    before { allow(ActiveFedora::SolrService).to receive(:query).and_return([model_doc]) }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it 'queues the job' do
+      expect { job }.to have_enqueued_job(described_class).on_queue("default")
+    end
+
+    it 'executes perform' do
+      perform_enqueued_jobs { job }
+      expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+      expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+      expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+      expect(HandleDeposit.all.count).to eq(1)
+      HandleDeposit.all.each do |record|
+        expect(record.noid).to eq(model_doc['id'])
+        expect(record.action).to eq('create')
+        expect(record.verified).to be false
+      end
+    end
+  end
+
+  context 'job' do
+    let(:job) { described_class.new }
+
+    describe '#perform' do
+      subject { job.perform }
+
+      let(:model_docs) { [] }
+
+      before { allow(job).to receive(:model_docs).and_return(model_docs) }
+
+      it 'does nothing' do
+        is_expected.to be true
+        expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+        expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+        expect(HandleVerifyJob).not_to have_received(:perform_now).with(model_doc['id'])
+        expect(HandleDeposit.all.count).to eq(0)
+      end
+
+      context 'when model doc' do
+        let(:model_docs) { [model_doc] }
+
+        it 'creates and verifies creation of handle' do
+          is_expected.to be true
+          expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeposit.all.count).to eq(1)
+          HandleDeposit.all.each do |record|
+            expect(record.noid).to eq(model_doc['id'])
+            expect(record.action).to eq('create')
+            expect(record.verified).to be false
+          end
+        end
+      end
+
+      context 'when delete not verified' do
+        before { HandleDeposit.create(noid: model_doc['id'], action: 'delete') }
+
+        it 'deletes' do
+          is_expected.to be true
+          expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeleteJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeposit.all.count).to eq(1)
+          HandleDeposit.all.each do |record|
+            expect(record.noid).to eq(model_doc['id'])
+            expect(record.action).to eq('delete')
+            expect(record.verified).to be false
+          end
+        end
+
+        context 'when model doc' do
+          let(:model_docs) { [model_doc] }
+
+          it 'overrides delete with create' do
+            is_expected.to be true
+            expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('create')
+              expect(record.verified).to be false
+            end
+          end
+        end
+      end
+
+      context 'when delete verified' do
+        before { HandleDeposit.create(noid: model_doc['id'], action: 'delete', verified: true) }
+
+        it 'does nothing' do
+          is_expected.to be true
+          expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleVerifyJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeposit.all.count).to eq(1)
+          HandleDeposit.all.each do |record|
+            expect(record.noid).to eq(model_doc['id'])
+            expect(record.action).to eq('delete')
+            expect(record.verified).to be true
+          end
+        end
+
+        context 'when model doc' do
+          let(:model_docs) { [model_doc] }
+
+          it 'overrides delete with create' do
+            is_expected.to be true
+            expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('create')
+              expect(record.verified).to be false
+            end
+          end
+        end
+      end
+
+      context 'when create not verified' do
+        before { HandleDeposit.create(noid: model_doc['id'], action: 'create') }
+
+        it 'creates' do
+          is_expected.to be true
+          expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeposit.all.count).to eq(1)
+          HandleDeposit.all.each do |record|
+            expect(record.noid).to eq(model_doc['id'])
+            expect(record.action).to eq('create')
+            expect(record.verified).to be false
+          end
+        end
+
+        context 'when model doc' do
+          let(:model_docs) { [model_doc] }
+
+          it 'creates' do
+            is_expected.to be true
+            expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('create')
+              expect(record.verified).to be false
+            end
+          end
+        end
+      end
+
+      context 'when create verified' do
+        before { HandleDeposit.create(noid: model_doc['id'], action: 'create', verified: true) }
+
+        it 'does nothing' do
+          is_expected.to be true
+          expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleVerifyJob).not_to have_received(:perform_now).with(model_doc['id'])
+          expect(HandleDeposit.all.count).to eq(1)
+          HandleDeposit.all.each do |record|
+            expect(record.noid).to eq(model_doc['id'])
+            expect(record.action).to eq('create')
+            expect(record.verified).to be true
+          end
+        end
+
+        context 'when model doc' do
+          let(:model_docs) { [model_doc] }
+
+          it 'does nothing' do
+            is_expected.to be true
+            expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('create')
+              expect(record.verified).to be true
+            end
+          end
+        end
+      end
+
+      context 'when record older than 30 days' do
+        before { allow(described_class).to receive(:thirty_days_ago).and_return(31.days.from_now) }
+
+        context 'when delete not verified' do
+          before { HandleDeposit.create(noid: model_doc['id'], action: 'delete') }
+
+          it 'deletes handle' do
+            is_expected.to be true
+            expect(HandleDeleteJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('delete')
+              expect(record.verified).to be false
+            end
+          end
+        end
+
+        context 'when delete verified' do
+          before { HandleDeposit.create(noid: model_doc['id'], action: 'delete', verified: true) }
+
+          it 'deletes record' do
+            is_expected.to be true
+            expect(HandleDeleteJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(0)
+          end
+        end
+
+        context 'when create not verified' do
+          before { HandleDeposit.create(noid: model_doc['id'], action: 'create') }
+
+          it 'overrides create and deletes handle' do
+            is_expected.to be true
+            expect(HandleDeleteJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('delete')
+              expect(record.verified).to be false
+            end
+          end
+        end
+
+        context 'when create verified' do
+          before { HandleDeposit.create(noid: model_doc['id'], action: 'create', verified: true) }
+
+          it 'overrides create and deletes handle' do
+            is_expected.to be true
+            expect(HandleDeleteJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleCreateJob).not_to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleVerifyJob).to have_received(:perform_now).with(model_doc['id'])
+            expect(HandleDeposit.all.count).to eq(1)
+            HandleDeposit.all.each do |record|
+              expect(record.noid).to eq(model_doc['id'])
+              expect(record.action).to eq('delete')
+              expect(record.verified).to be false
+            end
+          end
+        end
+      end
+    end
+
+    describe '#model_docs' do
+      subject { job.model_docs }
+
+      it 'is empty' do
+        is_expected.to be_empty
+      end
+
+      context 'when models' do
+        let(:model_docs) { [] }
+
+        before do
+          allow(ActiveFedora::SolrService).to receive(:query)
+            .with("+has_model_ssim:[* TO *]",
+              fl: %w[id has_model_ssim],
+              rows: 100_000)
+            .and_return(model_docs)
+        end
+
+        it 'returns model docs' do
+          is_expected.to be model_docs
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/handle_verify_job_spec.rb
+++ b/spec/jobs/handle_verify_job_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HandleVerifyJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:model_id) { 'validnoid' }
+
+  describe 'job queue' do
+    subject(:job) { described_class.perform_later(model_id) }
+
+    before { allow(Sighrax).to receive(:from_noid).with(model_id).and_call_original }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it 'queues the job' do
+      expect { job }.to have_enqueued_job(described_class).with(model_id).on_queue("default")
+    end
+
+    it 'executes perform' do
+      perform_enqueued_jobs { job }
+      expect(Sighrax).to have_received(:from_noid).with(model_id)
+    end
+  end
+
+  context 'job' do
+    let(:job) { described_class.new }
+
+    describe '#perform' do
+      subject { job.perform(model_id) }
+
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+      let(:not_kind_msg) { "HandleVerifyJob #{model_id} is NOT kind of Sighrax::Model" }
+      let(:not_found_msg) { "HandleVerifyJob #{model_id} handle deposit record NOT found!" }
+      let(:error_msg) { "HandleVerifyJob #{model_id} StandardError" }
+
+      before do
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn).with(not_kind_msg)
+        allow(logger).to receive(:warn).with(not_found_msg)
+        allow(logger).to receive(:error).with(error_msg)
+      end
+
+      it 'logs warnings' do
+        is_expected.to be false
+        expect(logger).to have_received(:warn).with(not_kind_msg)
+        expect(logger).to have_received(:warn).with(not_found_msg)
+        expect(logger).not_to have_received(:error).with(error_msg)
+      end
+
+      context 'when model' do
+        let(:model) { instance_double(Sighrax::Model, 'model', kind_of?: true, noid: model_id, resource_type: 'Model') }
+        let(:record) { nil }
+
+        before do
+          allow(Sighrax).to receive(:from_noid).with(model_id).and_return(model)
+          allow(HandleDeposit).to receive(:find_by).with(noid: model_id).and_return(record)
+        end
+
+        it 'nil record' do
+          is_expected.to be false
+          expect(logger).not_to have_received(:warn).with(not_kind_msg)
+          expect(logger).to have_received(:warn).with(not_found_msg)
+          expect(logger).not_to have_received(:error).with(error_msg)
+        end
+
+        context 'when record' do
+          let(:record) { instance_double(HandleDeposit, 'record', noid: model_id, action: 'action', verified: verified) }
+          let(:verified) { true }
+          let(:boolean) { double('boolean') }
+
+          before do
+            allow(HandleDeposit).to receive(:find_by).with(noid: model_id).and_return(record)
+            allow(job).to receive(:verify_handle).with(record.action, model).and_return(boolean)
+          end
+
+          it 'does nothing' do
+            is_expected.to be true
+            expect(job).not_to have_received(:verify_handle).with(record.action, model)
+            expect(logger).not_to have_received(:warn).with(not_kind_msg)
+            expect(logger).not_to have_received(:warn).with(not_found_msg)
+            expect(logger).not_to have_received(:error).with(error_msg)
+          end
+
+          context 'when not verified' do
+            let(:verified) { false }
+
+            before do
+              allow(record).to receive(:verified=).with(boolean)
+              allow(record).to receive(:save!)
+            end
+
+            it 'returns verify handle' do
+              is_expected.to be boolean
+              expect(job).to have_received(:verify_handle).with(record.action, model)
+              expect(record).to have_received(:verified=).with(boolean)
+              expect(record).to have_received(:save!)
+              expect(logger).not_to have_received(:warn).with(not_kind_msg)
+              expect(logger).not_to have_received(:warn).with(not_found_msg)
+              expect(logger).not_to have_received(:error).with(error_msg)
+            end
+
+            context 'standard error' do
+              before { allow(record).to receive(:save!).and_raise(StandardError) }
+
+              it 'returns' do
+                is_expected.to be false
+                expect(job).to have_received(:verify_handle).with(record.action, model)
+                expect(record).to have_received(:verified=).with(boolean)
+                expect(record).to have_received(:save!)
+                expect(logger).not_to have_received(:warn).with(not_kind_msg)
+                expect(logger).not_to have_received(:warn).with(not_found_msg)
+                expect(logger).to have_received(:error).with(error_msg)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe '#verify_handle' do
+      subject { job.verify_handle(action, model) }
+
+      let(:action) { 'action' }
+      let(:model) { instance_double(Sighrax::Model, 'model', noid: model_id) }
+      let(:boolean) { double('boolean') }
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+      let(:error_msg) { "HandleVerifyJob #{model_id} action #{action} invalid!!!" }
+
+
+      before do
+        allow(job).to receive(:verify_handle_create).with(model).and_return(boolean)
+        allow(job).to receive(:verify_handle_delete).with(model).and_return(boolean)
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error).with(error_msg)
+      end
+
+      it 'logs error' do
+        is_expected.to be false
+        expect(job).not_to have_received(:verify_handle_create).with(model)
+        expect(job).not_to have_received(:verify_handle_delete).with(model)
+        expect(logger).to have_received(:error).with(error_msg)
+      end
+
+      context 'when action create' do
+        let(:action) { 'create' }
+
+        it 'verify handle create' do
+          is_expected.to be boolean
+          expect(job).to have_received(:verify_handle_create).with(model)
+          expect(job).not_to have_received(:verify_handle_delete).with(model)
+          expect(logger).not_to have_received(:error).with(error_msg)
+        end
+      end
+
+      context 'when action delete' do
+        let(:action) { 'delete' }
+
+        it 'verify handle delete' do
+          is_expected.to be boolean
+          expect(job).not_to have_received(:verify_handle_create).with(model)
+          expect(job).to have_received(:verify_handle_delete).with(model)
+          expect(logger).not_to have_received(:error).with(error_msg)
+        end
+      end
+    end
+
+    describe '#verify_handle_create' do
+      subject { job.verify_handle_create(model) }
+
+      let(:model) { instance_double(Sighrax::Model, 'model', noid: model_id) }
+      let(:model_url) { "https://www.test.com/#{model.noid}" }
+      let(:service_url) { 'url' }
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+      let(:error_msg) { "HandleVerifyJob #{model.noid} verify handle create StandardError" }
+
+      before do
+        allow(Sighrax).to receive(:url).with(model).and_return(model_url)
+        allow(HandleService).to receive(:value).with(model.noid).and_return(service_url)
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error).with(error_msg)
+      end
+
+      it 'not verified' do
+        is_expected.to be false
+        expect(logger).not_to have_received(:error).with(error_msg)
+      end
+
+      context 'verified' do
+        let(:service_url) { model_url }
+
+        it 'urls match' do
+          is_expected.to be true
+          expect(logger).not_to have_received(:error).with(error_msg)
+        end
+
+        context 'when standard error' do
+          before { allow(HandleService).to receive(:value).with(model.noid).and_raise(StandardError) }
+
+          it 'not verified and logs error' do
+            is_expected.to be false
+            expect(logger).to have_received(:error).with(error_msg)
+          end
+        end
+      end
+    end
+
+    describe '#verify_handle_delete' do
+      subject { job.verify_handle_delete(model) }
+
+      let(:model) { instance_double(Sighrax::Model, 'model', noid: model_id) }
+      let(:service_url) { 'url' }
+      let(:logger) { instance_double(ActiveSupport::Logger, 'logger') }
+      let(:error_msg) { "HandleVerifyJob #{model.noid} verify handle delete StandardError" }
+
+      before do
+        allow(HandleService).to receive(:value).with(model.noid).and_return(service_url)
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error).with(error_msg)
+      end
+
+      it 'not verified' do
+        is_expected.to be false
+        expect(logger).not_to have_received(:error).with(error_msg)
+      end
+
+      context 'verified' do
+        let(:service_url) { "100 : Handle Not Found. (HTTP 404 Not Found)" }
+
+        it 'handle not found' do
+          is_expected.to be true
+          expect(logger).not_to have_received(:error).with(error_msg)
+        end
+
+        context 'when standard error' do
+          before { allow(HandleService).to receive(:value).with(model.noid).and_raise(StandardError) }
+
+          it 'not verified and logs error' do
+            is_expected.to be false
+            expect(logger).to have_received(:error).with(error_msg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/publisher_stats_job_spec.rb
+++ b/spec/jobs/publisher_stats_job_spec.rb
@@ -8,6 +8,19 @@ RSpec.describe PublisherStatsJob, type: :job do
   subject(:job) { described_class.perform_later(stats_file) }
 
   let(:stats_file) { Rails.root.join('tmp', 'publisher_stats.yml').to_s }
+  let(:user) { create(:press_editor, press: press) }
+  let(:press) { create(:press) }
+  let(:monograph) do
+    create(:public_monograph, user: user, press: press.subdomain) do |m|
+      m.ordered_members << file_set
+      m.save!
+      file_set.save!
+      m
+    end
+  end
+  let(:file_set) { create(:public_file_set) }
+
+  before { monograph }
 
   after do
     clear_enqueued_jobs

--- a/spec/models/handle_deposit_spec.rb
+++ b/spec/models/handle_deposit_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HandleDeposit, type: :model do
+  subject(:deposit) { create(:handle_deposit) }
+
+  it { expect(ValidationService.valid_noid?(deposit.noid)).to be true }
+end

--- a/spec/models/sighrax/monograph_spec.rb
+++ b/spec/models/sighrax/monograph_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sighrax::Monograph, type: :model do
   let(:data) { {} }
 
   it { is_expected.to be_an_instance_of(described_class) }
-  it { is_expected.to be_a_kind_of(Sighrax::Model) }
+  it { is_expected.to be_a_kind_of(Sighrax::Work) }
   it { expect(subject.resource_type).to eq :Monograph }
   it { expect(subject.epub_featured_representative).to be_an_instance_of(Sighrax::NullEntity) }
 

--- a/spec/models/sighrax/score_spec.rb
+++ b/spec/models/sighrax/score_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Sighrax::Score, type: :model do
   let(:data) { {} }
 
   it { is_expected.to be_an_instance_of(described_class) }
-  it { is_expected.to be_a_kind_of(Sighrax::Model) }
+  it { is_expected.to be_a_kind_of(Sighrax::Work) }
   it { expect(subject.resource_type).to eq :Score }
 end

--- a/spec/models/sighrax/work_spec.rb
+++ b/spec/models/sighrax/work_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sighrax::Work, type: :model do
+  subject { described_class.send(:new, noid, data) }
+
+  let(:noid) { 'validnoid' }
+  let(:data) { {} }
+
+  it { is_expected.to be_an_instance_of(described_class) }
+  it { is_expected.to be_a_kind_of(Sighrax::Model) }
+  it { expect(subject.resource_type).to eq :Work }
+
+  describe '#children' do
+    it { expect(subject.children).to be_empty }
+
+    context 'children' do
+      let(:data) { { 'ordered_member_ids_ssim' => [child.noid] } }
+      let(:child) { instance_double(Sighrax::Entity, 'child', noid: 'childnoid') }
+
+      before { allow(Sighrax).to receive(:from_noid).with(child.noid).and_return(child) }
+
+      it { expect(subject.children).not_to be_empty }
+      it { expect(subject.children).to contain_exactly(child) }
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -55,13 +55,13 @@ describe SolrDocument do
   it { is_expected.to respond_to(:display_date) }
   it { is_expected.to respond_to(:exclusive_to_platform) }
   it { is_expected.to respond_to(:external_resource_url) }
-  it { is_expected.to respond_to(:redirect_to) }
   it { is_expected.to respond_to(:keywords) }
+  it { is_expected.to respond_to(:license) }
   it { is_expected.to respond_to(:permissions_expiration_date) }
   it { is_expected.to respond_to(:primary_creator_role) }
+  it { is_expected.to respond_to(:redirect_to) }
   it { is_expected.to respond_to(:resource_type) }
   it { is_expected.to respond_to(:rights_granted) }
-  it { is_expected.to respond_to(:license) }
   it { is_expected.to respond_to(:section_title) }
   it { is_expected.to respond_to(:sort_date) }
   it { is_expected.to respond_to(:transcript) }

--- a/spec/requests/handle_deposits_spec.rb
+++ b/spec/requests/handle_deposits_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "HandleDeposits", type: :request do
+  let(:current_user) { User.guest(user_key: 'wolverine@umich.edu') }
+  let(:target) { create(:handle_deposit) }
+
+  before { target }
+
+  describe '#index' do
+    subject { get "/aptrust_deposits" }
+
+    it do
+      expect { subject }.not_to raise_error
+      expect(response).to render_template(file: Rails.root.join('public', '404.html').to_s)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context 'authenticated' do
+      before { sign_in(current_user) }
+
+      it do
+        expect { subject }.not_to raise_error
+        expect(response).to render_template(file: Rails.root.join('public', '404.html').to_s)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context 'authorized' do
+        before { allow_any_instance_of(ApplicationController).to receive(:authorize!) }
+
+        it do
+          expect { subject }.not_to raise_error
+          expect(response).to render_template(file: Rails.root.join('public', '404.html').to_s)
+          expect(response).to have_http_status(:not_found)
+        end
+
+        context 'platform administrator' do
+          let(:current_user) { create(:platform_admin) }
+
+          it do
+            expect { subject }.not_to raise_error
+            expect(response).to render_template(:index)
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/handle_service_spec.rb
+++ b/spec/services/handle_service_spec.rb
@@ -75,4 +75,21 @@ RSpec.describe HandleService do
       it { expect(described_class.value(validnoid)).to eq "200 : Values Not Found. The handle exists but has no values (or no values according to the types and indices specified). (HTTP 200 OK)" }
     end
   end
+
+  describe '#update' do
+    subject { described_class.update(noid, url) }
+
+    let(:noid) { 'validnoid' }
+    let(:url) { "url" }
+
+    it { is_expected.to be "TODO: UPDATE_OR_CREATE HANDLE RECORD" }
+  end
+
+  describe '#delete' do
+    subject { described_class.delete(noid) }
+
+    let(:noid) { 'validnoid' }
+
+    it { is_expected.to be "TODO: DELETE HANDLE RECORD" }
+  end
 end

--- a/spec/services/sighrax_spec.rb
+++ b/spec/services/sighrax_spec.rb
@@ -461,6 +461,30 @@ RSpec.describe Sighrax do
 
     before { allow(ActiveFedora::SolrService).to receive(:query).with("{!terms f=id}#{noid}", rows: 1).and_return([data]) }
 
+    describe '#url' do
+      subject { described_class.url(entity) }
+
+      it { is_expected.to be nil }
+
+      context 'monograph' do
+        let(:entity) { Sighrax::Monograph.send(:new, noid, data) }
+
+        it { is_expected.to eq "http://test.host/concern/monographs/validnoid" }
+      end
+
+      context 'score' do
+        let(:entity) { Sighrax::Score.send(:new, noid, data) }
+
+        it { is_expected.to eq "http://test.host/concern/scores/validnoid" }
+      end
+
+      context 'asset' do
+        let(:entity) { Sighrax::Asset.send(:new, noid, data) }
+
+        it { is_expected.to eq "http://test.host/concern/file_sets/validnoid" }
+      end
+    end
+
     describe '#allow_download?' do
       subject { described_class.allow_download?(entity) }
 


### PR DESCRIPTION
This pull request is mainly plumbing.  The rake task /lib/tasks/handle.rake will be run daily by cron.  Focus on understanding the HandleJob, all the other code supports this job.  I created a new table HandleDeposits and the model, view, and controller to support how it is being used.  I also added a new job form to the /fulcrum/jobs page (third one down) to create a handle for a noid a.k.a. Monograph, Score, or FileSet.  Go ahead and create a handle for a Monograph since the HandleService update and delete methods have yet to be implemented so no handles will be created or deleted.  The /handle_deposits page will display the HandleDeposits table and you'll see your request to create a handle for the Monograph has a verified status of false.

If you have any questions you know where to find me.