### PR TITLE
Partially resolves HELIO-3449 blacklight search_context.js cause 404 error.

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module UrlHelper
+  include Blacklight::UrlHelperBehavior
+
+  ##
+  # Attributes for a link that gives a URL we can use to track clicks for the current search session
+  # @param [SolrDocument] document
+  # @param [Integer] counter
+  # @example
+  #   session_tracking_params(SolrDocument.new(id: 123), 7)
+  #   => { data: { :'tracker-href' => '/catalog/123/track?counter=7&search_id=999' } }
+  def session_tracking_params(_document, _counter)
+    # path = session_tracking_path(document, per_page: params.fetch(:per_page, search_session['per_page']), counter: counter, search_id: current_search_session.try(:id))
+
+    # if path.nil?
+    # return {}
+    # end
+
+    # { data: {:'context-href' => path } }
+    #
+
+    # HELIO-3449 Return {} so data-context-href="/catalog/<noid>/track?counter=<n>&locale=en&search_id=<id>" is not included in anchor tag.
+    # Hence,
+    #
+    #   Blacklight.do_search_context_behavior = function() {
+    #     $('a[data-context-href]').on('click.search-context', Blacklight.handleSearchContextMethod);
+    #   };
+    #
+    # Will never happen.  See search_context.js in blacklight gem.
+    {}
+  end
+  protected :session_tracking_params
+end


### PR DESCRIPTION
Override session_tracking_params method in Blacklight URL Helper to remove data-context-href attribute from anchor tag in search results.

Before:

<a data-context-href="/catalog/8w32r7414/track?counter=1&amp;locale=en&amp;search_id=67204814" href="/concern/monographs/8w32r7414?locale=en">
  ...
</a>

After:

<a href="/concern/monographs/8w32r7414?locale=en">
  ...
</a>

Verify blacklight search behavior does not change from the user's perspective.

