### PR TITLE
HELIO-3668 fix failing travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: required
 bundler_args: --without production
 before_install:
   - gem update --system
-  - gem install bundler --pre
+  - gem install -v 2.1.4 bundler
   - nvm install node
   - npm install --global yarn
 install:


### PR DESCRIPTION
travis ci builds are failing with libv8 compilation errors.
It might be because bundler 2.2 was released yesterday and we've
been installing bundler on travis with "--pre".

Something seems to be up with bundler 2.2 being smart about fetching
pre-built gems but maybe not working quite right?

https://github.com/rubyjs/libv8/issues/310#issuecomment-742481001