### PR TITLE
Resolves HELIO-3677 Fix OPDS feed based on James English feedback

### DIFF
--- a/app/models/sighrax/monograph.rb
+++ b/app/models/sighrax/monograph.rb
@@ -35,8 +35,20 @@ module Sighrax
       @identifier
     end
 
-    def language
-      Array(data['language_tesim']).first
+    def languages
+      Array(data['language_tesim'])
+    end
+
+    def modified
+      # Going to leverage the aptrust_deposits table created_at field
+      # since this is the modify date of the entire monograph a.k.a.
+      # Maximum date_modified_dtsi of Monograph and FileSets .
+      record = AptrustDeposit.find_by(noid: noid)
+      value = record&.created_at
+      value ||= Time.parse(Array(data['date_modified_dtsi']).first) if Array(data['date_modified_dtsi']).first # rubocop:disable Rails/TimeZone
+      value
+    rescue StandardError => _e
+      nil
     end
 
     def published

--- a/spec/models/sighrax/monograph_spec.rb
+++ b/spec/models/sighrax/monograph_spec.rb
@@ -126,15 +126,30 @@ RSpec.describe Sighrax::Monograph, type: :model do
       end
     end
 
-    describe '#language' do
-      subject { monograph.language }
+    describe '#languages' do
+      subject { monograph.languages }
+
+      let(:languages) { %w[english french] }
 
       before do
-        hyrax_monograph.language = ['Language']
+        hyrax_monograph.language = languages
         hyrax_monograph.save!
       end
 
-      it { is_expected.to eq('Language') }
+      it { is_expected.to contain_exactly(*languages) }
+    end
+
+    describe '#modified' do
+      subject { monograph.modified }
+
+      let(:modified_date) { Time.parse(Time.now.utc.iso8601) }
+
+      before do
+        hyrax_monograph.date_modified = modified_date
+        hyrax_monograph.save!
+      end
+
+      it { is_expected.to eq(modified_date) }
     end
 
     describe '#published' do

--- a/spec/requests/api/opds/V2/feeds_spec.rb
+++ b/spec/requests/api/opds/V2/feeds_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             "navigation": [
               {
                 "title": "University of Michigan Press Ebook Collection Open Access",
-                "rel": "first",
-                "href": "/umpebc_oa",
+                "href": Rails.application.routes.url_helpers.api_opds_umpebc_oa_url,
                 "type": "application/opds+json"
               }
             ]
@@ -122,6 +121,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             monograph.representative_id = cover.id
             monograph.ordered_members << epub
             monograph.open_access = 'yes'
+            monograph.date_modified = Time.now
             monograph.save!
             cover.save!
             epub.save!


### PR DESCRIPTION
James English's team at SimplyE compiled this feedback on the work of HELIO-3483.

There are still some outstanding questions, and his answers my expand this ticket. But this much is clear:

[X] Replace relative URL /umpebc_oa with absolute https://www.fulcrum.org/api/opds/umpebc_oa.
Authors of OPDS 1.0/2.0 specs highly recommend to not use relative URLs.

[X] Publication’s metadata must include modified field. This field is required by Circulation Manager to be able to skip already processed items, i.e. it processes only publications which modified time is greater than the time when this publication was last processed. Without modified field is not able to process the feed correctly.

Follow formatting of examples at https://drafts.opds.io/opds-2.0:
"modified": "2015-09-29T17:00:00Z"

[X] Sort all Publication feeds (e.g. https://www.fulcrum.org/api/opds/umpebc_oa) by Modified ascending (newest first) descending most recent data first.

[X] Remove rel: attributes from the top-level Navigation feed (https://www.fulcrum.org/api/opds).

[X] Add language attribute to the Publication feeds. I suppose this should list all values present in {language}} attributes on the Monographs in the list?