### PR TITLE
CSB-254 - update csb to point to updated master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'combine_pdf', '~> 1.0'
 gem 'config'
 
 # Use gem version of cozy-sun-bear
-gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'cbc8a324857a3ff84da388a58a555e0f41d13ffc'
+gem 'cozy-sun-bear', git: 'https://github.com/mlibrary/cozy-sun-bear', ref: 'd6319f718343e09f793de7351e1d49a5c89536e9'
 
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mlibrary/cozy-sun-bear
-  revision: cbc8a324857a3ff84da388a58a555e0f41d13ffc
-  ref: cbc8a324857a3ff84da388a58a555e0f41d13ffc
+  revision: d6319f718343e09f793de7351e1d49a5c89536e9
+  ref: d6319f718343e09f793de7351e1d49a5c89536e9
   specs:
     cozy-sun-bear (0.1.0)
       railties (>= 3.1.1)


### PR DESCRIPTION
Resolves CSB-254, adds css to handle display of table heads that overflow the table container in the Fulcrum EReader.