### PR TITLE
HELIO-3417 - remove cite u like sharing option and update specs

### DIFF
--- a/app/presenters/concerns/social_share_widget_presenter.rb
+++ b/app/presenters/concerns/social_share_widget_presenter.rb
@@ -14,7 +14,6 @@ module SocialShareWidgetPresenter
           <li>#{social_share_link(:facebook)}</li>
           <li>#{social_share_link(:reddit)}</li>
           <li>#{social_share_link(:mendeley)}</li>
-          <li>#{social_share_link(:citeulike)}</li>
         </ul>
       </div>
     END
@@ -34,8 +33,6 @@ module SocialShareWidgetPresenter
       "<a href=\"http://www.reddit.com/submit?url=#{citable_link}\" target=\"_blank\">Reddit</a>"
     when :mendeley
       "<a href=\"http://www.mendeley.com/import/?url=#{citable_link}\" target=\"_blank\">Mendeley</a>"
-    when :citeulike
-      "<a href=\"http://www.citeulike.org/posturl?url=#{citable_link}&title=#{url_title}\" target=\"_blank\">Cite U Like</a>"
     end
   end
 end

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -33,7 +33,6 @@
         <li><a href="http://www.facebook.com/sharer.php?u=<%= @presenter.citable_link %>&t=<%= @presenter.url_title %>" target="_blank">Facebook</a></li>
         <li><a href="http://www.reddit.com/submit?url=<%= @presenter.citable_link %>" target="_blank">Reddit</a></li>
         <li><a href="http://www.mendeley.com/import/?url=<%= @presenter.citable_link %>" target="_blank">Mendeley</a></li>
-        <li><a href="http://www.citeulike.org/posturl?url=<%= @presenter.citable_link %>&title=<%= @presenter.url_title %>" target="_blank">Cite U Like</a></li>
       </ul>
   </div>
 </div><!-- form-actions -->

--- a/spec/features/edit_file_set_spec.rb
+++ b/spec/features/edit_file_set_spec.rb
@@ -130,7 +130,7 @@ describe 'Edit a file set' do
 
       # check share links
       share_links = page.all('.btn-group.share ul li a')
-      expect(share_links.count).to eq 5
+      expect(share_links.count).to eq 4
       expect(share_links[0].text).to eq 'Twitter'
       expect(share_links[0]['href']).to eq("http://twitter.com/intent/tweet?text=#{url_escaped_title}&url=#{file_set_share_link}")
       expect(share_links[0]['target']).to eq('_blank')
@@ -143,9 +143,6 @@ describe 'Edit a file set' do
       expect(share_links[3].text).to eq 'Mendeley'
       expect(share_links[3]['href']).to eq("http://www.mendeley.com/import/?url=#{file_set_share_link}")
       expect(share_links[3]['target']).to eq('_blank')
-      expect(share_links[4].text).to eq 'Cite U Like'
-      expect(share_links[4]['href']).to eq("http://www.citeulike.org/posturl?url=#{file_set_share_link}&title=#{url_escaped_title}")
-      expect(share_links[4]['target']).to eq('_blank')
 
       # FileSet page also has authors
       expect(page).to have_content 'Jimmy Johns, Wingperson M. Creator, Sub Way and Wingperson M. Contributor'

--- a/spec/presenters/concerns/social_share_widget_presenter_spec.rb
+++ b/spec/presenters/concerns/social_share_widget_presenter_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe SocialShareWidgetPresenter do
           <li>#{presenter.social_share_link(:facebook)}</li>
           <li>#{presenter.social_share_link(:reddit)}</li>
           <li>#{presenter.social_share_link(:mendeley)}</li>
-          <li>#{presenter.social_share_link(:citeulike)}</li>
         </ul>
       </div>
     END
@@ -39,7 +38,6 @@ RSpec.describe SocialShareWidgetPresenter do
       expect(presenter.social_share_link(:facebook)).to eq("<a href=\"http://www.facebook.com/sharer.php?u=https://hdl.handle.net/2027/fulcrum.999999999&t=%23hashtag+Test+monograph+with+MD+Italics+and+HTML+Italics\" target=\"_blank\">Facebook</a>")
       expect(presenter.social_share_link(:reddit)).to eq("<a href=\"http://www.reddit.com/submit?url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Reddit</a>")
       expect(presenter.social_share_link(:mendeley)).to eq("<a href=\"http://www.mendeley.com/import/?url=https://hdl.handle.net/2027/fulcrum.999999999\" target=\"_blank\">Mendeley</a>")
-      expect(presenter.social_share_link(:citeulike)).to eq("<a href=\"http://www.citeulike.org/posturl?url=https://hdl.handle.net/2027/fulcrum.999999999&title=%23hashtag+Test+monograph+with+MD+Italics+and+HTML+Italics\" target=\"_blank\">Cite U Like</a>")
     end
   end
 end


### PR DESCRIPTION
Resolves HELIO-3417 - removal of cite u like sharing option from the e-reader and file set show page.