### PR TITLE
Remove print message from rake task.

### DIFF
--- a/lib/tasks/handle.rake
+++ b/lib/tasks/handle.rake
@@ -4,6 +4,5 @@ desc 'Update Handle Records'
 namespace :heliotrope do
   task handle: :environment do
     HandleJob.perform_later
-    p "HandleJob.perform_later"
   end
 end


### PR DESCRIPTION
So cron won't send annoying emails.