### PR TITLE
licensed_for? world_institution

### DIFF
--- a/app/policies/ebook_operation.rb
+++ b/app/policies/ebook_operation.rb
@@ -30,6 +30,12 @@ class EbookOperation < ApplicationPolicy
         return true if licenses
                         .where(licensee_type: "Greensub::Institution")
                         .any? { |license| license.allows?(entitlement) && (license.affiliations.map(&:affiliation) & actor.affiliations(license.licensee).map(&:affiliation)).any? }
+
+        world_institution_ids = Greensub::Institution.where(identifier: Settings.world_institution_identifier).pluck(:id).to_a
+        return true if licenses
+                         .where(licensee_type: "Greensub::Institution", licensee_id: world_institution_ids)
+                         .any? { |license| license.allows?(entitlement) }
+
         false
       else
         authority

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe EPubsController, type: :controller do
         let(:epub) { Sighrax.from_noid(file_set.id) }
         let(:component) { Greensub::Component.create!(identifier: parent.resource_token, name: parent.title, noid: parent.noid) }
         let(:keycard) { { dlpsInstitutionId: dlpsInstitutionId } }
-        let(:dlpsInstitutionId) { '0' }
+        let(:dlpsInstitutionId) { '-1' }
 
         before do
           clear_grants_table


### PR DESCRIPTION
Refactored licensed_for?(entitlement) in EbookOperation to handle world institution licenses (Settings.world_institution_identifier) to behave like individual licenses a.k.a. ignore affiliations.