### PR TITLE
HELIO-3258 Modify download watermark

### DIFF
--- a/app/controllers/ebooks_controller.rb
+++ b/app/controllers/ebooks_controller.rb
@@ -9,15 +9,8 @@ class EbooksController < CheckpointController
     raise NotAuthorizedError unless @policy.download?
     return redirect_to(hyrax.download_path(params[:id])) unless Sighrax.watermarkable?(@entity) && @press_policy.watermark_download?
     begin
-      presenter = Sighrax.hyrax_presenter(@entity.parent)
-      text = <<~WATERMARK
-          #{wrap_text(watermark_authorship(presenter) + CGI.unescapeHTML(presenter.title), 100)}
-          #{presenter.date_created.first}. #{presenter.publisher.first}
-          Downloaded on behalf of #{request_origin}
-      WATERMARK
-
       CounterService.from(self, Sighrax.hyrax_presenter(@entity)).count(request: 1)
-      send_data watermark_pdf(@entity, text), type: @entity.media_type, filename: @entity.filename
+      send_data watermark_pdf(@entity), type: @entity.media_type, filename: @entity.filename
     rescue StandardError => e
       Rails.logger.error "EbooksController.download raised #{e}"
       head :no_content

--- a/app/helpers/hyrax/citations_behavior.rb
+++ b/app/helpers/hyrax/citations_behavior.rb
@@ -20,6 +20,10 @@ module Hyrax
       Hyrax::CitationsBehaviors::Formatters::MlaFormatter.new(self).format(work)
     end
 
+    def export_as_mla_structure(work)
+      Hyrax::CitationsBehaviors::Formatters::MlaFormatter.new(self).structure(work)
+    end
+
     # MIME type: 'application/x-openurl-ctx-kev'
     def export_as_openurl_ctx_kev(work)
       Hyrax::CitationsBehaviors::Formatters::OpenUrlFormatter.new(self).format(work)

--- a/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb
@@ -20,6 +20,19 @@ module Hyrax
           text.html_safe # rubocop:disable Rails/OutputSafety
         end
 
+        def structure(work)
+          struct = {}
+          # setup formatted author list
+          authors = author_list(work).reject(&:blank?)
+          struct[:author] = format_authors(authors)
+          # setup title
+          title_info = setup_title_info(work)
+          struct[:title] = mla_citation_title(title_info)
+          # Publication
+          struct[:publisher] = add_publisher_text_for(work)
+          struct
+        end
+
         def format_authors(authors_list = [])
           return '' if authors_list.blank?
           authors_list = Array.wrap(authors_list)

--- a/app/services/watermark/watermarkable.rb
+++ b/app/services/watermark/watermarkable.rb
@@ -3,15 +3,17 @@
 module Watermark
   module Watermarkable
     extend ActiveSupport::Concern
+    include Hyrax::CitationsBehavior
 
-    def watermark_pdf(entity, text, size = 7, file = nil)
-      Rails.cache.fetch(cache_key(entity, text, size), expires_in: 30.days) do
+    def watermark_pdf(entity, size = 7, file = nil)
+      fmt = watermark_formatted_text(entity)
+      Rails.cache.fetch(cache_key(entity, fmt.to_s, size), expires_in: 30.days) do
         content = file.presence || entity.content
 
         pdf = CombinePDF.parse(content, allow_optional_content: true)
         stamps = {} # Cache of stamps with potentially different media boxes
         pdf.pages.each do |page|
-          stamp = stamps[page[:MediaBox].to_s] || CombinePDF.parse(watermark(text, size, page[:MediaBox])).pages[0]
+          stamp = stamps[page[:MediaBox].to_s] || CombinePDF.parse(watermark(fmt, size, page[:MediaBox])).pages[0]
           page << stamp
           stamps[page[:MediaBox].to_s] = stamp
         end
@@ -49,7 +51,21 @@ module Watermark
       lines.join("\n")
     end
 
-    def watermark(text, size, media_box)
+    # Returns Prawn::Text::Formatted compatible structure
+    def watermark_formatted_text(entity)
+      presenter = Sighrax.hyrax_presenter(entity.parent)
+      struct = export_as_mla_structure(presenter)
+      wrapped = wrap_text(struct[:author] + '___' + struct[:title], 150)
+      parts = wrapped.split('___')
+      [{ text: parts[0] },
+       { text: parts[1], styles: [:italic] },
+       { text: "\n" + wrap_text(struct[:publisher], 150) },
+       { text: "\nDownloaded on behalf of #{request_origin}" }
+      ]
+    end
+
+    def watermark(formatted_text, size, media_box)
+      text = formatted_text.map { |t| t[:text] }.join('')
       height = (text.lines.count + 1) * size
       width = 0
       text.lines.each do |line|
@@ -59,14 +75,14 @@ module Watermark
       pdf = Prawn::Document.new do
         Prawn::Font::AFM.hide_m17n_warning = true
         font('Times-Roman', size: size) do
-          bounding_box([-20 + media_box[0], 0 + media_box[1]], width: width, height: height) do
+          bounding_box([-20 + media_box[0], -30 + height + media_box[1]], width: width, height: height) do
             transparent(0.5) do
               fill_color "ffffff"
               stroke_color "ffffff"
               fill_rectangle [-size, height + size], width + (2 * size), height + size
               fill_color "000000"
               stroke_color "000000"
-              text text
+              formatted_text formatted_text
             end
           end
         end

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe EPubsController, type: :controller do
       let(:file_set) { create(:file_set, id: '999999998', content: File.open(File.join(fixture_path, 'fake_epub_multi_rendition.epub'))) }
       let!(:fr) { create(:featured_representative, work_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
       let(:document) { double('document') }
-      let(:rendered) { "%PDF-1.3\n" }
+      let(:rendered) { +"%PDF-1.3\ntrailer<</Root<</Pages<</Kids[<</MediaBox[0 0 3 3]>>]>>>>>>" }
 
       before do
         monograph.ordered_members << file_set
@@ -432,7 +432,6 @@ RSpec.describe EPubsController, type: :controller do
         expect(document).to receive(:image).with(/images\/00000004\.png/, fit: [512, 692])
         expect(document).to receive(:image).with(/images\/00000005\.png/, fit: [512, 692])
         expect(document).to receive(:render).and_return(rendered)
-        expect(controller).to receive(:send_data).with(rendered, type: "application/pdf", disposition: "inline").and_call_original
         get :download_interval, params: { id: file_set.id, cfi: '/6/2[xhtml00000003]!/4/1:0', title: "This is Chapter One's Title" }
         expect(response).to have_http_status(:success)
         expect(response.headers['Content-Type']).to eq 'application/pdf'

--- a/spec/requests/e_pubs_spec.rb
+++ b/spec/requests/e_pubs_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "EPubs", type: :request do
           let(:interval) { double('interval', title: 'title') }
           let(:pdf) { double('pdf', document: document) }
           let(:document) { double('document', render: rendered_pdf) }
-          let(:rendered_pdf) { 'rendered_pdf' }
+          let(:rendered_pdf) { +"%PDF-1.\ntrailer<</Root<</Pages<</Kids[<</MediaBox[0 0 3 3]>>]>>>>>>" }
 
           before do
             allow(publication).to receive(:rendition).and_return(rendition)
@@ -292,7 +292,8 @@ RSpec.describe "EPubs", type: :request do
           it do
             expect { subject }.not_to raise_error
             expect(response).to have_http_status(:ok)
-            expect(response.body).to eq(rendered_pdf)
+            # watermarking will change the file content and PDF 'producer' metadata
+            expect(response.body).not_to eq(rendered_pdf)
             expect(counter_service).to have_received(:count).with(request: 1, section: 'title', section_type: 'Chapter')
           end
         end
@@ -313,9 +314,6 @@ RSpec.describe "EPubs", type: :request do
           subject { get "/epubs_download_interval/#{epub.id}?title=title;chapter_index=0" }
 
           let(:interval) { double('interval', title: 'title') }
-          let(:pdf) { double('pdf', document: document) }
-          let(:document) { double('document', render: rendered_pdf) }
-          let(:rendered_pdf) { 'rendered_pdf' }
 
           before do
             allow(PDFEbook::Interval).to receive(:from_title_level_cfi).with(epub.id, 0, 'title', 1, 5).and_return(interval)

--- a/spec/requests/ebooks_spec.rb
+++ b/spec/requests/ebooks_spec.rb
@@ -76,8 +76,11 @@ RSpec.describe "PDF EBooks", type: :request do
             let(:presenter) do
               instance_double(Hyrax::MonographPresenter, authors?: true,
                                                          authors: 'creator blah',
+                                                         creator: ['Creator, A.', 'Destroyer, Z.'],
                                                          title: 'title',
                                                          date_created: ['created'],
+                                                         based_near_label: ['Somewhere'],
+                                                         citable_link: 'www.example.com/something',
                                                          publisher: ['publisher'])
             end
 
@@ -96,7 +99,13 @@ RSpec.describe "PDF EBooks", type: :request do
           end
 
           context 'presenter does not return an authors value' do
-            let(:presenter) { instance_double(Hyrax::MonographPresenter, authors?: false, title: 'title', date_created: ['created'], publisher: ['publisher']) }
+            let(:presenter) { instance_double(Hyrax::MonographPresenter, authors?: false,
+                                                                         creator: [],
+                                                                         title: 'title',
+                                                                         date_created: ['created'],
+                                                                         based_near_label: ['Somewhere'],
+                                                                         citable_link: 'www.example.com/something',
+                                                                         publisher: ['publisher']) }
 
             it "doesn't raise an error" do
               allow(Sighrax).to receive(:hyrax_presenter).with(parent).and_return(presenter)


### PR DESCRIPTION
There is a certain amount of added nastiness in the specs with +"…" unfrozen PDF strings. Prawn is particular about forcing encodings and having PDF content actually be PDF-like.