### PR TITLE
HELIO-3624 - Fix access icon display, access copy, and access legend box sizing

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -485,6 +485,10 @@ footer.press {
   .panel-group .panel + .panel {
     margin-top: 0px;
   }
+
+  .access-legend {
+    padding-right: 15px;
+  }
 }
 
 ///////////////////////////////////
@@ -635,7 +639,7 @@ footer.press {
       }
     }
 
-    .open-access {
+    .access {
       display: flex;
       align-items:center;
       margin-top: 1em;

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -35,7 +35,7 @@
                   <% if params["user_access"].nil? %>
                     <input type="radio" aria-label="View all content" name="user_access" checked> All content
                   <% else %>
-                    <input type="radio" aria-lable="View all content" name="user_access"> All content
+                    <input type="radio" aria-label="View all content" name="user_access"> All content
                   <% end %>
                 </span>
               </a>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -33,9 +33,9 @@
               <a class="facet-anchor facet_select" href="<%= url_for(params.deep_dup.except("user_access").except("page").permit!) %>">
                 <span class="facet-label">
                   <% if params["user_access"].nil? %>
-                    <input type="radio" aria-label="View all content" name="user_access" checked> All Content
+                    <input type="radio" aria-label="View all content" name="user_access" checked> All content
                   <% else %>
-                    <input type="radio" aria-lable="View all content" name="user_access"> All Content
+                    <input type="radio" aria-lable="View all content" name="user_access"> All content
                   <% end %>
                 </span>
               </a>
@@ -73,7 +73,7 @@
   </div>
   <% if params['controller'] == "press_catalog" %>
   <%# Access Icon Legend, HELIO-3520 %>
-  <div class="panel-group" style="padding: 15px">
+  <div class="panel-group access-legend">
     <div class="panel panel-default facet_limit">
       <div class="panel-heading">
         <h3 class="panel-title">

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -59,7 +59,7 @@
       <span aria-label="funder display" class="funder_display"><i><%= @presenter.funder_display %></i></span>
     <% end %>
     <% if @presenter.access_level(@actor_product_ids, @allow_read_product_ids).show? %>
-      <div>
+      <div class="access">
         <%= @presenter.access_level(@actor_product_ids, @allow_read_product_ids).icon_lg.html_safe %>
         <span><%= @presenter.access_level(@actor_product_ids, @allow_read_product_ids).text.html_safe %></span>
       </div>

--- a/spec/features/press_catalog_facets_spec.rb
+++ b/spec/features/press_catalog_facets_spec.rb
@@ -11,7 +11,7 @@ describe "Press Catalog Facets" do
       visit press_catalog_path(press: press.subdomain)
       # save_and_open_page
       expect(page).to have_selector('#facet-user_access')
-      expect(page).to have_text 'All Content'
+      expect(page).to have_text 'All content'
       expect(page).to have_text 'Only content I can access'
       expect(page).not_to have_text 'Only open access content'
     end
@@ -21,7 +21,7 @@ describe "Press Catalog Facets" do
       visit press_catalog_path(press: press.subdomain)
       # save_and_open_page
       expect(page).to have_selector('#facet-user_access')
-      expect(page).to have_text 'All Content'
+      expect(page).to have_text 'All content'
       expect(page).to have_text 'Only content I can access'
       expect(page).to have_text 'Only open access content'
     end


### PR DESCRIPTION
Resolves HELIO-3624 by adding a class to the div wrapping the access icons on the monograph catalog page, adjusting the CSS for the access icon legend box on publisher page, and lower cases the "All content" radio select text on the publisher page.

<img width="558" alt="Screen Shot 2021-01-14 at 1 13 30 PM" src="https://user-images.githubusercontent.com/1686111/104631520-5a832b80-566a-11eb-90c4-f38850c349e5.png">

<img width="557" alt="Screen Shot 2021-01-14 at 1 13 42 PM" src="https://user-images.githubusercontent.com/1686111/104631531-5d7e1c00-566a-11eb-9963-0459dedb2c79.png">
