### PR TITLE
HELIO-3976 - Allow all presses to embed resources

### DIFF
--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -121,10 +121,8 @@ webgl = Webgl::Unity.from_directory(UnpackService.root_path_from_noid(webgl_id, 
           href: "<%= "#{main_app.epub_url.gsub!(/\?.*/, '')}/" %>",
           skipLink: '.skip',
           download_links: <%= @ebook_download_presenter.csb_download_links.to_json.html_safe %>,
-          loader_template: '<div class="fulcrum-loading"><div class="rect rect1"></div><div class="circle circ1"></div><div class="rect rect2"></div><div class="circle circ2"></div></div>',
-          <% if %w[leverpress michigan mps uncpress].include? @subdomain %>
+          loader_template: '<div class="fulcrum-loading"><div class="rect rect1"></div><div class="circle circ1"></div><div class="rect rect2"></div><div class="circle circ2"></div></div>',        
           injectStylesheet: '/css/fulcrum_enhanced_display.css',
-          <% end %>
           metadata: {
             doi: '<%= @citable_link %>',
             location: 'Ann Arbor, MI'


### PR DESCRIPTION
Resolves HELIO-3976

Inject embedded resources CSS into all press instances using CSB, so that embedded resources can be used, if desired, in all EPUBs.