### PR TITLE
HELIO-3936 - add auto height to bar brand logo

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -2143,6 +2143,7 @@ $barpublishing-white: #fff;
     .navbar-brand {
       @include arial;
       color: $barpublishing-white;
+      height: auto;
     }
 
     .navbar-nav {


### PR DESCRIPTION
Resolves HELIO-3936

Adds height: auto to .navbar-brand for BAR publishing to ensure active and focus borders outline entire container.

![Screen Shot 2021-09-14 at 12 42 29 PM](https://user-images.githubusercontent.com/1686111/133299024-310416ec-9832-4faa-a365-d5b88234ab79.png)
