### PR TITLE
Are Third-Party Cookies enabled?

### DIFF
--- a/app/views/press_statistics/index.html.erb
+++ b/app/views/press_statistics/index.html.erb
@@ -51,6 +51,7 @@
                 </div>
               </div>
             </div>
+            <p>Not seeing the graphs? Third-Party Cookies must be enabled (<a href="https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled" target="_blank">check here</a>). Strict tracker blocking will also cause issues. Please adjust browser settings and reload.</p>
           </section>
         <% end %>
       </div>


### PR DESCRIPTION
Automatic Third-Party Cookie detection isn't trivial so hopefully this passive solution of stating third-party cookies are required

`<p>Third-Party Cookies must be enabled. <a href="https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled" target="_blank">Are Third-Party Cookies enabled?</a></p>
`

and providing a link which opens a new tab to [https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled](https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled) which will test if the user has third-party cookies enabled and has information on where in the browser settings to look will be sufficient.