### PR TITLE
HELIO-3379 Create Press Analyst role

### DIFF
--- a/app/controllers/hyrax/admin/stats_controller.rb
+++ b/app/controllers/hyrax/admin/stats_controller.rb
@@ -74,13 +74,13 @@ module Hyrax
       private
 
         def only_elevated_users
-          return if current_ability.platform_admin? || current_ability.press_admin? || current_ability.press_editor?
+          return if current_ability.platform_admin? || current_ability.press_admin? || current_ability.press_editor? || current_ability.press_analyst?
           render 'hyrax/base/unauthorized', status: :unauthorized
         end
 
         def set_presses_and_institutions
           # Only presses the user is affiliated with (are an admin, editor, etc)
-          @presses = (current_user&.admin_presses + current_user&.editor_presses).uniq
+          @presses = (current_user&.admin_presses + current_user&.editor_presses + current_user&.analyst_presses).uniq
           # Reports can be "all institutions" at once or each individual institution seperately
           @institutions = Greensub::Institution.order(:name).to_a.unshift(Greensub::Institution.new(name: "All Institutions", identifier: '*'))
         end

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -6,6 +6,14 @@ class PublishJob < ApplicationJob
   def perform(curation_concern)
     curation_concern.date_published = [Hyrax::TimeService.time_in_utc]
 
+    # We need to make sure we're getting read_groups and write_groups inherited
+    # from the monograph if this is a FileSet
+    # This seems to be unstable, see HELIO-3630
+    if curation_concern.is_a?(FileSet) && curation_concern&.parent.present?
+      curation_concern.read_groups = curation_concern.parent.read_groups
+      curation_concern.edit_groups = curation_concern.parent.edit_groups
+    end
+
     # TODO: this is probably not how we publish in the long run
     curation_concern.visibility = 'open'
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Role < ApplicationRecord
-  ROLES = %w[admin editor].freeze
+  ROLES = %w[admin editor analyst].freeze
   # A platform_admin has a role of "admin" with a resource of "nil" so
   # we need belongs_to: resource to be optional. In rails 5 this defaults to false.
   belongs_to :resource, polymorphic: true, optional: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,6 +109,10 @@ class User < ApplicationRecord
     press_roles.where(role: 'editor')
   end
 
+  def analyst_roles
+    press_roles.where(role: 'analyst')
+  end
+
   # Presses for which this user is an editor
   def editor_presses
     platform_admin? ? Press.order(:name) : presses.where(['roles.role = ?', 'editor']).order(:name)
@@ -117,6 +121,10 @@ class User < ApplicationRecord
   # Presses for which this user is an admin
   def admin_presses
     platform_admin? ? Press.order(:name) : presses.where(['roles.role = ?', 'admin']).order(:name)
+  end
+
+  def analyst_presses
+    platform_admin? ? Press.order(:name) : presses.where(['roles.role = ?', 'analyst']).order(:name)
   end
 
   def platform_admin?

--- a/app/services/group_permission_actor_service.rb
+++ b/app/services/group_permission_actor_service.rb
@@ -5,17 +5,25 @@ module GroupPermissionActorService
   # and then use the shared_examples/group_permission_actor.rb spec
   # We need to apply these permissions to the Work on create/update due
   # to the way we use Roles in heliotrope and what hyrax/blacklight/AF expects...
-  def self.apply_default_group_permissions(env)
+  def self.apply_default_group_permissions(env) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     press = env.attributes['press'] || env.curation_concern.press
     admin = "#{press}_admin"
     editor = "#{press}_editor"
+    analyst = "#{press}_analyst"
 
-    (env.attributes["read_groups"] ||= []).push(admin).push(editor)
-    (env.attributes["edit_groups"] ||= []).push(admin).push(editor)
+    env.attributes["read_groups"] = [] if env.attributes["read_groups"].blank?
+    env.attributes["edit_groups"] = [] if env.attributes["edit_groups"].blank?
+
+    env.attributes["read_groups"].push(admin)   unless env.attributes["read_groups"].include?(admin)
+    env.attributes["read_groups"].push(editor)  unless env.attributes["read_groups"].include?(editor)
+    env.attributes["read_groups"].push(analyst) unless env.attributes["read_groups"].include?(analyst)
+
+    env.attributes["edit_groups"].push(admin)   unless env.attributes["edit_groups"].include?(admin)
+    env.attributes["edit_groups"].push(editor)  unless env.attributes["edit_groups"].include?(editor)
 
     if env.attributes["visibility"] == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC ||
        env.curation_concern.public?
-      env.attributes["read_groups"].push("public")
+      env.attributes["read_groups"].push("public") unless env.attributes["read_groups"].include?("public")
     end
     env
   end

--- a/app/views/hyrax/admin/stats/_institution.html.erb
+++ b/app/views/hyrax/admin/stats/_institution.html.erb
@@ -24,7 +24,7 @@ that will be emailed to the provided email address.</p>
     </div>
     <div class="col-sm-2">
       <label for="press" class="col-form-label">Press</label>
-      <%= select_tag(:press, options_for_select((current_user.admin_presses + current_user.editor_presses).uniq.map { |p| [p.name, p.id] }), class: 'form-control') %>
+      <%= select_tag(:press, options_for_select((current_user.admin_presses + current_user.editor_presses + current_user.analyst_presses).uniq.map { |p| [p.name, p.id] }), class: 'form-control') %>
     </div>
     <div class="col-sm-2">
       <label for="start_date" class="col-form-label">Start Date</label>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 </li>
 
-<% if can? :read, :admin_dashboard %>
+<% if can? :read, :stats_dashboard %>
 <li>
   <% #byebug %>
   <%= menu.collapsable_section "Reports",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,7 @@ en:
   role:
     admin: "Admin"
     editor: "Editor"
+    analyst: "Analyst"
   roles:
     index:
       email: "Email"

--- a/lib/tasks/temporary/add_analyst_role.rake
+++ b/lib/tasks/temporary/add_analyst_role.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+desc "Add the analyst role to all works and file_sets, HELIO-3379"
+namespace :heliotrope do
+  task add_analyst_role: :environment do
+    # This will not work.
+    # There's a big story about it in https://tools.lib.umich.edu/jira/browse/HELIO-3613
+    # I'll leave this here for now, but we'll need to do HELIO-3613 before
+    # we add the analyst role retroactively to all Works/FileSets
+    raise "Don't run this, see HELIO-3613"
+
+    Monograph.all.to_a.each do |m|
+      analyst = "#{m.press}_analyst"
+      next if m.read_groups.include?(analyst)
+      p "#{m.id}"
+      # If we try to do array operations like "<<" or "push" on m.read_groups
+      # it will fail silently because... AF I guess? IDK.
+      # It seems you can only assign to m.read_groups with "="
+      read_groups = m.read_groups
+      read_groups.push(analyst)
+      m.read_groups = read_groups
+      m.save!
+      # This job is being weird... might have to not use it after all...
+      InheritPermissionsJob.perform_later(m)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,5 +27,11 @@ FactoryBot.define do
         user.roles.create role: 'editor', resource: evaluator.press
       end
     end
+
+    factory :press_analyst do
+      after(:create) do |user, evaluator|
+        user.roles.create role: 'analyst', resource: evaluator.press
+      end
+    end
   end
 end

--- a/spec/helpers/roles_helper_spec.rb
+++ b/spec/helpers/roles_helper_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe RolesHelper, type: :helper do
   describe "#roles_for_select" do
     it 'works' do
-      expect(roles_for_select).to eq({ "Admin"=>"admin", "Editor"=>"editor" })
+      expect(roles_for_select).to eq({ "Admin"=>"admin", "Editor"=>"editor", "Analyst"=>"analyst" })
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -56,6 +56,7 @@ describe Ability do
 
       is_expected.to be_able_to(:manage, another_user)
       is_expected.to be_able_to(:read, :admin_dashboard)
+      is_expected.to be_able_to(:read, :stats_dashboard)
     end
 
     it "can read, update, publish or destroy a monograph created by another user" do
@@ -99,6 +100,7 @@ describe Ability do
       is_expected.to     be_able_to(:update, my_press)
       is_expected.not_to be_able_to(:update, other_press)
       is_expected.to     be_able_to(:read, :admin_dashboard)
+      is_expected.to be_able_to(:read, :stats_dashboard)
     end
 
     context "roles" do
@@ -180,6 +182,7 @@ describe Ability do
       is_expected.not_to be_able_to(:update, my_press)
       is_expected.not_to be_able_to(:update, other_press)
       is_expected.not_to be_able_to(:read, :admin_dashboard)
+      is_expected.to be_able_to(:read, :stats_dashboard)
     end
 
     context "roles" do
@@ -224,6 +227,98 @@ describe Ability do
     describe "RolePresenter" do
       let(:my_press_user) { create(:press_editor, press: my_press) }
       let(:other_press_user) { create(:press_editor, press: other_press) }
+
+      it { is_expected.to     be_able_to(:read, RolePresenter.new(current_user.roles.first, current_user, current_user)) }
+      it { is_expected.not_to be_able_to(:read, RolePresenter.new(my_press_user.roles.first, my_press_user, current_user)) }
+      it { is_expected.not_to be_able_to(:read, RolePresenter.new(other_press_user.roles.first, other_press_user, current_user)) }
+    end
+
+    describe "RolesPresenter" do
+      let(:another_user) { double("another_user") }
+
+      it { is_expected.to be_able_to(:read, RolesPresenter.new(current_user, current_user)) }
+      it { is_expected.to be_able_to(:read, RolesPresenter.new(another_user, current_user)) }
+    end
+
+    describe "UserPresenter" do
+      let(:my_press_user) { create(:press_editor, press: my_press) }
+      let(:other_press_user) { create(:press_editor, press: other_press) }
+
+      it { is_expected.to     be_able_to(:read, UserPresenter.new(current_user, current_user)) }
+      it { is_expected.not_to be_able_to(:read, UserPresenter.new(my_press_user, current_user)) }
+      it { is_expected.not_to be_able_to(:read, UserPresenter.new(other_press_user, current_user)) }
+    end
+
+    describe "UsersPresenter" do
+      it { is_expected.not_to be_able_to(:read, UsersPresenter.new(current_user)) }
+    end
+  end
+
+  describe 'press_analyst' do
+    let(:my_press) { create(:press) }
+    let(:other_press) { create(:press) }
+    let(:current_user) { create(:press_analyst, press: my_press) }
+
+    it do
+      is_expected.not_to be_able_to(:create, Press.new)
+      is_expected.not_to be_able_to(:update, my_press)
+      is_expected.not_to be_able_to(:update, other_press)
+      is_expected.not_to be_able_to(:read, :admin_dashboard)
+      is_expected.to be_able_to(:read, :stats_dashboard)
+    end
+
+    context "roles" do
+      let(:my_press_role) { create(:role, resource: my_press) }
+      let(:other_press_role) { create(:role) }
+
+      it do
+        is_expected.not_to be_able_to(:read, my_press_role)
+        is_expected.not_to be_able_to(:update, my_press_role)
+        is_expected.not_to be_able_to(:destroy, my_press_role)
+
+        is_expected.not_to be_able_to(:read, other_press_role)
+        is_expected.not_to be_able_to(:update, other_press_role)
+        is_expected.not_to be_able_to(:destroy, other_press_role)
+      end
+    end
+
+    context "creating" do
+      let(:monograph_for_my_press) { Monograph.new(press: my_press.subdomain) }
+      let(:monograph_for_other_press) { Monograph.new(press: other_press.subdomain) }
+
+      it do
+        is_expected.not_to be_able_to(:create, monograph_for_my_press)
+        is_expected.not_to be_able_to(:create, monograph_for_other_press)
+      end
+    end
+
+    context "reading" do
+      let(:monograph_for_my_press) { create(:monograph, title: ["A Book"], press: my_press.subdomain) }
+      let(:monograph_for_other_press) { create(:monograph, title: ["B Book"], press: other_press.subdomain) }
+
+      it do
+        is_expected.to     be_able_to(:read, monograph_for_my_press)
+        is_expected.not_to be_able_to(:read, monograph_for_other_press)
+      end
+    end
+
+    context "updating" do
+      let(:my_presenter) { Hyrax::MonographPresenter.new(SolrDocument.new(id: 'my_id', press_tesim: my_press.subdomain), subject) }
+      let(:other_presenter) { Hyrax::MonographPresenter.new(SolrDocument.new(id: 'other_id', press_tesim: other_press.subdomain), subject) }
+
+      it do
+        is_expected.not_to be_able_to(:update, my_presenter)
+        is_expected.not_to be_able_to(:update, other_presenter)
+      end
+    end
+
+    context "ApplicationPresenter" do
+      it { is_expected.not_to be_able_to(:read, ApplicationPresenter.new(current_user)) }
+    end
+
+    describe "RolePresenter" do
+      let(:my_press_user) { create(:press_analyst, press: my_press) }
+      let(:other_press_user) { create(:press_analyst, press: other_press) }
 
       it { is_expected.to     be_able_to(:read, RolePresenter.new(current_user.roles.first, current_user, current_user)) }
       it { is_expected.not_to be_able_to(:read, RolePresenter.new(my_press_user.roles.first, my_press_user, current_user)) }
@@ -308,6 +403,7 @@ describe Ability do
         is_expected.not_to be_able_to(:update, role)
         is_expected.not_to be_able_to(:destroy, role)
         is_expected.not_to be_able_to(:read, :admin_dashboard)
+        is_expected.not_to be_able_to(:read, :stats_dashboard)
       end
     end
 

--- a/spec/support/shared_examples/group_permission_actor.rb
+++ b/spec/support/shared_examples/group_permission_actor.rb
@@ -31,7 +31,7 @@ shared_examples "a group permission actor for works" do
       it "adds default group read and edit permissions" do
         expect(middleware.create(env)).to be true
 
-        expect(curation_concern.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
+        expect(curation_concern.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor", "heliotrope_analyst"]
         expect(curation_concern.edit_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
       end
 
@@ -53,7 +53,7 @@ shared_examples "a group permission actor for works" do
       it "adds default group read and edit permissions including public read" do
         expect(middleware.create(env)).to be true
 
-        expect(curation_concern.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor", "public"]
+        expect(curation_concern.read_groups).to match_array ["heliotrope_admin", "heliotrope_editor", "heliotrope_analyst", "public"]
         expect(curation_concern.edit_groups).to match_array ["heliotrope_admin", "heliotrope_editor"]
       end
 


### PR DESCRIPTION
Reports work fine for analysts, see HELIO-3379. Draft access should "mostly" work ok, but all our roles are having some issues as talked about in HELIO-3630.