### PR TITLE
Resolves HELIO-3429 BAR: default Relevance sort may not be sorting by…

### DIFF
--- a/app/models/press_search_builder.rb
+++ b/app/models/press_search_builder.rb
@@ -22,9 +22,18 @@ class PressSearchBuilder < ::SearchBuilder
   end
 
   def default_sort_field
+    # This code is working at the moment (see HELIO-3429).
+    # default_sort_field is a very ubiquitous term and is defined multiple times in multiple locations
+    # blacklight_config.default_sort_field appears to morph between being a hash and being a method
+    # In short this is a hack because I have no idea why it works.
+    # Feel free to purge this code and find a better solution.
     case blacklight_params['press']
     when /^barpublishing$/i
-      blacklight_config.sort_fields['year desc'] # Sort by Publication Date (Newest First)
+      if blacklight_params['q'].present?
+        blacklight_config.default_sort_field
+      else
+        blacklight_config.sort_fields['year desc'] # Sort by Publication Date (Newest First)
+      end
     else
       blacklight_config.default_sort_field
     end

--- a/spec/models/press_search_builder_spec.rb
+++ b/spec/models/press_search_builder_spec.rb
@@ -47,6 +47,14 @@ describe PressSearchBuilder do
       before { allow(sort_fields).to receive(:[]).with('year desc').and_return(year_desc) }
 
       it { is_expected.to be year_desc }
+
+      context "params['q'].present?" do
+        before do
+          allow(search_builder).to receive(:blacklight_params).and_return({ 'press' => press, 'q' => 'query' })
+        end
+
+        it { is_expected.to be default_sort_field }
+      end
     end
   end
 end


### PR DESCRIPTION
… relevance

How to validate (see ticket for specific example).

Before deploying to preview search for something, say "cattle".  Note search results.  Now explicitly sort result by relevance by using the drop down.  Note search results order has changed.

Now deploy branch to preview and search for the same thing again, say "cattle".  Note search results.  Now explicitly sort results by relevance by using the drop down.  Note search results order has NOT changed.
