### PR TITLE
HELIO-3958: Institution containing dlps_institution_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,19 +49,8 @@ class ApplicationController < ActionController::Base
   end
 
   def current_institution
-    insts = current_institutions
-    the_inst = insts.first
-    insts.each do |inst|
-      begin
-        left = the_inst.identifier.to_i
-        right = inst.identifier.to_i
-        next if left <= right
-        the_inst = inst
-      rescue StandardError => e
-        Rails.logger.debug("ApplicationController.current_institution error" + e)
-      end
-    end
-    the_inst
+    # current_institutions.sort { |x, y| x.identifier <=> y.identifier }.first
+    current_institutions.sort { |x, y| x.identifier.to_i <=> y.identifier.to_i }.first # TODO: Better sort logic
   end
 
   def current_institutions?
@@ -80,13 +69,13 @@ class ApplicationController < ActionController::Base
 
     def ip_based_institutions
       ids = request_attributes[:dlpsInstitutionId] || []
-      Greensub::Institution.where(identifier: ids).to_a
+      Greensub::Institution.containing_dlps_institution_id(ids).to_a
     end
 
     def shib_institutions
       entity_id = request_attributes[:identity_provider]
       if entity_id
-        Greensub::Institution.where(entity_id: entity_id).to_a
+        Greensub::Institution.for_entity_id(entity_id).to_a
       else
         []
       end

--- a/app/controllers/fulcrum_controller.rb
+++ b/app/controllers/fulcrum_controller.rb
@@ -45,6 +45,8 @@ class FulcrumController < ApplicationController
       ReindexJob.perform_later('file_sets')
     when 'seed_institution_affiliations'
       SeedInstitutionAffiliationsJob.perform_now
+    when 'seed_institution_affiliations_with_prefix'
+      SeedInstitutionAffiliationsJob.perform_now(true)
     end
     redirect_to action: :index, partials: :dashboard
   end

--- a/app/jobs/seed_institution_affiliations_job.rb
+++ b/app/jobs/seed_institution_affiliations_job.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class SeedInstitutionAffiliationsJob < ApplicationJob
-  def perform
+  def perform(prefix = false)
     Greensub::Institution.all.each do |institution|
-      Greensub::InstitutionAffiliation.find_or_create_by(institution_id: institution.id, dlps_institution_id: institution.identifier, affiliation: 'member').save
+      dlps_institution_id = /(\d+)/.match(institution.identifier)[0]
+      institution.identifier = dlps_institution_id
+      institution.identifier = "#" + institution.identifier if prefix
+      institution.save
+      Greensub::InstitutionAffiliation.find_or_create_by(institution_id: institution.id, dlps_institution_id: dlps_institution_id, affiliation: 'member').save
     end
     true
   end

--- a/app/models/greensub/institution.rb
+++ b/app/models/greensub/institution.rb
@@ -8,19 +8,16 @@ module Greensub
     scope :identifier_like, ->(like) { where("identifier like ?", "%#{like}%") }
     scope :name_like, ->(like) { where("name like ?", "%#{like}%") }
     scope :entity_id_like, ->(like) { where("entity_id like ?", "%#{like}%") }
+    scope :for_entity_id, ->(entity_id) { where(entity_id: entity_id) }
+    scope :containing_dlps_institution_id, ->(dlps_institution_id) { joins(:institution_affiliations).merge(InstitutionAffiliation.for_dlps_institution_id(dlps_institution_id)).distinct }
+
+    has_many :institution_affiliations, dependent: :restrict_with_exception
 
     validates :identifier, presence: true, allow_blank: false, uniqueness: true
     validates :name, presence: true, allow_blank: false
     # validates :entity_id, presence: true, allow_blank: false
     # validates :site, presence: true, allow_blank: false
     # validates :login, presence: true, allow_blank: false
-
-    before_validation(on: :update) do
-      if identifier_changed?
-        errors.add(:identifier, "institution identifier can not be changed!")
-        throw(:abort)
-      end
-    end
 
     before_destroy do
       if grants?
@@ -39,6 +36,10 @@ module Greensub
 
     def shibboleth?
       entity_id.present?
+    end
+
+    def dlps_institution_ids
+      institution_affiliations.pluck(:dlps_institution_id)
     end
 
     def agent_type

--- a/app/models/greensub/institution_affiliation.rb
+++ b/app/models/greensub/institution_affiliation.rb
@@ -12,6 +12,8 @@ module Greensub
     scope :dlps_institution_id_like, ->(like) { where("dlps_institution_id like ?", "%#{like}%") }
     scope :affiliation_like, ->(like) { where("affiliation like ?", "%#{like}%") }
 
+    scope :for_dlps_institution_id, ->(dlps_institution_id) { where(dlps_institution_id: dlps_institution_id) }
+
     validates :institution_id, presence: true, allow_blank: false
     validates :dlps_institution_id, presence: true, allow_blank: false
     validates :affiliation, presence: true, allow_blank: false

--- a/app/services/counter_service.rb
+++ b/app/services/counter_service.rb
@@ -35,7 +35,7 @@ class CounterService
     # institution, but not always (for instance: U of M and LIT IP ranges means 2 institutions)
     @controller.current_institutions.each do |institution|
       cr = CounterReport.new(session: session,
-                             institution: institution.identifier,
+                             institution: institution.identifier, # TODO: Replace with Institution ID ???????
                              noid: @presenter.id,
                              model: @presenter.has_model)
 

--- a/app/views/fulcrum/_institution_affiliations.html.erb
+++ b/app/views/fulcrum/_institution_affiliations.html.erb
@@ -26,7 +26,7 @@
             <span class="glyphicon glyphicon-sunglasses" aria-hidden="true"></span> Show
           <% end %>
         </td>
-        <td><%= institution_affiliation.institution.name %></td>
+        <td><%= link_to institution_affiliation.institution.name, greensub_institution_path(institution_affiliation.institution)  %></td>
         <td><%= institution_affiliation.dlps_institution_id %></td>
         <td><%= institution_affiliation.affiliation %></td>
       </tr>

--- a/app/views/fulcrum/_institutions.html.erb
+++ b/app/views/fulcrum/_institutions.html.erb
@@ -23,6 +23,9 @@
         <div></div>
       </th>
       <th>
+        <div>Affiliations</div>
+      </th>
+      <th>
         <div>Licenses</div>
         <div>&nbsp;</div>
         <div><button name="submit" type="submit" value="filter">Filter</button></div>
@@ -39,6 +42,11 @@
           <div><%= institution.identifier %></div>
           <div><%= institution.name %>&nbsp;</div>
           <div><%= institution.entity_id %>&nbsp;</div>
+        </td>
+        <td>
+          <% institution.institution_affiliations.each do |institution_affiliation| %>
+            <div><%= link_to institution_affiliation.dlps_institution_id.to_s + ":" + institution_affiliation.affiliation, greensub_institution_affiliation_path(institution_affiliation) %></div>
+          <% end %>
         </td>
         <td><%= institution.licenses.count %></td>
       </tr>

--- a/app/views/fulcrum/_jobs.html.erb
+++ b/app/views/fulcrum/_jobs.html.erb
@@ -152,4 +152,9 @@
       <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Seed Institution Affiliations
     <% end %>
   </div>
+  <div class="row">
+    <%= link_to(fulcrum_exec_path(:seed_institution_affiliations_with_prefix), method: :get, class: "btn btn-default", data: { confirm: 'Are you sure?' }) do %>
+      <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Seed Institution Affiliations (Prefixed)
+    <% end %>
+  </div>
 </div>

--- a/app/views/greensub/institution_affiliations/_form.html.erb
+++ b/app/views/greensub/institution_affiliations/_form.html.erb
@@ -10,4 +10,6 @@
   <div class="form-actions">
     <%= f.button :submit %>
   </div>
+
+  <div>&nbsp;</div>
 <% end %>

--- a/app/views/greensub/institution_affiliations/edit.html.erb
+++ b/app/views/greensub/institution_affiliations/edit.html.erb
@@ -4,3 +4,5 @@
 
 <%= link_to 'Show', greensub_institution_affiliation_path(@institution_affiliation) %> |
 <%= link_to 'Back', greensub_institution_affiliations_path %>
+
+<div>&nbsp;</div>

--- a/app/views/greensub/institution_affiliations/index.html.erb
+++ b/app/views/greensub/institution_affiliations/index.html.erb
@@ -25,7 +25,7 @@
 
   <% @institution_affiliations.each do |institution_affiliation| %>
     <div class="col-md-1"><%= institution_affiliation.id %></div>
-    <div class="col-md-5"><%= institution_affiliation.institution.name %></div>
+    <div class="col-md-5"><%= link_to institution_affiliation.institution.name, greensub_institution_path(institution_affiliation.institution) %></div>
     <div class="col-md-2"><%= institution_affiliation.dlps_institution_id %></div>
     <div class="col-md-2"><%= institution_affiliation.affiliation %></div>
     <div class="col-md-2">

--- a/app/views/greensub/institution_affiliations/new.html.erb
+++ b/app/views/greensub/institution_affiliations/new.html.erb
@@ -3,3 +3,5 @@
 <%= render 'form', institution_affiliation: @institution_affiliation %>
 
 <%= link_to 'Back', greensub_institution_affiliations_path %>
+
+<div>&nbsp;</div>

--- a/app/views/greensub/institution_affiliations/show.html.erb
+++ b/app/views/greensub/institution_affiliations/show.html.erb
@@ -2,13 +2,13 @@
 <div id="maincontent">
   <h1>Institution Affiliation</h1>
   <div class="col-md-1"><em>ID</em></div>
-  <div class="col-md-11">&nbsp;<%= @institution_affiliation.id %></div>
+  <div class="col-md-11"><%= @institution_affiliation.id %></div>
   <div class="col-md-1"><em>Institution</em></div>
-  <div class="col-md-11">&nbsp;<%= @institution_affiliation.institution.id %></div>
+  <div class="col-md-11"><%= link_to @institution_affiliation.institution.name, greensub_institution_path(@institution_affiliation.institution) %></div>
   <div class="col-md-1"><em>DLPS ID</em></div>
-  <div class="col-md-11">&nbsp;<%= @institution_affiliation.dlps_institution_id %></div>
+  <div class="col-md-11"><%= @institution_affiliation.dlps_institution_id %></div>
   <div class="col-md-1"><em>Affiliation</em></div>
-  <div class="col-md-11">&nbsp;<%= @institution_affiliation.affiliation %></div>
+  <div class="col-md-11"><%= @institution_affiliation.affiliation %></div>
   <div class="col-md-12"><br/></div>
   <div class="col-md-12">
     <%= link_to 'Edit', edit_greensub_institution_affiliation_path(@institution_affiliation) %>

--- a/app/views/greensub/institutions/index.html.erb
+++ b/app/views/greensub/institutions/index.html.erb
@@ -13,12 +13,13 @@
           <div>ID</div>
           <div>&nbsp;</div>
         </div>
-        <div class="col-md-9">
+        <div class="col-md-7">
           <% size = 24 %>
           <div><div class="col-md-2">Identifier</div><div class="col-md-10"><input type="text" name="identifier_like" value="<%= params[:identifier_like] %>" size="<%= size %>" aria-label="identifier_like"></div></div>
           <div><div class="col-md-2">Name</div><div class="col-md-10"><input type="text" name="name_like" value="<%= params[:name_like] %>" size="<%= size %>" aria-label="name_like"></div></div>
           <div><div class="col-md-2">Entity ID</div><div class="col-md-10"><input type="text" name="entity_id_like" value="<%= params[:entity_id_like] %>" size="<%= size %>" aria-label="entity_id_like"></div></div>
         </div>
+        <div class="col-md-2">Affiations</div>
         <div class="col-md-2"><div>Licenses</div><div>&nbsp;</div><div><button name="submit" type="submit" value="filter">Filter</button></div>
         </div>
       </div>
@@ -30,10 +31,15 @@
   <% @institutions.each do |institution| %>
     <div class="col-md-10">
       <div class="col-md-1"><%= institution.id %></div>
-      <div class="col-md-9">
+      <div class="col-md-7">
         <div><%= institution.identifier %></div>
         <div><%= institution.name %></div>
         <div><%= institution.entity_id %></div>
+      </div>
+      <div class="col-md-2">
+        <% institution.institution_affiliations.each do |institution_affiliation| %>
+          <div><%= link_to institution_affiliation.dlps_institution_id.to_s + ":" + institution_affiliation.affiliation, greensub_institution_affiliation_path(institution_affiliation) %></div>
+        <% end %>
       </div>
       <div class="col-md-2"><%= institution.licenses.count %></div>
     </div>

--- a/app/views/greensub/institutions/show.html.erb
+++ b/app/views/greensub/institutions/show.html.erb
@@ -14,9 +14,16 @@
   <div class="col-md-1"><em>Login</em></div>
   <div class="col-md-11">&nbsp;<%= @institution.login %></div>
   <div class="col-md-12"><br/></div>
+  <h2>Affiliations</h2>
+  <div class="col-md-12">
+    <% @institution.institution_affiliations.each do |institution_affiliation| %>
+      <div><%= link_to institution_affiliation.dlps_institution_id.to_s + ":" + institution_affiliation.affiliation, greensub_institution_affiliation_path(institution_affiliation) %></div>
+    <% end %>
+  </div>
+  <div class="col-md-12"><br/></div>
   <h2>Licenses</h2>
   <div class="col-md-12">
-    <%= render partial: '/greensub/licenses/licenses', locals: { institution: @individual, licenses: @institution.licenses } %>
+    <%= render partial: '/greensub/licenses/licenses', locals: { institution: @institution, licenses: @institution.licenses } %>
   </div>
   <div class="col-md-12"><br/></div>
   <div class="col-md-12">

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -40,6 +40,6 @@ open_access_ebook_trust_emails:
     - cc1@fulcrum
     - cc2@fulcrum
 
-world_institution_identifier: 0
+world_institution_identifier: 0 # TODO: Prefix with '#'
 
 princesse_de_cleves_noid: pdecleves

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -80,16 +80,17 @@ RSpec.describe EPubsController, type: :controller do
         let(:monograph) { create(:public_monograph) }
         let(:file_set) { create(:public_file_set, content: File.open(File.join(fixture_path, 'fake_epub01.epub'))) }
         let!(:fr) { create(:featured_representative, work_id: monograph.id, file_set_id: file_set.id, kind: 'epub') }
-        let(:keycard) { { dlpsInstitutionId: [institution.identifier] } }
-        let(:institution) { double('institution', identifier: '9999') }
+        let(:keycard) { { dlpsInstitutionId: [dlps_institution_id.to_s] } }
+        let(:institution) { create(:institution, identifier: dlps_institution_id.to_s) } # TODO: Prefix with '#'
+        let(:institution_affiliation) { create(:institution_affiliation, institution: institution, dlps_institution_id: dlps_institution_id, affiliation: 'member') }
+        let(:dlps_institution_id) { 9999 }
 
         before do
+          institution_affiliation
           monograph.ordered_members << file_set
           monograph.save!
           file_set.save!
           allow_any_instance_of(Keycard::Request::Attributes).to receive(:all).and_return(keycard)
-          allow(Greensub::Institution).to receive(:where).with(identifier: ['9999']).and_return([institution])
-          allow(institution).to receive(:products).and_return([])
 
           get :show, params: { id: file_set.id }
         end

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -74,14 +74,17 @@ RSpec.describe EmbedController, type: :controller do
                            visibility_ssi: 'open',
                            read_access_group_ssim: ["public"])
       end
-      let(:keycard) { { dlpsInstitutionId: [institution.identifier] } }
-      let(:institution) { double('institution', identifier: '9999') }
+      let(:keycard) { { dlpsInstitutionId: [dlps_institution_id.to_s] } }
+      let(:institution) { create(:institution, identifier: dlps_institution_id.to_s) } # TODO: Prefix with '#'
+      let(:institution_affiliation) { create(:institution_affiliation, institution: institution, dlps_institution_id: dlps_institution_id, affiliation: 'member') }
+      let(:dlps_institution_id) { 9999 }
+
 
       before do
+        institution_affiliation
         ActiveFedora::SolrService.add([monograph.to_h, file_set.to_h])
         ActiveFedora::SolrService.commit
         allow_any_instance_of(Keycard::Request::Attributes).to receive(:all).and_return(keycard)
-        allow(Greensub::Institution).to receive(:where).with(identifier: ['9999']).and_return([institution])
         allow(HandleNet).to receive(:noid).with(hdl).and_return('file_set_noid')
       end
 

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -196,12 +196,14 @@ RSpec.describe Hyrax::FileSetsController, type: :controller do
   end
 
   context "counter report counts from the show page" do
-    let(:keycard) { { dlpsInstitutionId: [institution.identifier] } }
-    let(:institution) { double('institution', identifier: '9999') }
+    let(:keycard) { { dlpsInstitutionId: [dlps_institution_id.to_s] } }
+    let(:institution) { create(:institution, identifier: dlps_institution_id.to_s) } # TODO: Prefix with '#'
+    let(:institution_affiliation) { create(:institution_affiliation, institution: institution, dlps_institution_id: dlps_institution_id, affiliation: 'member') }
+    let(:dlps_institution_id) { 9999 }
 
     before do
+      institution_affiliation
       allow_any_instance_of(Keycard::Request::Attributes).to receive(:all).and_return(keycard)
-      allow(Greensub::Institution).to receive(:where).with(identifier: ['9999']).and_return([institution])
       file_set.read_groups << "public"
       file_set.visibility = "open"
     end

--- a/spec/jobs/seed_institution_affiliations_job_spec.rb
+++ b/spec/jobs/seed_institution_affiliations_job_spec.rb
@@ -26,26 +26,41 @@ RSpec.describe SeedInstitutionAffiliationsJob, type: :job do
     it 'seeds institution affiliations' do
       institution_1
       job.perform
+      institution_1.reload
       expect(Greensub::InstitutionAffiliation.count).to eq 1
       expect(Greensub::InstitutionAffiliation.first.institution).to eq institution_1
-      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id).to eq institution_1.identifier.to_i
+      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id.to_s).to eq institution_1.identifier
       expect(Greensub::InstitutionAffiliation.first.affiliation).to eq 'member'
       institution_2
       job.perform
+      institution_1.reload
+      institution_2.reload
       expect(Greensub::InstitutionAffiliation.count).to eq 2
       expect(Greensub::InstitutionAffiliation.first.institution).to eq institution_1
-      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id).to eq institution_1.identifier.to_i
+      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id.to_s).to eq institution_1.identifier
       expect(Greensub::InstitutionAffiliation.first.affiliation).to eq 'member'
       expect(Greensub::InstitutionAffiliation.last.institution).to eq institution_2
-      expect(Greensub::InstitutionAffiliation.last.dlps_institution_id).to eq institution_2.identifier.to_i
+      expect(Greensub::InstitutionAffiliation.last.dlps_institution_id.to_s).to eq institution_2.identifier
+      expect(Greensub::InstitutionAffiliation.last.affiliation).to eq 'member'
+      job.perform(true)
+      institution_1.reload
+      institution_2.reload
+      expect(Greensub::InstitutionAffiliation.count).to eq 2
+      expect(Greensub::InstitutionAffiliation.first.institution).to eq institution_1
+      expect("#" + Greensub::InstitutionAffiliation.first.dlps_institution_id.to_s).to eq institution_1.identifier
+      expect(Greensub::InstitutionAffiliation.first.affiliation).to eq 'member'
+      expect(Greensub::InstitutionAffiliation.last.institution).to eq institution_2
+      expect("#" + Greensub::InstitutionAffiliation.last.dlps_institution_id.to_s).to eq institution_2.identifier
       expect(Greensub::InstitutionAffiliation.last.affiliation).to eq 'member'
       job.perform
+      institution_1.reload
+      institution_2.reload
       expect(Greensub::InstitutionAffiliation.count).to eq 2
       expect(Greensub::InstitutionAffiliation.first.institution).to eq institution_1
-      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id).to eq institution_1.identifier.to_i
+      expect(Greensub::InstitutionAffiliation.first.dlps_institution_id.to_s).to eq institution_1.identifier
       expect(Greensub::InstitutionAffiliation.first.affiliation).to eq 'member'
       expect(Greensub::InstitutionAffiliation.last.institution).to eq institution_2
-      expect(Greensub::InstitutionAffiliation.last.dlps_institution_id).to eq institution_2.identifier.to_i
+      expect(Greensub::InstitutionAffiliation.last.dlps_institution_id.to_s).to eq institution_2.identifier
       expect(Greensub::InstitutionAffiliation.last.affiliation).to eq 'member'
     end
   end

--- a/spec/models/greensub/institution_affiliation_spec.rb
+++ b/spec/models/greensub/institution_affiliation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Greensub::InstitutionAffiliation, type: :model do
     subject
     expect(Greensub::Institution.count).to eq 1
     expect(Greensub::InstitutionAffiliation.count).to eq 1
-    expect { institution.destroy }.to raise_error(ActiveRecord::StatementInvalid, /Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails/)
+    expect { institution.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError, "Cannot delete record because of dependent institution_affiliations")
     institution_affiliation.destroy
     expect(Greensub::InstitutionAffiliation.count).to eq 0
     expect(Greensub::Institution.count).to eq 1

--- a/spec/requests/api/v1/institutions_spec.rb
+++ b/spec/requests/api/v1/institutions_spec.rb
@@ -252,13 +252,6 @@ RSpec.describe "Institutions", type: :request do
         expect(response_body[:id.to_s]).to eq(institution.id)
         expect(response_body[:name.to_s]).to eq('updated_name')
       end
-
-      it 'existing update identifier unprocessable_entity' do
-        put api_institution_path(institution.id), params: { institution: { identifier: 'updated_identifier' } }.to_json, headers: headers
-        expect(response.content_type).to eq("application/json")
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response_body[:identifier.to_s]).to eq(["institution identifier can not be changed!"])
-      end
     end
 
     describe "PUT /api/v1/products/:product_id:/institutions/:id" do # update

--- a/spec/requests/e_pubs_spec.rb
+++ b/spec/requests/e_pubs_spec.rb
@@ -421,10 +421,13 @@ RSpec.describe "EPubs", type: :request do
           context "valid token" do
             let(:token) { JsonWebToken.encode(data: epub.id, exp: Time.now.to_i + 48 * 3600) }
             let(:request_attributes_for) { double('request_attributes_for') }
-            let(:request_attributes) { { dlpsInstitutionId: [institution.identifier] } }
-            let(:institution) { create(:institution) }
+            let(:request_attributes) { { dlpsInstitutionId: [dlps_institution_id] } }
+            let(:institution) { create(:institution, identifier: dlps_institution_id.to_s, entity_id: 'https://entity.id') } # TODO: Prefix identifier value with '#'
+            let(:institution_affiliation) { create(:institution_affiliation, institution: institution, dlps_institution_id: dlps_institution_id, affiliation: 'member') }
+            let(:dlps_institution_id) { 9999 }
 
             before do
+              institution_affiliation
               allow(Services).to receive(:request_attributes).and_return(request_attributes_for)
               allow(request_attributes_for).to receive(:for).and_return(request_attributes)
               allow(ShareLinkLog).to receive(:create)

--- a/spec/requests/greensub/institutions_spec.rb
+++ b/spec/requests/greensub/institutions_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe "Greensub::Institutions", type: :request do
           end
 
           context 'invalid institution params' do
-            let(:institution_params) { { identifier: 'identifier' } }
+            let(:institution_params) { { identifier: '' } }
 
             it do
               expect { subject }.not_to raise_error


### PR DESCRIPTION
Replace all institution lookups by identifier (a.k.a. dlsp_institution_id) with institution lookups by dlsp_institution_id via the institution_affliations table.

Created HELIO-3977 to address current institution identifier usage in creating Counter Report data and logic in selecting the user's primary institution when there is more than one current institutions.