### PR TITLE
HELIO-3307 - Allow subpresses to inherit parent press branding in PDF and EPUB ereaders

### DIFF
--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -54,7 +54,7 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
     <%= render 'shared/survey_nonmodal' %>
   <% end %>
   <div class="skip"></div>
-  <div id="epub" class="<%= @subdomain %>">
+  <%= tag.div id: 'epub', class: press_presenter.present? ? press_presenter.press_subdomains : '' do %>
     <div id="reader"></div>
 
     <script type="text/javascript">
@@ -177,7 +177,7 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
         });
       }
     </script>
-  </div>
+  <% end %>
   <%= render 'shared/ga' %>
 <% end %>
 <%= render template: 'layouts/boilerplate' %>

--- a/app/views/e_pubs/show_pdf.html.erb
+++ b/app/views/e_pubs/show_pdf.html.erb
@@ -47,11 +47,11 @@
   <!-- `role="status"` implies `aria-live="polite"` but redundancy is recommended for maximum compatibility -->
   <!-- see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions -->
   <div id="pdfLoadingProgressBar" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
-    <div id="epub" class="<%= @subdomain %>">
+    <%= tag.div id: 'epub', class: press_presenter.present? ? press_presenter.press_subdomains : '' do %>
       <div id="reader">
         <div id="mainContainer"></div>
       </div>
-    </div>
+    <% end %>
 
     <div id="mozilla-pdf-viewer-ui" style="display: none">
       <div id="sidebarResizer" class="hidden"></div>


### PR DESCRIPTION
Adds the parent press subdomain to #epub container, if a parent press exists, so that subpresses inherit ereader branding of their parent press.