### PR TITLE
Hotfix 2.75.1 which includes HELIO-3900 and HELIO-3916

### DIFF
--- a/app/controllers/fulcrum_controller.rb
+++ b/app/controllers/fulcrum_controller.rb
@@ -33,6 +33,8 @@ class FulcrumController < ApplicationController
       MigrateMetadataJob.perform_later(params[:job], params[:noid])
     when 'recache_in_common_metadata'
       RecacheInCommonMetadataJob.perform_now
+    when 'license_delete'
+      LicenseDeleteJob.perform_now
     when 'reindex'
       ReindexJob.perform_later(params[:noid])
     when 'reindex_everything'

--- a/app/jobs/license_delete_job.rb
+++ b/app/jobs/license_delete_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class LicenseDeleteJob < ApplicationJob
+  def perform
+    Greensub::License.where(type: '').each do |license|
+      grants = Checkpoint::DB::Grant
+                 .where(credential_type: 'License')
+                 .where(credential_id: license.id)
+      grants.each do |grant|
+        grant.delete
+      end
+      license.destroy
+    end
+
+    Greensub::License.where(type: 'Greensub::License').each do |license|
+      grants = Checkpoint::DB::Grant
+                 .where(credential_type: 'License')
+                 .where(credential_id: license.id)
+      grants.each do |grant|
+        grant.delete
+      end
+      license.destroy
+    end
+  end
+end

--- a/app/models/monograph_search_builder.rb
+++ b/app/models/monograph_search_builder.rb
@@ -32,7 +32,7 @@ class MonographSearchBuilder < ::SearchBuilder
   def filter_out_representatives(solr_parameters)
     id = monograph_id(blacklight_params)
     ids = FeaturedRepresentative.where(work_id: id).map(&:file_set_id)
-    solr_parameters[:fq] << "-id:(#{ids.join(',')})" if ids.present?
+    solr_parameters[:fq] << "-id:(#{ids.join(' ')})" if ids.present?
   end
 
   # Redundant but consistent with PressSearchBuilder

--- a/app/views/fulcrum/_jobs.html.erb
+++ b/app/views/fulcrum/_jobs.html.erb
@@ -110,6 +110,11 @@
       <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Recache InCommon Metadata
     <% end %>
   </div>
+  <div class="row">
+    <%= link_to(fulcrum_exec_path(:license_delete), method: :get, class: "btn btn-default", data: { confirm: 'Are you sure?' }) do %>
+      <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> License Delete
+    <% end %>
+  </div>
 </div>
 <div class="col-sm-6">
   <div class="row">

--- a/spec/jobs/license_delete_job_spec.rb
+++ b/spec/jobs/license_delete_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LicenseDeleteJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe 'job queue' do
+    subject(:job) { described_class.perform_later }
+
+    after do
+      clear_enqueued_jobs
+      clear_performed_jobs
+    end
+
+    it 'queues the job' do
+      expect { job }.to have_enqueued_job(described_class).on_queue("default")
+    end
+  end
+
+  describe 'job' do
+    let(:job) { described_class.new }
+    let(:blank) { create(:license, type: '') }
+    let(:license) { create(:license) }
+    let(:read_license) { create(:read_license) }
+    let(:full_license) { create(:full_license) }
+    let(:individual) { create(:individual) }
+    let(:product) { create(:product) }
+    let(:blank_grant) { create(:individual_license_grant, agent_id: individual.id, credential_id: blank.id, resource_id: product.id) }
+    let(:license_grant) { create(:individual_license_grant, agent_id: individual.id, credential_id: license.id, resource_id: product.id) }
+
+    before do
+      clear_grants_table
+    end
+
+    it 'deletes blank and license' do
+      blank
+      license
+      read_license
+      full_license
+      expect(Greensub::License.count).to eq 4
+      job.perform
+      expect(Greensub::License.count).to eq 2
+      expect { Greensub::License.find(blank.id) }.to raise_exception ActiveRecord::RecordNotFound
+      expect { Greensub::License.find(license.id) }.to raise_exception ActiveRecord::RecordNotFound
+    end
+
+    it 'deletes blank and license and grants' do
+      blank
+      license
+      read_license
+      full_license
+      blank_grant
+      license_grant
+      expect(Greensub::License.count).to eq 4
+      expect(grants_table_count).to eq 2
+      job.perform
+      expect(Greensub::License.count).to eq 2
+      expect { Greensub::License.find(blank.id) }.to raise_exception ActiveRecord::RecordNotFound
+      expect { Greensub::License.find(license.id) }.to raise_exception ActiveRecord::RecordNotFound
+      expect(grants_table_count).to eq 0
+    end
+  end
+end

--- a/spec/models/monograph_search_builder_spec.rb
+++ b/spec/models/monograph_search_builder_spec.rb
@@ -95,7 +95,7 @@ describe MonographSearchBuilder do
           create(:featured_representative, work_id: id, file_set_id: '2', kind: 'pdf_ebook')
           solr_params = { fq: [] }
           search_builder.filter_out_representatives(solr_params)
-          expect(solr_params[:fq]).to contain_exactly("-id:(1,2)")
+          expect(solr_params[:fq]).to contain_exactly("-id:(1 2)")
         end
       end
     end


### PR DESCRIPTION
HELIO-3900 Grants to the :none License cause confusion
HELIO-3916 File Representatives show in Resource list

License Delete job was added to the fulcrum/jobs page which will delete all greensub licenses of type 'Greensub::License' or empty string and their corresponding grants.