### PR TITLE
HELIO-3656 - Customize AblePlayer play button

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -1020,6 +1020,21 @@ footer.press {
     width: 97%;
     height: auto;
     margin: initial;
+
+    // HELIO-3656
+    .able-big-play-button {
+      opacity: 0.4;
+      filter: alpha(opacity=40);
+      background-color: #555;
+      color: #fdfdfd !important;
+    }
+
+    .able-big-play-button:hover {
+      opacity: .7;
+      filter: alpha(opacity=70);
+      color: #fdfdfd !important;
+    }
+
   }
 
   figcaption {

--- a/app/assets/stylesheets/embed/embed_styles.scss
+++ b/app/assets/stylesheets/embed/embed_styles.scss
@@ -48,10 +48,12 @@ html {
       opacity: 0.4;
       filter: alpha(opacity=40);
       background-color: #555;
+      color: #fdfdfd !important;
     }
     .able-big-play-button:hover {
       opacity: .7;
       filter: alpha(opacity=70);
+      color: #fdfdfd !important;
     }
 
     // HELIO-3674

--- a/app/assets/stylesheets/embed/embed_styles.scss
+++ b/app/assets/stylesheets/embed/embed_styles.scss
@@ -43,6 +43,17 @@ html {
       z-index: 6501;
     }
 
+    // HELIO-3656
+    .able-big-play-button {
+      opacity: 0.4;
+      filter: alpha(opacity=40);
+      background-color: #555;
+    }
+    .able-big-play-button:hover {
+      opacity: .7;
+      filter: alpha(opacity=70);
+    }
+
     // HELIO-3674
     .able-descriptions {
       // the `able-descriptions` div needs to be contiguous with the controls, so that it's visible in the iframe


### PR DESCRIPTION
Resolves HELIO-3656

Adds a background color behind the white play button to ensure it is visible regardless of the color contrast of the first frame of video. This applies to the embed view and the FileSet view.

