### PR TITLE
HELIO-2915 Add default icon for representing map resource types

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -214,7 +214,7 @@ module Hyrax
     end
 
     def glyphicon_type
-      return 'glyphicon glyphicon-file' if pdf? || resource_type.blank?
+      return 'glyphicon glyphicon-file' if resource_type.blank?
       glyphicon_by_resource_type
     end
 
@@ -228,6 +228,8 @@ module Hyrax
         'glyphicon glyphicon-film'
       when 'audio'
         'glyphicon glyphicon-volume-up'
+      when 'map', 'interactive map'
+        'glyphicon glyphicon-map-marker'
       else
         'glyphicon glyphicon-file'
       end


### PR DESCRIPTION
Removed the `pdf?` call in `glyphicon_type` in order to characterize PDF (interactive) maps, otherwise they just get a generic icon.