### PR TITLE
turbolinks and ga_event_tracking

### DIFF
--- a/app/assets/javascripts/mozilla-pdf-viewer.js
+++ b/app/assets/javascripts/mozilla-pdf-viewer.js
@@ -1,7 +1,11 @@
 // A place to put mozilla-pdf-viwer-specific scripts
 //
 //= require jquery
+// needed to load Google Analytics Event Tracking
+//= require turbolinks
 //= require js.cookie
 // needed by social media share links widget (data-toggle="dropdown")
 //= require bootstrap/dropdown
 //= require cozy-sun-bear-main
+// needed by Google Analytics
+//= require application/ga_event_tracking


### PR DESCRIPTION
Added turbolinks and ga_event_tracking requires to mozilla-pdf-viewer.js