### PR TITLE
actor institution affiliations

### DIFF
--- a/app/models/anonymous.rb
+++ b/app/models/anonymous.rb
@@ -19,6 +19,10 @@ class Anonymous
     Services.dlps_institution.find(request_attributes)
   end
 
+  def affiliations(institution)
+    Services.dlps_institution_affiliation.find(request_attributes).select { |ia| ia.institution_id == institution.id }
+  end
+
   def agent_type
     :Anonymous
   end

--- a/app/models/greensub/institution.rb
+++ b/app/models/greensub/institution.rb
@@ -19,6 +19,7 @@ module Greensub
 
     has_many :licenses, as: :licensee, dependent: :restrict_with_error
     has_many :institution_affiliations, dependent: :restrict_with_error
+    alias_attribute :affiliations, :institution_affiliations
 
     before_validation(on: :update) do
       if identifier_changed?

--- a/app/models/greensub/institution_affiliation.rb
+++ b/app/models/greensub/institution_affiliation.rb
@@ -8,9 +8,9 @@ module Greensub
 
     include Filterable
 
-    scope :institution_id_like, ->(like) { where("institution_id like ?", "%#{like}%") }
-    scope :dlps_institution_id_like, ->(like) { where("dlps_institution_id like ?", "%#{like}%") }
-    scope :affiliation_like, ->(like) { where("affiliation like ?", "%#{like}%") }
+    scope :institution_id_like, ->(like) { where("institution_id like ?", "#{like}") }
+    scope :dlps_institution_id_like, ->(like) { where("dlps_institution_id like ?", "#{like}%") }
+    scope :affiliation_like, ->(like) { where("affiliation like ?", "#{like}") }
 
     scope :for_dlps_institution_id, ->(dlps_institution_id) { where(dlps_institution_id: dlps_institution_id) }
 

--- a/app/models/greensub/license.rb
+++ b/app/models/greensub/license.rb
@@ -22,6 +22,7 @@ module Greensub
     validates :type, uniqueness: { scope: [:licensee_type, :licensee_id, :product_id] }
 
     has_many :license_affiliations, dependent: :restrict_with_error
+    alias_attribute :affiliations, :license_affiliations
 
     # temporary! TODO: HELIO-3994
     #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,14 @@ class User < ApplicationRecord
     display_name || identifier
   end
 
+  def individual
+    if Incognito.sudo_actor?(self)
+      Incognito.sudo_actor_individual(self)
+    else
+      Greensub::Individual.find_by(email: email) if email.present?
+    end
+  end
+
   def institutions
     if Incognito.sudo_actor?(self)
       [Incognito.sudo_actor_institution(self)].compact
@@ -167,11 +175,11 @@ class User < ApplicationRecord
     end
   end
 
-  def individual
+  def affiliations(institution)
     if Incognito.sudo_actor?(self)
-      Incognito.sudo_actor_individual(self)
+      [Incognito.sudo_actor_institution_affiliation(self)].compact.select { |ia| ia.institution_id == institution.id }
     else
-      Greensub::Individual.find_by(email: email) if email.present?
+      Services.dlps_institution_affiliation.find(request_attributes).select { |ia| ia.institution_id == institution.id }
     end
   end
 

--- a/app/policies/ebook_operation.rb
+++ b/app/policies/ebook_operation.rb
@@ -29,7 +29,7 @@ class EbookOperation < ApplicationPolicy
 
         return true if licenses
                         .where(licensee_type: "Greensub::Institution")
-                        .any? { |license| license.allows?(entitlement) } && affiliation_match?(licenses)
+                        .any? { |license| license.allows?(entitlement) && (license.affiliations.map(&:affiliation) & actor.affiliations(license.licensee).map(&:affiliation)).any? }
         false
       else
         authority
@@ -38,13 +38,4 @@ class EbookOperation < ApplicationPolicy
           .any? { |license| license.allows?(entitlement) }
       end
     end
-
-    private
-
-      def affiliation_match?(licenses)
-        licenses.where(licensee_type: "Greensub::Institution").each do |license|
-          return true if (license.licensee.institution_affiliations.map(&:affiliation) & license.license_affiliations.map(&:affiliation)).present?
-        end
-        false
-      end
 end

--- a/app/services/dlps_institution.rb
+++ b/app/services/dlps_institution.rb
@@ -10,12 +10,14 @@ class DlpsInstitution
     def ip_based_institutions(request_attributes)
       ids = request_attributes[:dlpsInstitutionId]
       return [] if ids.blank?
+
       Greensub::Institution.where(identifier: ids).to_a
     end
 
     def shib_institutions(request_attributes)
       entity_id = request_attributes[:identity_provider]
       return [] if entity_id.blank?
+
       Greensub::Institution.where(entity_id: entity_id).to_a
     end
 end

--- a/app/services/dlps_institution_affiliation.rb
+++ b/app/services/dlps_institution_affiliation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class DlpsInstitutionAffiliation
+  def find(request_attributes)
+    (ip_based_institution_affiliations(request_attributes) + shib_institution_affiliations(request_attributes)).uniq
+  end
+
+  private
+
+    def ip_based_institution_affiliations(request_attributes)
+      ids = request_attributes[:dlpsInstitutionId]
+      return [] if ids.blank?
+
+      Greensub::InstitutionAffiliation.where(dlps_institution_id: ids).to_a
+    end
+
+    def shib_institution_affiliations(request_attributes)
+      entity_id = request_attributes[:identity_provider]
+      return [] if entity_id.blank?
+
+      ids = Greensub::Institution.where(entity_id: entity_id).pluck(:id).to_a
+      affiliations = request_attributes[:eduPersonScopedAffiliation]&.map { |scoped| scoped.strip[0, scoped.strip.index('@')] } || ['member']
+
+      Greensub::InstitutionAffiliation.where(institution_id: ids, affiliation: affiliations).to_a
+    end
+end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -55,6 +55,8 @@ Services.register(:request_attributes) { Keycard::Request::AttributesFactory.new
 
 Services.register(:dlps_institution) { DlpsInstitution.new }
 
+Services.register(:dlps_institution_affiliation) { DlpsInstitutionAffiliation.new }
+
 Services.register(:score_press) { 'carillon' }
 
 Services.register(:handle_service) do

--- a/spec/models/anonymous_spec.rb
+++ b/spec/models/anonymous_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe Anonymous, type: :model do
   subject { described_class.new(request_attributes) }
 
   let(:request_attributes) { {} }
+  let(:institution) { build(:institution, id: 100) }
+  let(:affiliation) { build(:institution_affiliation, institution_id: 100) }
 
   it { expect(subject.email).to be nil }
   it { expect(subject.individual).to be nil }
   it { expect(subject.institutions).to eq [] }
+  it { expect(subject.affiliations(institution)).to eq [] }
   it { expect(subject.agent_type).to eq :Anonymous }
   it { expect(subject.agent_id).to eq :any }
   it { expect(subject.platform_admin?).to be false }
@@ -18,4 +21,17 @@ RSpec.describe Anonymous, type: :model do
   it { expect(subject.admin_presses).to be_empty }
   it { expect(subject.editor_presses).to be_empty }
   it { expect(subject.analyst_presses).to be_empty }
+
+  context 'when institution' do
+    before { allow(Services.dlps_institution).to receive(:find).with(request_attributes).and_return [institution] }
+
+    it { expect(subject.institutions).to contain_exactly(institution) }
+  end
+
+  context 'when affiliations' do
+    before { allow(Services.dlps_institution_affiliation).to receive(:find).with(request_attributes).and_return [affiliation] }
+
+    it { expect(subject.affiliations(institution)).to contain_exactly(affiliation) }
+    it { expect(subject.affiliations(build(:institution, id: 101))).to eq [] }
+  end
 end

--- a/spec/services/dlps_institution_affiliation_spec.rb
+++ b/spec/services/dlps_institution_affiliation_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DlpsInstitutionAffiliation do
+  describe '#find' do
+    subject { described_class.new.find(request_attributes) }
+
+    let(:request_attributes) { {} }
+
+    it { is_expected.to eq [] }
+
+    context 'request_attributes' do
+      let(:request_attributes) { { dlpsInstitutionId: ids, identity_provider: entity_id, eduPersonScopedAffiliation: scoped_affiliations } }
+      let(:ids) { }
+      let(:entity_id) { }
+      let(:scoped_affiliations) { }
+
+      it { is_expected.to eq [] }
+
+      context 'institution_affiliations' do
+        let(:institution_1) { create(:institution, identifier: '1', entity_id: 'entity_1') }
+        let(:institution_1_affiliation_1) { create(:institution_affiliation, institution: institution_1, dlps_institution_id: 1, affiliation: 'member') }
+        let(:institution_1_affiliation_2) { create(:institution_affiliation, institution: institution_1, dlps_institution_id: 3, affiliation: 'alum') }
+        let(:institution_2) { create(:institution, identifier: '2', entity_id: 'entity_2') }
+        let(:institution_2_affiliation_1) { create(:institution_affiliation, institution: institution_2, dlps_institution_id: 2, affiliation: 'member') }
+
+        before do
+          institution_1_affiliation_1
+          institution_1_affiliation_2
+          institution_2_affiliation_1
+        end
+
+        context 'ip_based' do
+          let(:ids) { [institution_2.identifier] }
+          let(:entity_id) { 'entity_id' }
+
+          it { is_expected.to contain_exactly(institution_2_affiliation_1) }
+        end
+
+        context 'shib' do
+          let(:ids) { ['ids'] }
+          let(:entity_id) { institution_1.entity_id }
+
+          it { is_expected.to contain_exactly(institution_1_affiliation_1) }
+
+          context 'eduPersonScopedAffiliation' do
+            let(:scoped_affiliations) { ['staff@x.y.z', 'alum@z.y.x', 'joker@z.z.z'] }
+
+            it { is_expected.to contain_exactly(institution_1_affiliation_2) }
+          end
+        end
+
+        context 'both' do
+          let(:ids) { [institution_1.identifier, institution_2.identifier] }
+          let(:entity_id) { institution_1.entity_id }
+
+          it { is_expected.to contain_exactly(institution_1_affiliation_1, institution_2_affiliation_1) }
+
+          context 'eduPersonScopedAffiliation' do
+            let(:scoped_affiliations) { ['staff@x.y.z', 'alum@z.y.x', 'joker@z.z.z'] }
+
+            it { is_expected.to contain_exactly(institution_1_affiliation_1, institution_1_affiliation_2, institution_2_affiliation_1) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created dlps_institution_affiliation service (as inspired by dlps_institution service) to retrieve Greensub::InstitutionAffiliation records for the current user from request attributes.

Added intersection between license affiliations and actor affiliations for the licensed institution any? clause to ebook operations policy.