### PR TITLE
Upgrade Skylight gem to 5.0beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,7 @@ gem 'oauth2', '~> 1.2'
 gem 'signet'
 
 # performance profiling
-gem 'skylight'
+gem 'skylight', '~> 5.0.0.beta4'
 
 # Rails Webpack Tool
 gem 'webpacker', '~> 5.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -931,10 +931,8 @@ GEM
       tilt (~> 2.0)
     sitemap_generator (6.0.1)
       builder (~> 3.0)
-    skylight (3.1.1)
-      skylight-core (= 3.1.1)
-    skylight-core (3.1.1)
-      activesupport (>= 4.2.0)
+    skylight (5.0.0.beta4)
+      activesupport (>= 5.2.0)
     slop (4.8.1)
     solr_wrapper (2.2.0)
       faraday
@@ -1116,7 +1114,7 @@ DEPENDENCIES
   simple_solr_client
   sinatra (~> 2.0.2)
   sitemap_generator (~> 6.0.1)
-  skylight
+  skylight (~> 5.0.0.beta4)
   solr_wrapper (>= 1.1, < 3.0)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
Thank you so much for participating in the [Skylight for Open Source](https://www.skylight.io/oss) program. We'd like to invite Fulcrum to participate in the public alpha for Source Locations for Skylight!

With this new feature, Skylight can help you pinpoint the locations in your code that correspond to events in the Skylight Event Sequence. This feature will allow your contributors to more easily find out exactly where an expensive operation originated without having to scour your code.

![https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png](https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png)

When you merge this PR, we will enable the feature flag for you on Skylight's servers. Then, once you deploy, you should begin seeing source locations data shortly after.

You can find documentation about the new feature at [https://www.skylight.io/support/source-locations](https://www.skylight.io/support/source-locations), and as always, if you have any questions or feedback, please get in touch with us either by responding here, emailing support@skylight.io, or via the in-app communicator at the lower-right of your Skylight dashboard.