### PR TITLE
HELIO-3378 crossref file_set_metadata service changes

### DIFF
--- a/db/migrate/20200603181002_increase_response_xml_length_in_crossref_submission_logs.rb
+++ b/db/migrate/20200603181002_increase_response_xml_length_in_crossref_submission_logs.rb
@@ -1,0 +1,5 @@
+class IncreaseResponseXmlLengthInCrossrefSubmissionLogs < ActiveRecord::Migration[5.1]
+  def change
+    change_column :crossref_submission_logs, :response_xml, :mediumtext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200420214220) do
+ActiveRecord::Schema.define(version: 20200603181002) do
 
   create_table "api_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20200420214220) do
     t.text "initial_http_message"
     t.text "submission_xml", limit: 16777215
     t.string "status"
-    t.text "response_xml"
+    t.text "response_xml", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "file_name"

--- a/spec/services/crossref/file_set_metadata_spec.rb
+++ b/spec/services/crossref/file_set_metadata_spec.rb
@@ -105,6 +105,35 @@ RSpec.describe Crossref::FileSetMetadata do
     end
   end
 
+  describe "#monograph_doi_is_registered?" do
+    # HELIO-3378
+    context "if the monograph has a registered doi" do
+      let(:press) { create(:press, subdomain: "blue", name: "The Blue Press", doi_creation: true) }
+      let(:code) { 200 }
+
+      before do
+        Typhoeus.stub(/api.crossref.org\/works\/10.9985\/blue.999999999/).and_return(Typhoeus::Response.new(response_code: code))
+      end
+
+      it "returns true" do
+        expect(described_class.new(monograph.id).monograph_doi_is_registered?).to be true
+      end
+    end
+
+    context "if the monograph has an unregistered doi" do
+      let(:press) { create(:press, subdomain: "blue", name: "The Blue Press", doi_creation: true) }
+      let(:code) { 404 }
+
+      before do
+        Typhoeus.stub(/api.crossref.org\/works\/10.9985\/blue.999999999/).and_return(Typhoeus::Response.new(response_code: code))
+      end
+
+      it "returns false" do
+        expect(described_class.new(monograph.id).monograph_doi_is_registered?).to be false
+      end
+    end
+  end
+
   describe "#build" do
     subject { described_class.new('999999999').build }
 


### PR DESCRIPTION
* Don't save resource/file_set DOIs if the work DOI is unregistered

* mime_type "audio/x-wave" is sent as "audio/basic"

* CrossrefSubmissionLog submission_xml field is now a :mediumtext