### PR TITLE
HELIO-3332 Don't use AF in Riiif::Image.file_resolver.id_to_uri use s…

### DIFF
--- a/config/initializers/riiif_initializer.rb
+++ b/config/initializers/riiif_initializer.rb
@@ -5,8 +5,12 @@ Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
 
 # This tells RIIIF how to resolve the identifier to a URI in Fedora
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-  # This is slow. TODO: find an alternative if possible
-  FileSet.find(id).files.first&.uri.to_s || ''
+  # see HELIO-3332. This should work with re-versioned Files.
+  doc = ActiveFedora::SolrService.query("{!terms f=id}#{id}", fl: ['id', 'original_file_id_ssi'], rows: 1).first
+  return "" if doc.nil? || doc["original_file_id_ssi"].nil?
+  ActiveFedora::Base.id_to_uri(CGI.unescape(doc["original_file_id_ssi"])).tap do |url|
+    Rails.logger.info "[RIIIF] Resolved #{id} to #{url}"
+  end
 end
 
 # In order to return the info.json endpoint, we have to have the full height and width of
@@ -14,17 +18,20 @@ end
 # cached in Solr. The following block directs the info_service to return those values:
 Riiif::Image.info_service = lambda do |id, _file|
   Rails.logger.debug("[RIIIF] H/W CHECK FOR #{id}")
-  doc = ActiveFedora::SolrService.query("{!terms f=id}#{id}", rows: 1).first
+  doc = ActiveFedora::SolrService.query("{!terms f=id}#{id}", fl: ['id', 'height_is', 'width_is'], rows: 1).first
   { height: doc["height_is"], width: doc["width_is"] }
 end
 
 module Riiif
   def Image.cache_key(id, options)
-    str = options.to_h.merge(id: id).delete_if { |_, v| v.nil? }.to_s
-    # add md5 of the file itself to invalidate the cache if the file has been changed (by reversioning or whatever)
-    filemd5 = Digest::MD5.file(Riiif::Image.file_resolver.find(id).path)
-    Rails.logger.debug("[RIIIF] FILE MD5: #{filemd5}")
-    'riiif:' + Digest::MD5.hexdigest(str) + filemd5.to_s
+    # How expensive is this...? maybe skylight can help here
+    Skylight.instrument title: "Riiif CacheKey" do
+      str = options.to_h.merge(id: id).delete_if { |_, v| v.nil? }.to_s
+      # Add md5 of the file itself to invalidate the cache if the file has been changed (by reversioning or whatever)
+      filemd5 = Digest::MD5.file(Riiif::Image.file_resolver.find(id).path)
+      Rails.logger.debug("[RIIIF] FILE MD5: #{filemd5}")
+      'riiif:' + Digest::MD5.hexdigest(str) + filemd5.to_s
+    end
   end
 end
 

--- a/spec/config/initializers/riiif_initializer_spec.rb
+++ b/spec/config/initializers/riiif_initializer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Riiif::Image do
+  describe "#file_resolver.id_to_uri" do
+    context "with original_file_id_ssi indexed" do
+      let(:fs1) do
+        ::SolrDocument.new(id: '111111111',
+                           has_model_ssim: ['FileSet'],
+                           original_file_id_ssi: "111111111/files/c2ae57cc-bb27-4d43-af8a-aab28cf807ba/fcr:versions/version1")
+      end
+
+      before do
+        ActiveFedora::SolrService.add(fs1.to_h)
+        ActiveFedora::SolrService.commit
+      end
+
+      it "returns the file uri for download" do
+        expect(Riiif::Image.file_resolver.id_to_uri.call("111111111")).to match "/rest/test/11/11/11/11/111111111/files/c2ae57cc-bb27-4d43-af8a-aab28cf807ba/fcr:versions/version1"
+      end
+    end
+
+    context "if there's no original_file_id_ssi" do
+      # Prior to around hyrax 2.5, the "original_file_id_ssi" field was not indexed.
+      # See https://tools.lib.umich.edu/jira/browse/HELIO-3332?focusedCommentId=1019705&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1019705
+      # All pre Hyrax 2.5 image files on testing/staging/preview and production have now been reindexed
+      # So we should never see that field missing, but on the very remote chance it is, we'll test the "sad" path.
+      let(:fs1) do
+        ::SolrDocument.new(id: '222222222',
+                           has_model_ssim: ['FileSet'])
+      end
+
+      before do
+        ActiveFedora::SolrService.add(fs1.to_h)
+        ActiveFedora::SolrService.commit
+      end
+
+      it "returns nothing, with no errors" do
+        expect(Riiif::Image.file_resolver.id_to_uri.call("222222222")).to eq ""
+      end
+    end
+
+    context "with a missing/incorrect noid" do
+      it "returns nothing, with no errors" do
+        expect(Riiif::Image.file_resolver.id_to_uri.call("x9")).to eq ""
+      end
+    end
+  end
+end


### PR DESCRIPTION
…olr instead.

There are a lot of notes in the ticket but essentially:

1) Using solr instead of fedora is faster, including at "scale" when testing on preview. 
2) The field we need to use is in the index of all image FileSets on testing/staging/preview/production and will continue to be for all new FIleSets. If you have really old images in dev you should reindex their FileSets.
3) This works with "re-versioned" FileSets, you'll always get the latest version.
4) If by some remote chance the field is ever missing from the index there won't be any errors thrown and there are tests that prove that (but obviously IIIF won't work, you wouldn't get an image, similar to when height and/or width is missing).


