### PR TITLE
Hotfix HELIO-3279

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ $ ./bin/bundle exec ./bin/rails lib_spec
 $ ./bin/bundle exec rspec
 ```
 #### System specs
-By default, _system_ (headless chrome javascript tests) specs are excluded from `rake ci`. This is done because because of a timing bug we're having with Travis CI and system specs.
-To run ALL specs, including the system specs, do: `bundle exec rspec -t browser`
-Do run JUST the system specs, do: `bundle exec rspec ./spec/system/ -t browser`
+System specs are skipped on Travis due to frequent timing failures. This won't affect running `rspec` locally either directly or through the `ci` task. 
 
 
 ## Running specs individually

--- a/app/assets/javascripts/application/tabs.js
+++ b/app/assets/javascripts/application/tabs.js
@@ -144,7 +144,7 @@ $(document).on('turbolinks:load', function() {
       // the presence of these query parameters indicate the user is interacting with results (sorting, paging)
       var blacklight_params = ['page', 'per_page', 'sort', 'view'];
       var blacklight_param_found = false;
-      window.location.search.substring(1).split('&').forEach((queryNameValue) => {
+      window.location.search.substring(1).split('&').forEach(function(queryNameValue) {
         if (blacklight_params.includes(queryNameValue.split('=')[0])) {
           blacklight_param_found = true;
         }

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -79,11 +79,13 @@
   </script>
 
   </head>
+
   <%= tag.body class: press_subdomains(press_subdomain) do %>
 
     <%= content_for?(:body) ? yield(:body) : yield %>
 
     <%= render 'shared/ajax_modal' %>
     <%= render 'shared/cookie_alert' %>
+    <%= render 'shared/monitoring' %>
   <% end %>
 </html>

--- a/app/views/shared/_monitoring.html.erb
+++ b/app/views/shared/_monitoring.html.erb
@@ -1,0 +1,12 @@
+<!-- www.site24x7.com -->
+<script type="text/javascript">
+  var rumMOKey='3f150fa97a0b97d16b968c6e2ff4e3f4';
+  (function(){
+    if(window.performance && window.performance.timing && window.performance.navigation) {
+      var site24x7_rum_beacon=document.createElement('script');
+      site24x7_rum_beacon.async=true;
+      site24x7_rum_beacon.setAttribute('src','//static.site24x7rum.com/beacon/site24x7rum-min.js?appKey='+rumMOKey);
+      document.getElementsByTagName('head')[0].appendChild(site24x7_rum_beacon);
+    }
+  })(window)
+</script>

--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -18,7 +18,7 @@ encoding: "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 # Jekyll will delete everything under public for security reasons. We want to keep these symlinks into `shared/public/`
-keep_files: ["assets", "sitemaps", "system", "upload"]
+keep_files: ["assets", "sitemaps", "system", "upload", "DiscoFeed"]
 
 # Conversion
 markdown: kramdown

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,10 +48,8 @@ RSpec.configure do |config|
     # If you actually want to watch these happen in the browser (and have chrome installed)
     # driven_by :selenium_chrome, screen_size: [1200, 1200]
   end
-  # exclude system specs by default because of HELIO-3046 (frequent-yet-random Travis failures... timing?)
-  # to include them add a `-t browser` or `--tag browser`, e.g. `bundle exec rspec -t browser` or for just...
-  # the system/browser specs use `bundle exec rspec ./spec/system/ -t browser`
-  config.filter_run_excluding browser: :true
+  # exclude system specs on Travis (timing issues etc), see HELIO-3046 and HELIO-3271
+  config.filter_run_excluding browser: :true if ENV['TRAVIS']
 
   config.after(:all) do
     if Rails.env.test? || Rails.env.cucumber?


### PR DESCRIPTION
Hotfix branch based on v2.55.1 that resolves HELIO-3279 IE11 compatibility issues.