### PR TITLE
show only `YYYY` or `cYYYY` for citation pub date

### DIFF
--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
 
     attr_accessor :pageviews
 
-    delegate :date_created, :date_modified, :date_uploaded, :location, :description,
+    delegate :date_modified, :date_uploaded, :location, :description,
              :creator_display, :creator_full_name, :contributor,
              :subject, :section_titles, :based_near, :publisher, :date_published, :language,
              :isbn, :license, :copyright_holder, :open_access, :funder, :funder_display, :holding_contact, :has_model,
@@ -93,8 +93,18 @@ module Hyrax
       solr_document.funder_display.present?
     end
 
+    def date_created
+      # Only show the first 4 contiguous digits of this, which is the citation publication date, because...
+      # for sorting we also allow `-MM-DD` and, in theory, other digits appended (see MonographIndexer)
+      # optionally take a 'c' right next to that, as almost 3000 HEB titles have stuff like c1996 in here
+      #
+      # wrap this in an array as CitationsBehavior calls `.first` on it, though since we first started using...
+      # CitationsBehavior we have copied pretty much all of it into heliotrope so could change that if we wanted to
+      Array(solr_document['date_created_tesim']&.first.to_s[/c?[0-9]{4}/])
+    end
+
     def date_created?
-      solr_document.date_created.present?
+      date_created.present?
     end
 
     def isbn_noformat

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -94,6 +94,39 @@ RSpec.describe Hyrax::MonographPresenter do
     it { is_expected.to eq ['Oct 7th'] }
   end
 
+  describe '#date_created (catalog page citation pub date)' do
+    subject { presenter.date_created }
+
+    context 'clean 4 digit year' do
+      let(:mono_doc) { ::SolrDocument.new(id: 'mono', has_model_ssim: ['Monograph'], date_created_tesim: ['1999']) }
+      it { is_expected.to eq ['1999'] }
+    end
+
+    context "HEB-style 4 digit year with 'circa c', which persists" do
+      let(:mono_doc) { ::SolrDocument.new(id: 'mono', has_model_ssim: ['Monograph'], date_created_tesim: ['c1999']) }
+      it { is_expected.to eq ['c1999'] }
+    end
+
+    context 'YYYY-MM-DD' do
+      let(:mono_doc) { ::SolrDocument.new(id: 'mono', has_model_ssim: ['Monograph'], date_created_tesim: ['1999-05-06']) }
+      it { is_expected.to eq ['1999'] }
+    end
+
+    context 'YYYY-MM-DD with some sub-day custom sort number for catalog sort' do
+      let(:mono_doc) { ::SolrDocument.new(id: 'mono',
+                                          has_model_ssim: ['Monograph'],
+                                          date_created_tesim: ['1999-05-06-2']) }
+      it { is_expected.to eq ['1999'] }
+    end
+
+    context 'a mess' do
+      let(:mono_doc) { ::SolrDocument.new(id: 'mono',
+                                          has_model_ssim: ['Monograph'],
+                                          date_created_tesim: ['this was pubbed on 1999-05-06 LOLZ 123456']) }
+      it { is_expected.to eq ['1999'] }
+    end
+  end
+
   describe '#authors' do
     describe "creator_display exists, creators/contributors don't" do
       subject { presenter.authors }


### PR DESCRIPTION
HELIO-3260