### PR TITLE
Rake task to cleanup :none licenses

### DIFF
--- a/lib/tasks/cleanup/license_delete.rake
+++ b/lib/tasks/cleanup/license_delete.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+desc 'Cleanup :none licenses'
+namespace :heliotrope do
+  task license_delete: :environment do
+    LicenseDeleteJob.perform_later
+    p "LicenseDeleteJob.perform_later"
+  end
+end


### PR DESCRIPTION
Rake task to be run daily by cron to cleanup :none licenses.