### PR TITLE
Resolves HELIO-3308 Monograph Catalog Full-Screen Cover Needs Cache B…

### DIFF
--- a/app/overrides/riiif/images_controller_overrides.rb
+++ b/app/overrides/riiif/images_controller_overrides.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Riiif::ImagesController.class_eval do
+  prepend(HeliotropeImagesControllerOverrides = Module.new do
+    def image_id
+      #
+      # HELIO-3308 a.k.a. Cache Busting
+      #
+      # Cache busting is where we invalidate a cached file
+      # and force the browser to retrieve the file from the server.
+      #
+      # We can instruct the browser to bypass the cache
+      # by simply changing the filename. To the browser,
+      # this is a completely new resource
+      # so it will fetch the resource from the server.
+      #
+      # The first nine characters of the id is the NOID the rest is the cache buster.
+      params[:id][0..8]
+    end
+  end)
+end

--- a/app/presenters/concerns/common_work_presenter.rb
+++ b/app/presenters/concerns/common_work_presenter.rb
@@ -40,26 +40,27 @@ module CommonWorkPresenter
     end
   end
 
-  def work_thumbnail_src(width = 255)
+  def thumbnail_tag(width, options = {})
     if representative_id.present?
-      "\"/image-service/#{representative_id}/full/#{width},/0/default.png#{cover_cache_breaker(representative_id)}\""
+      ActionController::Base.helpers.image_tag(Riiif::Engine.routes.url_helpers.image_path(cache_buster_id, "#{width},"), options)
     else
-      "\"#{thumbnail_path}\" style=\"max-width:#{width}px\""
+      options[:style] = "max-width: #{width}px"
+      ActionController::Base.helpers.image_tag(thumbnail_path || '', options)
     end
   end
 
-  def work_thumbnail(width = 225)
-    img_tag = "<img class=\"img-responsive\" src="
-    img_tag += work_thumbnail_src(width)
-    img_tag += " alt=\"Cover image for #{title}\">"
-    img_tag
+  def poster_tag(options = {})
+    if representative_id.present?
+      ActionController::Base.helpers.image_tag(Riiif::Engine.routes.url_helpers.image_path(cache_buster_id, :full, :full, 0), options)
+    else
+      ActionController::Base.helpers.image_tag(thumbnail_path || '', options)
+    end
   end
 
-  def cover_cache_breaker(representative_id)
-    # HELIO-2007, HELIO-3305
+  def cache_buster_id
     thumbnail = Hyrax::DerivativePath.new(representative_id).derivative_path + "thumbnail.jpeg"
-    return "" unless File.exist? thumbnail
-    "?#{File.mtime(thumbnail).to_i}"
+    return representative_id unless File.exist? thumbnail
+    representative_id + "#{File.mtime(thumbnail).to_i}"
   end
 
   # This overrides CC 1.6.2's work_show_presenter.rb which is recursive.

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -7,13 +7,13 @@
     <% if @presenter.representative_id.present? %>
       <!-- Image trigger modal -->
       <button type="button" class="btn btn-link" aria-label="Select to enlarge cover" data-toggle="modal" data-target="#modalImage">
-        <%= raw @presenter.work_thumbnail(225) %>
+        <%= @presenter.thumbnail_tag(225, class: "img-responsive", alt: "Cover image for #{@presenter.title}") %>
       </button>
 
       <!-- Modal image -->
       <div class="modal" id="modalImage" tabindex="-1" role="dialog" aria-label="Select the escape key to close the modal window">
         <button type="button" class="close btn btn-default" id="modalClose" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <%= image_tag(riiif.image_path(@presenter.representative_id, :full, :full, 0), tabindex: "-1", alt: '') %>
+        <%= @presenter.poster_tag(tabindex: "-1", alt: '') %>
       </div>
 
       <script type="text/javascript">
@@ -24,7 +24,7 @@
         });
       </script>
     <% else %>
-      <%= raw @presenter.work_thumbnail(225) %>
+      <%= @presenter.thumbnail_tag(225) %>
     <% end %>
     <% if can? :edit, @presenter %>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.monograph_show_path(@presenter.id) %>" title="<%= t('monograph_catalog.index.show_page_button') %>" data-turbolinks="false"><%= t('monograph_catalog.index.show_page_button') %></a>

--- a/app/views/press_catalog/_index_gallery.html.erb
+++ b/app/views/press_catalog/_index_gallery.html.erb
@@ -2,7 +2,7 @@
 <div class="document col-xs-6 col-md-4">
   <%= link_to(url_for_document(document), document_link_params(document, counter: counter)) do %>
     <div class="thumbnail">
-      <img class=\"img-responsive\" src=<%= raw presenter.work_thumbnail_src(145) %> alt="">
+      <%= presenter.thumbnail_tag(145, class: "img-responsive", alt: "") %>
     </div>
     <div class="caption">
       <h3 class="index_title">

--- a/app/views/press_catalog/_index_list.html.erb
+++ b/app/views/press_catalog/_index_list.html.erb
@@ -1,7 +1,7 @@
 <% # container for document in index list view -%>
 <%= link_to(url_for_document(document), document_link_params(document, counter: counter)) do %>
   <div class="col-sm-2 thumbnail">
-    <img class="img-responsive" src=<%= raw presenter.work_thumbnail_src(145) %> alt="">
+    <%= presenter.thumbnail_tag(145, class: "img-responsive", alt: "") %>
   </div>
   <div class="col-sm-10 caption">
     <h3 class="index_title">

--- a/app/views/score_catalog/_index_score.html.erb
+++ b/app/views/score_catalog/_index_score.html.erb
@@ -4,7 +4,7 @@
       <span class="Z3988" title="<%= @presenter.monograph_coins_title %>" aria-hidden="true"></span>
   <% end %>
   <div class="col-sm-3 monograph-cover">
-    <%= raw @presenter.work_thumbnail(225) %>
+    <%= @presenter.thumbnail_tag(225) %>
     <% if can? :edit, @presenter %>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.score_show_path(@presenter.id) %>" title="<%= t('score_catalog.index.show_page_button') %>" data-turbolinks="false"><%= t('score_catalog.index.show_page_button') %></a>
       <a class="btn btn-default manage-monograph-button" href="<%= main_app.edit_hyrax_score_path(@presenter.id) %>" title="<%= t('score_catalog.index.edit_page_button') %>" data-turbolinks="false"><%= t('score_catalog.index.edit_page_button') %></a>


### PR DESCRIPTION
…reaker

Riiif::ImagesController.class_eval do
  prepend(HeliotropeImagesControllerOverrides = Module.new do
    def image_id
      #
      # HELIO-3308 a.k.a. Cache Busting
      #
      # Cache busting is where we invalidate a cached file
      # and force the browser to retrieve the file from the server.
      #
      # We can instruct the browser to bypass the cache
      # by simply changing the filename. To the browser,
      # this is a completely new resource
      # so it will fetch the resource from the server.
      #
      # The first nine characters of the id is the NOID the rest is the cache buster.
      params[:id][0..8]
    end
  end)
end
