### PR TITLE
Resolves HELIO-3171 default sort on catalog page.

### DIFF
--- a/app/models/press_search_builder.rb
+++ b/app/models/press_search_builder.rb
@@ -9,4 +9,13 @@ class PressSearchBuilder < ::SearchBuilder
     all_presses = children.push(blacklight_params['press']).uniq
     solr_parameters[:fq] << "{!terms f=press_sim}#{all_presses.map(&:downcase).join(',')}"
   end
+
+  def default_sort_field
+    case blacklight_params['press']
+    when /^barpublishing$/i
+      blacklight_config.sort_fields['year desc'] # Sort by Publication Date (Newest First)
+    else
+      blacklight_config.default_sort_field
+    end
+  end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,4 +4,27 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
+
+  def sort
+    sort_field = if blacklight_params[:sort].blank?
+                   # no sort param provided, use default
+                   default_sort_field
+                 else
+                   # check for sort field key
+                   blacklight_config.sort_fields[blacklight_params[:sort]]
+                 end
+
+    field = if sort_field.present?
+              sort_field.sort
+            else
+              # just pass the key through
+              blacklight_params[:sort]
+            end
+
+    field.presence
+  end
+
+  def default_sort_field # rubocop:disable Rails/Delegate
+    blacklight_config.default_sort_field
+  end
 end

--- a/spec/models/press_search_builder_spec.rb
+++ b/spec/models/press_search_builder_spec.rb
@@ -24,4 +24,29 @@ describe PressSearchBuilder do
       end
     end
   end
+
+  describe '#default_sort_field' do
+    subject { search_builder.default_sort_field }
+
+    let(:default_sort_field) { double('default_sort_field') }
+    let(:sort_fields) { double('sort_fields') }
+    let(:press) { 'press' }
+
+    before do
+      allow(search_builder).to receive(:blacklight_params).and_return({ 'press' => press })
+      allow(config).to receive(:default_sort_field).and_return(default_sort_field)
+      allow(config).to receive(:sort_fields).and_return(sort_fields)
+    end
+
+    it { is_expected.to be default_sort_field }
+
+    context 'barpublishing' do
+      let(:press) { 'barpublishing' }
+      let(:year_desc) { double('year_desc') }
+
+      before { allow(sort_fields).to receive(:[]).with('year desc').and_return(year_desc) }
+
+      it { is_expected.to be year_desc }
+    end
+  end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -37,4 +37,35 @@ describe SearchBuilder do
       expect(subject['facet.field']).to include 'subject_sim'
     end
   end
+
+  context 'sort field' do
+    let(:default_sort_field) { double('default_sort_field') }
+
+    before { allow(config).to receive(:default_sort_field).and_return(default_sort_field) }
+
+    describe '#default_sort_field' do
+      subject { search_builder.default_sort_field }
+
+      it { is_expected.to be default_sort_field }
+    end
+
+    describe "#sort" do
+      subject { search_builder.sort }
+
+      let(:field) { double('field') }
+
+      before { allow(default_sort_field).to receive(:sort).and_return(field) }
+
+      it { is_expected.to be field }
+
+      context 'param sort' do
+        let(:blacklight_params) { { sort: param_field } }
+        let(:param_field) { double('param_field') }
+
+        before { allow(search_builder).to receive(:blacklight_params).and_return(blacklight_params) }
+
+        it { is_expected.to be param_field }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Copied and pasted #sort from Blacklight to SearchBuilder.  Modified #sort to call new #default_sort_field method which returns blackligh_config.default_sort_field.  Added new #default_sort_field method to PressSearchBuilder which switches on press.