### PR TITLE
HELIO-3701 Send usage report emails to OAeBU Data Trust

### DIFF
--- a/app/jobs/open_access_ebook_trust_job.rb
+++ b/app/jobs/open_access_ebook_trust_job.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+class OpenAccessEbookTrustJob < ApplicationJob
+  queue_as :ebook_trust
+  # HELIO-3701
+  # Run via cron on the first day of the month generating stats from the previous month
+  def perform(subdomain: nil)
+    subdomain = subdomain || "michigan"
+    press = Press.where(subdomain: subdomain).first
+
+    reports = {}
+    reports = institution_reports(press, reports)
+    reports = item_master_reports(press, reports)
+    reports = usage_report(reports) if january_or_july?
+
+    tmp_zip = zipup(reports)
+
+    OpenAccessEbookTrustMailer.send_report(tmp_zip).deliver_now
+  end
+
+  def item_master_reports(press, reports)
+    institutions.each do |institution|
+      params = CounterReporter::ReportParams.new('ir', {
+        institution: institution.identifier,
+        start_date: start_date,
+        end_date: end_date,
+        press: press.id,
+        metric_type: 'Total_Item_Requests',
+        data_type: 'Book',
+        access_type: ['Controlled', 'OA_Gold'],
+        access_method: 'Regular'
+      })
+
+      result = CounterReporter::ItemReport.new(params).report
+      if result.present?
+        name = "Item Master Report Total_Item_Requests of #{press.name} for #{institution.name} from #{start_date} to #{end_date}"
+        reports[name] = CounterReporterService.csv(result)
+      end
+    end
+
+    reports
+  end
+
+  def institution_reports(press, reports)
+    requests = InstitutionReportService.run(args: {
+      start_date: start_date,
+      end_date: end_date,
+      press: press.id,
+      institutions: institutions,
+      report_type: "request"
+    })
+    if requests.present?
+      name = "Total_Item_Requests for all Institutions for #{press.name} from #{start_date} to #{end_date}"
+      output = InstitutionReportService.make_csv(subject: name, results: requests)
+      reports[name] = output
+    end
+
+    investigations = InstitutionReportService.run(args: {
+      start_date: start_date,
+      end_date: end_date,
+      press: press.id,
+      institutions: institutions,
+      report_type: "investigation"
+    })
+    if investigations.present?
+      name = "Total_Item_Investigations for all Institutions for #{press.name} from #{start_date} to #{end_date}"
+      output = InstitutionReportService.make_csv(subject: name, results: investigations)
+      reports[name] = output
+    end
+
+    reports
+  end
+
+  def zipup(reports)
+    tmp_zip = Tempfile.new('fulcrum_ebc_reports_zip')
+
+    Zip::OutputStream.open(tmp_zip) { |zos| }
+    Zip::File.open(tmp_zip.path, Zip::File::CREATE) do |zip|
+      reports.each do |name, data|
+        tmp_report = Tempfile.new
+        tmp_report.write(data)
+        tmp_report.close
+        zip.add(flatten_name(name), tmp_report.path)
+        # tmp_report.unlink
+      end
+    end
+
+    tmp_zip.close
+    tmp_zip
+  end
+
+  def flatten_name(name)
+    name.gsub(/[^0-9A-z.\-]/, '_') + ".csv"
+  end
+
+  def start_date
+    # First day of last month
+    Time.zone.today.at_beginning_of_month.prev_month.to_s
+  end
+
+  def end_date
+    # Last day of last month
+    (Time.zone.today - Time.zone.today.mday).to_s
+  end
+
+  def usage_report_start_date
+    # First day of month, 6 months ago
+    Time.zone.today.at_beginning_of_month.prev_month(6).to_s
+  end
+
+  def usage_report(reports)
+    # Get royalty usage report for heb, for UMich Press titles from the previous 6 months.
+    result = Royalty::UsageReport.new("heb", usage_report_start_date, end_date).report_for_copyholder("University of Michigan Press")
+    if result.present? && result[:items].present?
+      output = CounterReporterService.csv(result)
+      name = "Royalty Usage Report for University of Michigan Press in the Humanities EBook Collection from #{usage_report_start_date} to #{end_date}"
+      reports[name] = output
+    end
+    reports
+  end
+
+  def january_or_july?
+    Time.zone.now.month == 1 || Time.zone.now.month == 7
+  end
+
+  def institutions
+    subscribers = []
+    Greensub::Product.where("identifier like ?", "ebc_%").each do |product|
+      subscribers << Greensub.product_subscribers(product)
+    end
+    subscribers.flatten.uniq.map { |s| s if s.is_a? Greensub::Institution }.compact
+  end
+end

--- a/app/mailers/open_access_ebook_trust_mailer.rb
+++ b/app/mailers/open_access_ebook_trust_mailer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class OpenAccessEbookTrustMailer < ApplicationMailer
+  default from: "fulcrum-info@umich.edu"
+
+  def send_report(tmp_zip)
+    @month_year = Time.zone.now.prev_month.strftime("%B %Y")
+    @email_subject = "Monthly Fulcrum reports for OAeBU Data Trust"
+    attachment_name = "Monthly Fulcrum_Reports #{@month_year}.zip".gsub(" ", "_")
+    attachments[attachment_name] = File.read(tmp_zip)
+    mail(to: Settings.open_access_ebook_trust_emails.to, cc: Settings.open_access_ebook_trust_emails.cc, subject: @email_subject)
+
+    tmp_zip.unlink
+  end
+end

--- a/app/views/open_access_ebook_trust_mailer/send_report.html.erb
+++ b/app/views/open_access_ebook_trust_mailer/send_report.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Attached are Fulcrum reports for <%= @month_year %>.<p>
+  </body>
+</html>

--- a/app/views/open_access_ebook_trust_mailer/send_report.text.erb
+++ b/app/views/open_access_ebook_trust_mailer/send_report.text.erb
@@ -1,0 +1,1 @@
+Attached are Fulcrum reports for <%= @month_year %>.

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -34,6 +34,12 @@ handle_service:
   password: secret
   ssl_verify: false
 
+open_access_ebook_trust_emails:
+  to: test@fulcrum
+  cc:
+    - cc1@fulcrum
+    - cc2@fulcrum
+
 # List of Greensub Products to allow read access to everyone.
 allow_read_products:
   - allow_read_product

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -34,6 +34,12 @@ handle_service:
   password: secret
   ssl_verify: false
 
+open_access_ebook_trust_emails:
+  to: test@fulcrum
+  cc:
+    - cc1@fulcrum
+    - cc2@fulcrum
+
 # List of Greensub Products to allow read access to everyone.
 allow_read_products:
   - allow_read_product

--- a/spec/jobs/open_access_ebook_trust_job_spec.rb
+++ b/spec/jobs/open_access_ebook_trust_job_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OpenAccessEbookTrustJob, type: :job do
+  describe "perform" do
+    let(:mailer) { double("mailer", deliver_now: true) }
+    let(:mock_zip) { double('mock_zip') }
+
+    before do
+      create(:press, subdomain: "michigan")
+      allow(OpenAccessEbookTrustMailer).to receive(:send_report).with(mock_zip).and_return(mailer)
+      # This is SUPER mocky, it's bad to mock the system under test, obvs.
+      # Because the methods in this job are being tested individually I'm
+      # justifiying this. But I agree, it's not great.
+      # An alternative I experimented with was setting up the system state with like 100 variables,
+      # monographs, file_sets, featured_reps, counter report counts, greensub institutions/products/components
+      # and then zipping all the results. I don't know. I didn't like that either.
+      allow_any_instance_of(described_class).to receive(:zipup).and_return(mock_zip)
+    end
+
+    it "calls the mailer" do
+      described_class.perform_now
+      expect(OpenAccessEbookTrustMailer).to have_received(:send_report).with(mock_zip)
+    end
+  end
+
+  describe "#start_date" do
+    it "returns the first of the previous month" do
+      travel_to(Time.parse("2020-02-01")) do
+        expect(described_class.new.start_date).to eq "2020-01-01"
+      end
+
+      travel_to(Time.parse("2020-01-01")) do
+        expect(described_class.new.start_date).to eq "2019-12-01"
+      end
+    end
+  end
+
+  describe "#end_date" do
+    it "returns the last day of the previous month" do
+      travel_to(Time.parse("2020-02-01")) do
+        expect(described_class.new.end_date).to eq "2020-01-31"
+      end
+
+      travel_to(Time.parse("2020-01-01")) do
+        expect(described_class.new.end_date).to eq "2019-12-31"
+      end
+    end
+  end
+
+  describe "#usage_report_start_date" do
+    it "returns the first day of the month 6 months ago" do
+      travel_to(Time.parse("2020-01-01")) do
+        expect(described_class.new.usage_report_start_date).to eq "2019-07-01"
+      end
+
+      travel_to(Time.parse("2020-07-01")) do
+        expect(described_class.new.usage_report_start_date).to eq "2020-01-01"
+      end
+    end
+  end
+
+  describe "#january_or_july?" do
+    context "if january" do
+      it "returns true" do
+        travel_to(Time.parse("2020-01-01")) do
+          expect(described_class.new.january_or_july?).to be true
+        end
+      end
+    end
+    context "if july" do
+      it "returns true" do
+        travel_to(Time.parse("2020-07-01")) do
+          expect(described_class.new.january_or_july?).to be true
+        end
+      end
+    end
+    context "if october" do
+      it "returns false" do
+        travel_to(Time.parse("2020-10-01")) do
+          expect(described_class.new.january_or_july?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#institutions" do
+    let(:inst1) { create(:institution, identifier: 1, name: "UofA") }
+    let(:inst2) { create(:institution, identifier: 2, name: "UofB") }
+    let(:indv1) { create(:individual, identifier: 3, name: "Frank") }
+    let(:prod1) { create(:product, identifier: "ebc_123") }
+    let(:prod2) { create(:product, identifier: "ebc_rrr") }
+
+    before do
+      Greensub.subscribe(subscriber: inst1, target: prod1)
+      Greensub.subscribe(subscriber: inst2, target: prod2)
+      Greensub.subscribe(subscriber: indv1, target: prod1)
+    end
+
+    it "returns institutions that are subscribed to ebc_* products" do
+      expect(described_class.new.institutions).to eq [inst1, inst2]
+    end
+  end
+
+  describe "#usage_report" do
+    let(:royalty) { double("royalty") }
+    let(:result) { double("result") }
+    let(:output) { "report csv data" }
+    let(:name) { "Royalty Usage Report for University of Michigan Press in the Humanities EBook Collection from 2019-07-01 to 2019-12-31" }
+
+    before do
+      allow(Royalty::UsageReport).to receive(:new).with("heb", "2019-07-01", "2019-12-31").and_return(royalty)
+      allow(royalty).to receive(:report_for_copyholder).with("University of Michigan Press").and_return(result)
+      allow(CounterReporterService).to receive(:csv).with(result).and_return(output)
+      allow(result).to receive(:[]).and_return(["stuff"])
+    end
+
+    it "returns a royalty usage report" do
+      travel_to(Time.parse("2020-01-01")) do
+        expect(described_class.new.usage_report({ "name" => "data" })).to eq (
+          {
+            "name" => "data",
+            "#{name}" => "#{output}"
+          }
+        )
+      end
+    end
+  end
+
+  describe "#item_master_reports" do
+    let(:press) { create(:press, subdomain: "michigan", name: "UMich") }
+    let(:inst1) { create(:institution, identifier: 1, name: "UofA") }
+    let(:inst2) { create(:institution, identifier: 2, name: "UofB") }
+    let(:prod1) { create(:product, identifier: "ebc_123") }
+    let(:prod2) { create(:product, identifier: "ebc_rrr") }
+    let(:start_date) { "2020-01-01" }
+    let(:end_date) { "2020-01-31" }
+    let(:inst1params) { double("inst1params") }
+    let(:inst2params) { double("inst2params") }
+    let(:report1) { double("report1", report: "data for #{inst1.name}") }
+    let(:report2) { double("report2", report: "data for #{inst2.name}") }
+    let(:report1_csv) { "csv for #{inst1.name}" }
+    let(:report2_csv) { "csv for #{inst2.name}" }
+    let(:report1_name) { "Item Master Report Total_Item_Requests of #{press.name} for #{inst1.name} from #{start_date} to #{end_date}" }
+    let(:report2_name) { "Item Master Report Total_Item_Requests of #{press.name} for #{inst2.name} from #{start_date} to #{end_date}" }
+
+    before do
+      Greensub.subscribe(subscriber: inst1, target: prod1)
+      Greensub.subscribe(subscriber: inst2, target: prod2)
+      allow(CounterReporter::ReportParams).to receive(:new).with('ir', {
+        institution: inst1.identifier,
+        start_date: start_date,
+        end_date: end_date,
+        press: press.id,
+        metric_type: 'Total_Item_Requests',
+        data_type: 'Book',
+        access_type: ['Controlled', 'OA_Gold'],
+        access_method: 'Regular'
+      }).and_return(inst1params)
+      allow(CounterReporter::ReportParams).to receive(:new).with('ir', {
+        institution: inst2.identifier,
+        start_date: start_date,
+        end_date: end_date,
+        press: press.id,
+        metric_type: 'Total_Item_Requests',
+        data_type: 'Book',
+        access_type: ['Controlled', 'OA_Gold'],
+        access_method: 'Regular'
+      }).and_return(inst2params)
+      allow(CounterReporter::ItemReport).to receive(:new).with(inst1params).and_return(report1)
+      allow(CounterReporter::ItemReport).to receive(:new).with(inst2params).and_return(report2)
+      allow(CounterReporterService).to receive(:csv).with(report1.report).and_return(report1_csv)
+      allow(CounterReporterService).to receive(:csv).with(report2.report).and_return(report2_csv)
+    end
+
+    it "return reports for each institution" do
+      travel_to(Time.parse("2020-02-01")) do
+        expect(described_class.new.item_master_reports(press, {})).to eq (
+          {
+            report1_name => report1_csv,
+            report2_name => report2_csv
+          }
+        )
+      end
+    end
+  end
+
+  describe "#instituion_reports" do
+    let(:press) { create(:press, subdomain: "michigan", name: "UMich") }
+    let(:institutions) { [] }
+    let(:start_date) { "2020-01-01" }
+    let(:end_date) { "2020-01-31" }
+    let(:requests) { "request data" }
+    let(:request_csv) { "request data in csv" }
+    let(:request_name) { "Total_Item_Requests for all Institutions for #{press.name} from #{start_date} to #{end_date}" }
+    let(:request_args) do
+      {
+        start_date: start_date,
+        end_date: end_date,
+        press: press.id,
+        institutions: institutions,
+        report_type: "request"
+      }
+    end
+    let(:investigations) { "investigation data" }
+    let(:investigation_csv) { "investigation data in csv" }
+    let(:investigation_name) { "Total_Item_Investigations for all Institutions for #{press.name} from #{start_date} to #{end_date}" }
+    let(:investigation_args) do
+      {
+        start_date: start_date,
+        end_date: end_date,
+        press: press.id,
+        institutions: institutions,
+        report_type: "investigation"
+      }
+    end
+
+    before do
+      allow(InstitutionReportService).to receive(:run).with(args: request_args).and_return(requests)
+      allow(InstitutionReportService).to receive(:make_csv).with(subject: request_name, results: requests).and_return(request_csv)
+      allow(InstitutionReportService).to receive(:run).with(args: investigation_args).and_return(investigations)
+      allow(InstitutionReportService).to receive(:make_csv).with(subject: investigation_name, results: investigations).and_return(investigation_csv)
+    end
+
+    it "returns reports" do
+      travel_to("2020-02-01") do
+        expect(described_class.new.institution_reports(press, {})).to eq (
+          {
+            request_name => request_csv,
+            investigation_name => investigation_csv
+          }
+        )
+      end
+    end
+  end
+
+  describe "#zipup" do
+    let(:reports) do
+      {
+        "A Report" => "A Report csv data",
+        "B Report" => "B Report csv data",
+        "C Report" => "C Report csv data"
+      }
+    end
+
+    it "returns a zipped archive containing reports" do
+      Zip::File.open(described_class.new.zipup(reports)) do |zip|
+        expect(zip.entries[0].name).to eq "A_Report.csv"
+        expect(zip.entries[0].get_input_stream.read).to eq "A Report csv data"
+        expect(zip.entries[1].name).to eq "B_Report.csv"
+        expect(zip.entries[1].get_input_stream.read).to eq "B Report csv data"
+        expect(zip.entries[2].name).to eq "C_Report.csv"
+        expect(zip.entries[2].get_input_stream.read).to eq "C Report csv data"
+      end
+    end
+  end
+end

--- a/spec/mailers/open_access_ebook_trust_mailer_spec.rb
+++ b/spec/mailers/open_access_ebook_trust_mailer_spec.rb
@@ -1,0 +1,31 @@
+
+# frozen_string_literal: true
+
+require "rails_helper"
+require "zlib"
+
+RSpec.describe OpenAccessEbookTrustMailer, type: :mailer do
+  describe '#send_report' do
+    let(:reports) do
+      {
+        "first report" => "first report cvs data",
+        "second report" => "second report csv data"
+      }
+    end
+    let(:tmp_zip) { OpenAccessEbookTrustJob.new.zipup(reports) }
+
+    it "has the correct fields and attachment" do
+      travel_to(Time.parse("2020-02-01")) do
+        described_class.send_report(tmp_zip).deliver
+        email = ActionMailer::Base.deliveries.last
+        expect(email.from).to eq ["fulcrum-info@umich.edu"]
+        expect(email.subject).to eq "Monthly Fulcrum reports for OAeBU Data Trust"
+        expect(email.to).to eq ["test@fulcrum"]
+        expect(email.cc).to eq ["cc1@fulcrum", "cc2@fulcrum"]
+        expect(email.attachments[0].main_type).to eq "application"
+        expect(email.attachments[0].sub_type).to eq "zip"
+        expect(email.attachments[0].filename).to eq "Monthly_Fulcrum_Reports_January_2020.zip"
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Warden::Test::Helpers, type: :feature
   config.include RSpecHtmlMatchers
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 # Stub out anything that requires a redis connection,


### PR DESCRIPTION
I've run this against production data, example in the ticket. Seems to work ok.