### PR TITLE
Resolves HELIO-3259 FeaturedRepresentative unique index not working

### DIFF
--- a/app/models/featured_representative.rb
+++ b/app/models/featured_representative.rb
@@ -4,11 +4,10 @@ class FeaturedRepresentative < ApplicationRecord
   KINDS = %w[epub webgl database aboutware pdf_ebook mobi reviews related peer_review].freeze
 
   validates :work_id, presence: true
-  validates :file_set_id, presence: true
+  validates :file_set_id, presence: true, uniqueness: true
   validates :kind, inclusion: { in: KINDS }
-  validates :kind, uniqueness: { scope: %i[work_id file_set_id],
-                                 message: "Only 1 type of Kind can be used for each Work's FileSet" }
-
+  validates :kind, uniqueness: { scope: %i[work_id kind],
+                                 message: "Work can only have one of each kind" }
   def self.kinds
     KINDS
   end

--- a/db/migrate/20200330165632_add_indexes_to_featured_representatives.rb
+++ b/db/migrate/20200330165632_add_indexes_to_featured_representatives.rb
@@ -1,0 +1,6 @@
+class AddIndexesToFeaturedRepresentatives < ActiveRecord::Migration[5.1]
+  def change
+    add_index :featured_representatives, :file_set_id, unique: true
+    add_index :featured_representatives, [:work_id, :kind], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200313153535) do
+ActiveRecord::Schema.define(version: 20200330165632) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -162,6 +162,7 @@ ActiveRecord::Schema.define(version: 20200313153535) do
     t.string "kind"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["work_id", "file_set_id"], name: "index_featured_representatives_on_work_id_and_file_set_id", unique: true
   end
 
   create_table "featured_works", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/models/featured_representative_spec.rb
+++ b/spec/models/featured_representative_spec.rb
@@ -7,11 +7,26 @@ RSpec.describe FeaturedRepresentative, type: :model do
     it { expect(described_class.kinds).to eq %w[epub webgl database aboutware pdf_ebook mobi reviews related peer_review] }
   end
 
-  describe "the combination of mongraph_id, file_set_id and kind" do
+
+  describe "file_set" do
     let!(:fr1) { create(:featured_representative, work_id: 1, file_set_id: 1, kind: 'epub') }
 
     it "is unique" do
-      expect(described_class.create(work_id: 1, file_set_id: 1, kind: 'epub')).not_to be_valid
+      expect { described_class.create!(work_id: 2, file_set_id: 1, kind: 'epub') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: File set has already been taken")
+    end
+  end
+
+  describe "kind" do
+    it "is valid" do
+      expect { described_class.create!(work_id: 1, file_set_id: 1, kind: 'kind') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Kind is not included in the list")
+    end
+  end
+
+  describe "work and kind" do
+    let!(:fr1) { create(:featured_representative, work_id: 1, file_set_id: 1, kind: 'epub') }
+
+    it "is unique" do
+      expect { described_class.create!(work_id: 1, file_set_id: 2, kind: 'epub') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Kind Work can only have one of each kind")
     end
   end
 end


### PR DESCRIPTION
FYI: Ran the following rake task on production and it came up empty, hence the database migration should succeed when released to production.

desc 'Find non unique kind works'
namespace :heliotrope do
  task find_non_unique_kind_works: :environment do
    FeaturedRepresentative.distinct.pluck(:work_id).each do |work_id|
      kind_count = FeaturedRepresentative.where(work_id: work_id).count
      unique_kind_count = FeaturedRepresentative.where(work_id: work_id).distinct.pluck(:kind).count
      next if kind_count == unique_kind_count
      puts Sighrax.url(Sighrax.from_noid(work_id))
    end
  end
end
