### PR TITLE
Update CSB to include feature CSB-227

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ gem 'combine_pdf', '~> 1.0'
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: '08acc610622088f7087d27edc1b08dc8602901ab'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'cbc8a324857a3ff84da388a58a555e0f41d13ffc'
 
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: 08acc610622088f7087d27edc1b08dc8602901ab
-  ref: 08acc610622088f7087d27edc1b08dc8602901ab
+  revision: cbc8a324857a3ff84da388a58a555e0f41d13ffc
+  ref: cbc8a324857a3ff84da388a58a555e0f41d13ffc
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Updates ref point in Gemfile for CSB to include feature CSB-227: when there are problems displaying sections of an EPUB in the ereader, reader should emit a message that heliotrope can listen for.