### PR TITLE
Quick fix to migrate transcript job to process videos only.

### DIFF
--- a/app/jobs/migrate_metadata_job.rb
+++ b/app/jobs/migrate_metadata_job.rb
@@ -20,6 +20,7 @@ class MigrateMetadataJob < ApplicationJob
 
   def migrate_transcript_to_captions(noid)
     file_set = FileSet.find(noid)
+    return false unless file_set.video?
     return false if file_set.transcript.blank?
     return false if file_set.closed_captions.present?
 

--- a/spec/jobs/migrate_metadata_job_spec.rb
+++ b/spec/jobs/migrate_metadata_job_spec.rb
@@ -71,14 +71,16 @@ RSpec.describe MigrateMetadataJob, type: :job do
         end
       end
 
-      context 'file set' do
+      context 'file set with transcript and without closed_captions' do
         let(:noid) { file_set.id }
-        let(:file_set) { create(:public_file_set) }
+        let(:file_set) { create(:public_file_set, transcript: 'transcript') }
+
+        before { allow(FileSet).to receive(:find).with(file_set.id).and_return(file_set) }
 
         it { is_expected.to be false }
 
-        context 'transcript' do
-          let(:file_set) { create(:public_file_set, transcript: 'transcript') }
+        context 'video' do
+          before { allow(file_set).to receive(:video?).and_return(true) }
 
           it 'migrates' do
             is_expected.to be true
@@ -86,7 +88,7 @@ RSpec.describe MigrateMetadataJob, type: :job do
             expect(file_set.closed_captions).to eq(['transcript'])
           end
 
-          context 'closed_captions' do
+          context 'with closed_captions' do
             let(:file_set) { create(:public_file_set, transcript: 'transcript', closed_captions: ['closed_captions']) }
 
             it do


### PR DESCRIPTION
Migrate transcript to closed captions of video file sets only.