### PR TITLE
Ebook Interval Download Operation Policy and Add Interval To Presses

### DIFF
--- a/app/controllers/presses_controller.rb
+++ b/app/controllers/presses_controller.rb
@@ -75,7 +75,8 @@ class PressesController < ApplicationController
                                     :doi_creation,
                                     :navigation_block,
                                     :default_list_view,
-                                    :aboutware
+                                    :aboutware,
+                                    :interval
                                   )
     end
 end

--- a/app/models/sighrax/null_publisher.rb
+++ b/app/models/sighrax/null_publisher.rb
@@ -20,6 +20,10 @@ module Sighrax
       false
     end
 
+    def interval?
+      false
+    end
+
     private
 
       def initialize(subdomain)

--- a/app/models/sighrax/publisher.rb
+++ b/app/models/sighrax/publisher.rb
@@ -88,6 +88,10 @@ module Sighrax
       press.watermark
     end
 
+    def interval?
+      press.interval
+    end
+
     protected
 
       def type

--- a/app/policies/ebook_interval_download_operation.rb
+++ b/app/policies/ebook_interval_download_operation.rb
@@ -2,12 +2,8 @@
 
 class EbookIntervalDownloadOperation < EbookOperation
   def allowed?
-    allows_interval_download? && licensed_for?(:download)
+    return false unless ebook.publisher.interval?
+
+    licensed_for?(:download)
   end
-
-  private
-
-    def allows_interval_download?
-      ['barpublishing', 'heb', 'heliotrope'].include? ebook.publisher.subdomain
-    end
 end

--- a/app/views/monograph_catalog/_index_epub_toc.html.erb
+++ b/app/views/monograph_catalog/_index_epub_toc.html.erb
@@ -2,7 +2,7 @@
   level = 0
   ebook_presenter = @presenter.epub? ? @presenter.epub_presenter : @presenter.pdf_ebook_presenter
   if Incognito.developer?(current_actor)
-    permit_download_buttons = EbookIntervalDownloadOperation.new(current_actor, Sighrax.from_presenter(ebook_presenter)).allowed?
+    permit_download_buttons = EbookIntervalDownloadOperation.new(current_actor, Sighrax.from_solr_document(@presenter.reader_ebook)).allowed?
   else
     epub_policy = @presenter.epub? ? @monograph_policy.epub_policy : @monograph_policy.pdf_ebook_policy
     # we could show the buttons even if epub_policy.show? = false, as another entry point into the `epubs_access`...

--- a/app/views/presses/_form.html.erb
+++ b/app/views/presses/_form.html.erb
@@ -39,6 +39,7 @@
   <%= f.input :restricted_message, label: 'Message for restricted works (if any). HTML is ok' %>
   <%= f.input :share_links, label: 'Allow "share links" for temporary access of restricted materials?', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>
   <%= f.input :watermark, label: 'Apply watermark to downloaded ebooks?', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>
+  <%= f.input :interval, label: 'Allow ebook interval (chapter) download?', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>
   <%= f.input :doi_creation, label: 'Press allows AUTOMATIC creation of Component (FileSet) level DOIs?', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>
   <%= f.input :default_list_view, label: 'Select the default view', as: :radio_buttons, collection: [['List View', true], ['Gallery View', false]], default: false %>
   <%= f.input :aboutware, label: 'Press has "aboutware" (MAY include a complex "navigation_block" or MAY NOT)', as: :radio_buttons, collection: [['Yes', true], ['No', false]], default: false %>

--- a/db/migrate/20210323134614_add_interval_to_presses.rb
+++ b/db/migrate/20210323134614_add_interval_to_presses.rb
@@ -1,0 +1,5 @@
+class AddIntervalToPresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :presses, :interval, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_19_181153) do
+ActiveRecord::Schema.define(version: 2021_03_23_134614) do
 
   create_table "api_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -391,6 +391,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_181153) do
     t.text "navigation_block"
     t.boolean "default_list_view", default: false
     t.boolean "aboutware", default: false
+    t.boolean "interval", default: false
     t.index ["parent_id"], name: "index_presses_on_parent_id"
   end
 

--- a/spec/models/sighrax/null_publisher_spec.rb
+++ b/spec/models/sighrax/null_publisher_spec.rb
@@ -33,5 +33,6 @@ RSpec.describe Sighrax::NullPublisher, type: :model do
     it { expect(subject.resource_noids(true)).to be_empty }
     it { expect(subject.user_ids(true)).to be_empty }
     it { expect(subject.watermark?).to be false }
+    it { expect(subject.interval?).to be false }
   end
 end

--- a/spec/models/sighrax/publisher_spec.rb
+++ b/spec/models/sighrax/publisher_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe Sighrax::Publisher, type: :model do
 
     let(:publisher) { described_class.send(:new, subdomain, press) }
     let(:subdomain) { 'publisher' }
-    let(:press) { create(:press, subdomain: subdomain, watermark: watermark) }
+    let(:press) { create(:press, subdomain: subdomain, watermark: watermark, interval: interval) }
     let(:watermark) { false }
+    let(:interval) { false }
 
     it { is_expected.to be_an_instance_of described_class }
     it { expect(subject.subdomain).to eq subdomain }
@@ -58,11 +59,18 @@ RSpec.describe Sighrax::Publisher, type: :model do
     it { expect(subject.resource_noids(true)).to be_empty }
     it { expect(subject.user_ids(true)).to be_empty }
     it { expect(subject.watermark?).to be false }
+    it { expect(subject.interval?).to be false }
 
     context 'watermark' do
       let(:watermark) { true }
 
       it { expect(subject.watermark?). to be true }
+    end
+
+    context 'interval' do
+      let(:interval) { true }
+
+      it { expect(subject.interval?).to be true }
     end
 
     context 'with child' do

--- a/spec/policies/ebook_interval_download_operation_spec.rb
+++ b/spec/policies/ebook_interval_download_operation_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe EbookIntervalDownloadOperation do
     let(:policy) { described_class.new(actor, ebook) }
     let(:actor) { Anonymous.new({}) }
     let(:ebook) { instance_double(Sighrax::Ebook, 'ebook', publisher: publisher) }
-    let(:publisher) { instance_double(Sighrax::Publisher, 'publisher', subdomain: subdomain) }
-    let(:subdomain) { 'subdomain' }
+    let(:publisher) { instance_double(Sighrax::Publisher, 'publisher', interval?: interval) }
+    let(:interval) { false }
     let(:licensed_for_download) { false }
 
     before do
@@ -24,8 +24,8 @@ RSpec.describe EbookIntervalDownloadOperation do
 
       it { is_expected.to be false }
 
-      context 'when publisher subdomain' do
-        let(:subdomain) { 'heliotrope' }
+      context 'when publisher interval' do
+        let(:interval) { true }
 
         it { is_expected.to be true }
       end


### PR DESCRIPTION
Add interval to press table to explicitly support publishers that allow download of intervals (chapters).