### PR TITLE
Validate institution identifier is an integer

### DIFF
--- a/app/models/greensub/institution.rb
+++ b/app/models/greensub/institution.rb
@@ -11,7 +11,7 @@ module Greensub
     scope :for_entity_id, ->(entity_id) { where(entity_id: entity_id) }
     scope :containing_dlps_institution_id, ->(dlps_institution_id) { joins(:institution_affiliations).merge(InstitutionAffiliation.for_dlps_institution_id(dlps_institution_id)).distinct }
 
-    validates :identifier, presence: true, allow_blank: false, uniqueness: true
+    validates :identifier, presence: true, allow_blank: false, uniqueness: true, numericality: { only_integer: true }
     validates :name, presence: true, allow_blank: false
     # validates :entity_id, presence: true, allow_blank: false
     # validates :site, presence: true, allow_blank: false

--- a/app/views/fulcrum/_dashboard.html.erb
+++ b/app/views/fulcrum/_dashboard.html.erb
@@ -9,7 +9,7 @@
 <h2>Instituions</h2>
 <ul>
   <% current_institutions.each do |institution| %>
-    <li>Institution:<%= "#{institution.id} (#{institution.name})" %></li>
+    <li>Institution:<%= "#{institution.id} (#{institution.identifier} - #{institution.name})" %></li>
   <% end %>
 </ul>
 <h2>Keycard</h2>

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe EPubsController, type: :controller do
         let(:epub) { Sighrax.from_noid(file_set.id) }
         let(:component) { Greensub::Component.create!(identifier: parent.resource_token, name: parent.title, noid: parent.noid) }
         let(:keycard) { { dlpsInstitutionId: dlpsInstitutionId } }
-        let(:dlpsInstitutionId) { 'institute' }
+        let(:dlpsInstitutionId) { '1' }
 
         before do
           clear_grants_table

--- a/spec/models/greensub/institution_spec.rb
+++ b/spec/models/greensub/institution_spec.rb
@@ -32,6 +32,30 @@ RSpec.describe Greensub::Institution, type: :model do
     end
   end
 
+  context 'validation' do
+    subject { institution }
+
+    let(:institution) { described_class.create!(params) }
+    let(:params) { { identifier: identifier,
+                     name: name,
+                     entity_id: entity_id,
+                     site: site,
+                     login: login,
+                     catalog_url: catalog_url,
+                     link_resolver_url: link_resolver_url,
+                     logo_path: logo_path } }
+    let(:identifier) { nil }
+    let(:name) { nil }
+    let(:entity_id) { nil }
+    let(:site) { nil }
+    let(:login) { nil }
+    let(:catalog_url) { nil }
+    let(:link_resolver_url) { nil }
+    let(:logo_path) { nil }
+
+    it { expect { subject }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Identifier can't be blank, Identifier is not a number, Name can't be blank") }
+  end
+
   context 'before validation' do
     it 'on update' do
       institution = create(:institution)

--- a/spec/requests/api/v1/institutions_spec.rb
+++ b/spec/requests/api/v1/institutions_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Institutions", type: :request do
           post api_institutions_path, params: params, headers: headers
           expect(response.content_type).to eq("application/json")
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(response_body[:identifier.to_s]).to eq(["can't be blank"])
+          expect(response_body[:identifier.to_s]).to eq(["can't be blank", "is not a number"])
           expect(response_body[:name.to_s]).to eq(["can't be blank"])
           expect(response_body[:entity_id.to_s]).to be nil
           expect(Greensub::Institution.count).to eq(0)
@@ -150,7 +150,7 @@ RSpec.describe "Institutions", type: :request do
       end
 
       context 'non existing' do
-        let(:identifier) { 'identifier' }
+        let(:identifier) { '1' }
         let(:name) { 'name' }
         let(:entity_id) { 'entity_id' }
 

--- a/spec/requests/greensub/institutions_spec.rb
+++ b/spec/requests/greensub/institutions_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Greensub::Institutions", type: :request do
   describe '#create' do
     subject { post greensub_institutions_path, params: { greensub_institution: institution_params } }
 
-    let(:institution_params) { { identifier: 'identifier', name: 'name' } }
+    let(:institution_params) { { identifier: '1', name: 'name' } }
 
     it { expect { subject }.to raise_error(ActionController::RoutingError) }
 


### PR DESCRIPTION
The institution identifier is a dlps_institution_id which is an integer hence the added clause numericality: { only_integer: true } to validates identifier in the model. 