### PR TITLE
Resolves HELIO-3207 Delete NCID publisher entry

### DIFF
--- a/app/controllers/presses_controller.rb
+++ b/app/controllers/presses_controller.rb
@@ -37,6 +37,19 @@ class PressesController < ApplicationController
     end
   end
 
+  def destroy?
+    publisher = Sighrax::Publisher.from_press(@press)
+    !(publisher.children.present? || publisher.user_ids.present? || publisher.work_noids.present?)
+  end
+
+  def destroy
+    @press.destroy if destroy?
+    respond_to do |format|
+      format.html { redirect_to fulcrum_partials_path(:refresh), notice: "Publisher was #{@press.destroyed? ? 'successfully': 'NOT'} destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
   private
 
     def press_params

--- a/app/jobs/publisher_stats_job.rb
+++ b/app/jobs/publisher_stats_job.rb
@@ -4,45 +4,26 @@ class PublisherStatsJob < ApplicationJob
   def perform(stats_file)
     presses = []
     Press.order(:name).each do |press|
-      presses.push(
-        subdomain: press.subdomain,
-        name: press.name,
-        monographs: monograph_ids(press).count,
-        assets: asset_ids(press).count,
-        users: user_ids(press).count
-      )
+      presses.append(stats(press))
     end
     File.open(stats_file, 'w') { |file| file.write({ presses: presses, timestamp: Time.now.utc.to_s }.to_yaml) }
   end
 
   private
 
-    def monograph_ids(press = nil)
-      docs = ActiveFedora::SolrService.query("+has_model_ssim:Monograph", rows: 10_000)
-      ids = []
-      docs.each do |doc|
-        if press.nil?
-          ids << doc['id']
-        elsif doc['press_tesim']&.first == press.subdomain
-          ids << doc['id']
-        end
-      end
-      ids
-    end
-
-    def asset_ids(press = nil)
-      asset_ids = []
-      monograph_ids(press).each do |monograph_id|
-        monograph_doc = ActiveFedora::SolrService.query("{!terms f=id}#{monograph_id}", rows: 1)
-        if monograph_doc.present?
-          asset_ids += monograph_doc[0][Solrizer.solr_name('ordered_member_ids', :symbol)] || []
-        end
-      end
-      asset_ids
-    end
-
-    def user_ids(press = nil)
-      return User.all.map(&:id) if press.nil?
-      User.joins("INNER JOIN roles ON roles.user_id = users.id AND roles.resource_id = #{press.id} AND roles.resource_type = 'Press'").map(&:id)
+    def stats(press)
+      publisher = Sighrax::Publisher.from_press(press)
+      monograph_count = publisher.work_noids.count
+      asset_count = publisher.asset_noids.count
+      user_count = publisher.user_ids.count
+      trash_flag = !(monograph_count.positive? || asset_count.positive? || user_count.positive? || publisher.children.present?)
+      {
+        subdomain: press.subdomain,
+        name: press.name,
+        monographs: monograph_count,
+        assets: asset_count,
+        users: user_count,
+        trash: trash_flag
+      }
     end
 end

--- a/app/models/sighrax/publisher.rb
+++ b/app/models/sighrax/publisher.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Sighrax
+  class Publisher
+    private_class_method :new
+
+    attr_reader :subdomain
+
+    # Class Methods
+
+    def self.null_publisher(subdomain = 'null_subdomain')
+      NullPublisher.send(:new, subdomain)
+    end
+
+    def self.from_subdomain(subdomain)
+      press = Press.find_by(subdomain: subdomain)
+      return self.null_publisher(subdomain) if press.blank?
+      self.send(:new, subdomain, press)
+    end
+
+    def self.from_press(press)
+      return self.null_publisher unless press.present? && press.is_a?(Press)
+      self.send(:new, press.subdomain, press)
+    end
+
+    # Instance Methods
+
+    def valid?
+      !instance_of?(NullPublisher)
+    end
+
+    def resource_type
+      type
+    end
+
+    def resource_id
+      subdomain
+    end
+
+    def resource_token
+      resource_type.to_s + ':' + resource_id.to_s
+    end
+
+    def parent
+      return self.class.null_publisher unless press.present? && press.parent.present?
+      self.class.from_press(press.parent)
+    end
+
+    def children
+      return [] if press.blank? || press.children.blank?
+      children = []
+      press.children.each do |child|
+        children << self.class.from_press(child)
+      end
+      children
+    end
+
+    def work_noids(recursive = false)
+      subdomains = recursive ? press.children.pluck(:subdomain) : []
+      subdomains = subdomains.push(subdomain).uniq
+      docs = ActiveFedora::SolrService.query("{!terms f=press_sim}#{subdomains.map(&:downcase).join(',')}", fl: ['id'], rows: 100_000)
+      docs.map { |doc| doc['id'] }.uniq
+    end
+
+    def asset_noids(recursive = false)
+      asset_noids = []
+      work_noids(recursive).each do |noid|
+        docs = ActiveFedora::SolrService.query("{!terms f=id}#{noid}", fl: ['id', Solrizer.solr_name('ordered_member_ids', :symbol)], rows: 1)
+        asset_noids += (docs[0][Solrizer.solr_name('ordered_member_ids', :symbol)] || []) if docs.present?
+      end
+      asset_noids.uniq
+    end
+
+    def user_ids(recursive = false)
+      press_ids = recursive ? press.children.pluck(:id) : []
+      press_ids = press_ids.push(press.id).uniq
+      User.joins("INNER JOIN roles ON roles.user_id = users.id AND roles.resource_id IN (#{press_ids.join(', ')}) AND roles.resource_type = 'Press'").map(&:id)
+    end
+
+    def ==(other)
+      return false unless other.present? && subdomain == other.subdomain
+      press == other.press
+    end
+
+    protected
+
+      attr_reader :press
+
+      def type
+        @type ||= /^Sighrax::(.+$)/.match(self.class.to_s)[1].to_sym
+      end
+
+    private
+
+      def initialize(subdomain, press)
+        @subdomain = subdomain
+        @press = press
+      end
+  end
+
+  class NullPublisher < Publisher
+    private_class_method :new
+
+    def work_noids(recursive = false)
+      []
+    end
+
+    def asset_noids(recursive = false)
+      []
+    end
+
+    def user_ids(recursive = false)
+      []
+    end
+
+    private
+
+      def initialize(subdomain)
+        super(subdomain, nil)
+      end
+  end
+end

--- a/app/views/fulcrum/_publishers.html.erb
+++ b/app/views/fulcrum/_publishers.html.erb
@@ -11,6 +11,7 @@
     <th onclick="sortTable(3, true)">Monographs</th>
     <th onclick="sortTable(4, true)">Assets</th>
     <th onclick="sortTable(5, true)">Users</th>
+    <th></th>
   </tr>
   <% @publishers_stats[:presses].each do |press| %>
     <tr>
@@ -26,6 +27,13 @@
       </td>
       <td><%= press[:assets] %></td>
       <td><%= press[:users] %></td>
+      <td>
+        <% if press[:trash] %>
+          <%= link_to(press_path(press[:subdomain]), method: :delete, class: "btn btn-default", data: { confirm: 'Are you sure?' }) do %>
+            <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+          <% end %>
+      <% end %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,7 @@ Rails.application.routes.draw do
   end
 
   get '/presses' => 'presses#index'
-  resources :presses, only: %i[new create edit update]
+  resources :presses, only: %i[new create edit update destroy]
   resources :presses, path: '/', only: %i[index edit] do
     resources :roles, path: 'users', only: %i[index create destroy] do
       collection do

--- a/spec/controllers/presses_controller_spec.rb
+++ b/spec/controllers/presses_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe PressesController, type: :controller do
     end
   end
 
-  context 'a platform-wide admin user create/edit' do
+  context 'a platform-wide admin user create/edit/destroy' do
     let(:user) { create(:platform_admin) }
 
     before { sign_in user }
@@ -85,6 +85,28 @@ RSpec.describe PressesController, type: :controller do
       it 'displays the form to edit the press' do
         expect(response).to render_template :edit
         expect(response).to be_success
+      end
+    end
+
+    describe '#destroy' do
+      before { delete :destroy, params: { id: press.subdomain } }
+
+      it 'deletes the press' do
+        expect(response).to redirect_to(fulcrum_partials_path(:refresh))
+        expect(Press.count).to eq(0)
+      end
+    end
+
+    describe '#destroy not' do
+      before do
+        press.children << create(:press)
+        press.save
+        delete :destroy, params: { id: press.subdomain }
+      end
+
+      it 'does NOT deletes the press' do
+        expect(response).to redirect_to(fulcrum_partials_path(:refresh))
+        expect(Press.count).to eq(2)
       end
     end
   end
@@ -110,6 +132,15 @@ RSpec.describe PressesController, type: :controller do
       it 'displays the form to edit the press' do
         expect(response).to render_template :edit
         expect(response).to be_success
+      end
+    end
+
+    describe '#destroy' do
+      before { delete :destroy, params: { id: press.subdomain } }
+
+      it 'deletes the press' do
+        expect(response).to render_template :unauthorized
+        expect(response).to be_unauthorized
       end
     end
   end

--- a/spec/models/sighrax/publisher_spec.rb
+++ b/spec/models/sighrax/publisher_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sighrax::Publisher, type: :model do
+  context 'null publisher' do
+    subject { described_class.null_publisher }
+
+    it { is_expected.to be_an_instance_of(Sighrax::NullPublisher) }
+    it { expect(subject.subdomain).to eq 'null_subdomain' }
+    it { expect(subject.send(:press)).to eq(nil) }
+    it { expect(subject.valid?).to be false }
+    it { expect(subject.resource_type).to eq :NullPublisher }
+    it { expect(subject.resource_id).to eq 'null_subdomain' }
+    it { expect(subject.resource_token).to eq "#{subject.resource_type}:#{subject.resource_id}" }
+    it { expect(subject.parent).to be_an_instance_of(Sighrax::NullPublisher) }
+    it { expect(subject.children).to be_empty }
+    it { expect(subject.work_noids(true)).to be_empty }
+    it { expect(subject.asset_noids(true)).to be_empty }
+    it { expect(subject.user_ids(true)).to be_empty }
+  end
+
+  context 'factories' do
+    let(:subdomain) { 'publisher' }
+
+    describe '#from_subdomain' do
+      subject { described_class.from_subdomain(subdomain) }
+
+      it { is_expected.to eq described_class.null_publisher(subdomain) }
+
+      context 'press' do
+        let(:press) { create(:press, subdomain: subdomain) }
+
+        before { press }
+
+        it { is_expected.to eq described_class.send(:new, subdomain, press) }
+      end
+    end
+
+    describe '#from_press' do
+      subject { described_class.from_press(press) }
+
+      let(:press) { double('non press') }
+
+      it { is_expected.to eq described_class.null_publisher }
+
+      context 'press' do
+        let(:press) { create(:press, subdomain: subdomain) }
+
+        before { press }
+
+        it { is_expected.to eq described_class.send(:new, subdomain, press) }
+      end
+    end
+  end
+
+  context 'root publisher' do
+    subject { described_class.send(:new, subdomain, press) }
+
+    let(:subdomain) { 'root' }
+    let(:press) { create(:press, subdomain: subdomain) }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+    it { expect(subject.subdomain).to eq subdomain }
+    it { expect(subject.send(:press)).to eq press }
+    it { expect(subject.valid?).to be true }
+    it { expect(subject.resource_type).to eq :Publisher }
+    it { expect(subject.resource_id).to eq subdomain }
+    it { expect(subject.resource_token).to eq "#{subject.resource_type}:#{subject.resource_id}" }
+    it { expect(subject.parent).to be_an_instance_of(Sighrax::NullPublisher) }
+    it { expect(subject.children).to be_empty }
+    it { expect(subject.work_noids(true)).to be_empty }
+    it { expect(subject.asset_noids(true)).to be_empty }
+    it { expect(subject.user_ids(true)).to be_empty }
+
+    context 'with child' do
+      let(:child_subdomain) { 'child' }
+      let(:child_press) { create(:press, subdomain: child_subdomain) }
+
+      before do
+        press.children << child_press
+        press.save
+      end
+
+      it { expect(subject.children.count).to eq 1 }
+      it { expect(subject.children.first).to eq described_class.from_press(child_press) }
+      it { expect(subject.children.first).to be_an_instance_of(described_class) }
+      it { expect(subject.children.first.parent).to eq subject }
+    end
+
+    context 'with user' do
+      let(:press_admin) { create(:press_admin, press: press) }
+
+      before { press_admin }
+
+      it { expect(subject.user_ids(true)).to contain_exactly(press_admin.id) }
+
+      context 'with child user' do
+        let(:child_subdomain) { 'child' }
+        let(:child_press) { create(:press, subdomain: child_subdomain) }
+        let(:child_press_admin) { create(:press_admin, press: child_press) }
+
+        before do
+          press.children << child_press
+          press.save
+          child_press_admin
+        end
+
+        it { expect(subject.user_ids).to contain_exactly(press_admin.id) }
+        it { expect(subject.user_ids(true)).to contain_exactly(press_admin.id, child_press_admin.id) }
+      end
+    end
+
+    context 'with work and asset' do
+      let(:monograph) do
+        create(:public_monograph, press: press.subdomain) do |m|
+          m.ordered_members << file_set
+          m.save
+          m
+        end
+      end
+      let(:file_set) { create(:public_file_set) }
+
+      before { monograph }
+
+      it { expect(subject.work_noids(true)).to contain_exactly(monograph.id) }
+      it { expect(subject.asset_noids(true)).to contain_exactly(file_set.id) }
+
+      context 'with child work and asset' do
+        let(:child_subdomain) { 'child' }
+        let(:child_press) { create(:press, subdomain: child_subdomain) }
+        let(:child_score) do
+          create(:public_score, press: child_press.subdomain) do |m|
+            m.ordered_members << child_file_set
+            m.save
+            m
+          end
+        end
+        let(:child_file_set) { create(:public_file_set) }
+
+        before do
+          press.children << child_press
+          press.save
+          child_score
+        end
+
+        it { expect(subject.work_noids).to contain_exactly(monograph.id) }
+        it { expect(subject.asset_noids).to contain_exactly(file_set.id) }
+        it { expect(subject.work_noids(true)).to contain_exactly(monograph.id, child_score.id) }
+        it { expect(subject.asset_noids(true)).to contain_exactly(file_set.id, child_file_set.id) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Platform administrators can now delete empty publishers from the fulcrum dashboard publishers page.