### PR TITLE
use iframe embed codes for images

### DIFF
--- a/app/services/embed_code_service.rb
+++ b/app/services/embed_code_service.rb
@@ -67,15 +67,15 @@ module EmbedCodeService
       # the EPUB off-Fulcrum. There is no other reason they would have a style attribute, so delete it completely.
       node.remove_attribute('style')
 
-      if file_set_presenter.audio? || file_set_presenter.video?
-        # for these full embed markup is added inside the <figure> element in the derivative-folder XHTML file
-        node.add_child(file_set_presenter.embed_code)
-      else
-        # data attributes prompt CSB to add embed modal and button
+      if file_set_presenter.interactive_map?
+        # these data attributes prompt CSB to add embed modal and button
         # see https://github.com/mlibrary/cozy-sun-bear/blob/51b7e4e62be0e4b0afb6c43b08fbbc46de312204/src/utils/manglers.js#L189
         node['data-href'] = file_set_presenter.embed_link
         node['data-title'] = file_set_presenter.embed_code_title
         node['data-resource-type'] = resource_type(file_set_presenter)
+      else
+        # for these full embed markup is added inside the <figure> element in the derivative-folder XHTML file
+        node.add_child(file_set_presenter.embed_code)
       end
 
       maybe_add_figcaption(node, file_set_presenter)
@@ -96,16 +96,16 @@ module EmbedCodeService
       # both embed code methods require node's parents to hold new div elements, so the parent cannot be a p
       node.parent.name = 'div' if node.parent.name == 'p'
 
-      if file_set_presenter.audio? || file_set_presenter.video?
-        # full embed markup added to XHTML file for these
-        # the local image is no longer needed, just replace it with the embed code
-        node.replace(file_set_presenter.embed_code)
-      else
-        # data attributes prompt CSB to add embed modal and button
+      if file_set_presenter.interactive_map?
+        # these data attributes prompt CSB to add embed modal and button
         # see https://github.com/mlibrary/cozy-sun-bear/blob/51b7e4e62be0e4b0afb6c43b08fbbc46de312204/src/utils/manglers.js#L189
         node.add_next_sibling("<div data-href=\"#{file_set_presenter.embed_link}\" " \
                               "data-title=\"#{file_set_presenter.embed_code_title}\" " \
                               "data-resource-type=\"#{resource_type(file_set_presenter)}\" />")
+      else
+        # full embed markup added to XHTML file for these
+        # the local image is no longer needed, just replace it with the embed code
+        node.replace(file_set_presenter.embed_code)
       end
     end
   end

--- a/fulcrum/css/fulcrum_enhanced_display.css
+++ b/fulcrum/css/fulcrum_enhanced_display.css
@@ -1,68 +1,15 @@
-/* SPECIAL STYLESHEET USED TO DISPLAY EMBEDDED 
+/* SPECIAL STYLESHEET USED TO DISPLAY EMBEDDED
    MEDIA in U-M PRESS EPUB FILES on FULCRUM */
 
 /* Hide default media blocks, such as image thumbnails */
 .default-media-display {
-    display: none !important;
+  display: none !important;
 }
 /* Display enhanced media blocks, such as Fulcrum embedded audio/video/images */
 .enhanced-media-display {
-    display: block !important;
+  display: block !important;
 }
 /* Display enhanced media inline, such as links to Fulcrum resource pages */
 span.enhanced-media-display {
-    display: inline !important;
-}
-
-/* place "open <resource>" button in the middle of the figure, 
-   presumably a nested <img> */
-
-figure > div {
-    display: flex !important;
-    justify-content: center !important;
-    align-items: center !important;
-    flex-direction: column !important;
-}
-
-figure div[data-href*="embed"] {
-    display: flex !important;
-    position: absolute !important;
-    align-items: center !important;
-    justify-content: center !important;
-    background-color: transparent !important;
-}
-
-figure .cozy-mangled-popup--container {
-    background-color: transparent;
-}
-figure .cozy-mangled-popup--container button.cozy-mangled-popup--action {
-    clip-path: inset(100%);
-    clip: rect(1px, 1px, 1px, 1px);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-}
-
-figure:hover .cozy-mangled-popup--container button.cozy-mangled-popup--action,
-figure:active .cozy-mangled-popup--container button.cozy-mangled-popup--action,
-figure:focus .cozy-mangled-popup--container button.cozy-mangled-popup--action,
-figure .cozy-mangled-popup--container button.cozy-mangled-popup--action:hover,
-figure .cozy-mangled-popup--container button.cozy-mangled-popup--action:active,
-figure .cozy-mangled-popup--container button.cozy-mangled-popup--action:focus
-  {
-    clip-path: unset;
-    clip: unset;
-    height: unset;
-    overflow: unset;
-    position: unset;
-    white-space: unset;
-    width: unset;
-}
-
-figure:hover img,
-figure:active img,
-figure:focus img {
-    opacity: 0.2;
+  display: inline !important;
 }

--- a/spec/services/embed_code_service_spec.rb
+++ b/spec/services/embed_code_service_spec.rb
@@ -99,20 +99,20 @@ RSpec.describe EmbedCodeService do
       end
 
       context "Files referenced in the EPUB using data attributes" do
-        it "inserts iframe embed codes for audio and video files" do
+        it "inserts iframe embed codes for image, audio and video files" do
           expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml'))).to be true
           doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml')))
+          expect(doc.search(image_embed_attributes)).to be_empty
+          expect(doc.search("iframe[@src=\"#{image_embed_url}\"]").size).to eq(1)
           expect(doc.search(audio_embed_attributes)).to be_empty
           expect(doc.search("iframe[@src=\"#{audio_embed_url}\"]").size).to eq(2) # one is a no-local-image example
           expect(doc.search(video_embed_attributes)).to be_empty
           expect(doc.search("iframe[@src=\"#{video_embed_url}\"]").size).to eq(1)
         end
 
-        it "inserts CSB-modal embed codes for images and interactive maps" do
+        it "inserts CSB-modal embed codes for interactive maps" do
           expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml'))).to be true
           doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml')))
-          expect(doc.search(image_embed_attributes).size).to eq(1)
-          expect(doc.search("iframe[@src=\"#{image_embed_url}\"]")).to be_empty
           expect(doc.search(interactive_map_embed_attributes).size).to eq(1)
           expect(doc.search("iframe[@src=\"#{interactive_map_embed_url}\"]")).to be_empty
         end
@@ -143,9 +143,12 @@ RSpec.describe EmbedCodeService do
       end
 
       context "Inserts embed codes for files referenced in the EPUB using img src basename matching" do
-        it "inserts iframe embed codes for audio and video files and removes the original img tags" do
+        it "inserts iframe embed codes for image, audio and video files and removes the original img tags" do
           expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_img_src_basenames.xhtml'))).to be true
           doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_img_src_basenames.xhtml')))
+          expect(doc.search(image_embed_attributes)).to be_empty
+          expect(doc.search("iframe[@src=\"#{image_embed_url}\"]").size).to eq(1)
+          expect(doc.search("img[@alt=\"local image for image embed\"]")).to be_empty
           expect(doc.search(audio_embed_attributes)).to be_empty
           expect(doc.search("iframe[@src=\"#{audio_embed_url}\"]").size).to eq(1)
           expect(doc.search("img[@alt=\"local image for audio embed\"]")).to be_empty
@@ -154,12 +157,9 @@ RSpec.describe EmbedCodeService do
           expect(doc.search("img[@alt=\"local image for video embed\"]")).to be_empty
         end
 
-        it "inserts CSB-modal embed codes for images and interactive maps, leaving their img tags in place" do
+        it "inserts CSB-modal embed codes for interactive maps, leaving their img tags in place" do
           expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_img_src_basenames.xhtml'))).to be true
           doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_img_src_basenames.xhtml')))
-          expect(doc.search(image_embed_attributes).size).to eq(1)
-          expect(doc.search("iframe[@src=\"#{image_embed_url}\"]")).to be_empty
-          expect(doc.search("img[@alt=\"local image for image embed\"]").size).to eq(1)
           expect(doc.search(interactive_map_embed_attributes).size).to eq(1)
           expect(doc.search("iframe[@src=\"#{interactive_map_embed_url}\"]")).to be_empty
           expect(doc.search("img[@alt=\"local image for interactive map embed\"]").size).to eq(1)
@@ -267,9 +267,11 @@ RSpec.describe EmbedCodeService do
         end
 
         context "Inserts embed codes for files referenced in the EPUB using data attributes" do
-          it "inserts iframe embed codes for audio and video files" do
+          it "inserts iframe embed codes for image, audio and video files" do
             expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml'))).to be true
             doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml')))
+            expect(doc.search(image_embed_attributes)).to be_empty
+            expect(doc.search("iframe[@src=\"#{image_embed_url}\"]").size).to eq(1)
             expect(doc.search(audio_embed_attributes)).to be_empty
             expect(doc.search("iframe[@src=\"#{audio_embed_url}\"]").size).to eq(2) # one is a no-local-image example
             expect(doc.search(video_embed_attributes)).to be_empty
@@ -278,11 +280,9 @@ RSpec.describe EmbedCodeService do
             expect(doc.search("figure[@data-fulcrum-embed-filename][@style]")).to be_empty
           end
 
-          it "Inserts CSB-modal embed codes for images and interactive maps" do
+          it "Inserts CSB-modal embed codes for interactive maps" do
             expect(File.exist?(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml'))).to be true
             doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'embeds_using_data_attributes.xhtml')))
-            expect(doc.search(image_embed_attributes).size).to eq(1)
-            expect(doc.search("iframe[@src=\"#{image_embed_url}\"]")).to be_empty
             expect(doc.search(interactive_map_embed_attributes).size).to eq(1)
             expect(doc.search("iframe[@src=\"#{interactive_map_embed_url}\"]")).to be_empty
             # all styles removed from additional resources (especially targeting the `display:none` needed off-Fulcrum)
@@ -340,7 +340,8 @@ RSpec.describe EmbedCodeService do
           doc = Nokogiri::XML(File.read(File.join(root_path, 'EPUB', 'xhtml', 'spec_filename_testing.xhtml')))
           # check parent `p.image` tags are changed to <div> tags for the two <img> `src` basename embeds
           expect(doc.search("div[@class='image']").count).to eq(2)
-          expect(doc.search(weird_case_image_embed_attributes).size).to eq(1)
+          expect(doc.search(weird_case_image_embed_attributes)).to be_empty
+          expect(doc.search("iframe[@src=\"#{weird_case_image_embed_url}\"]").size).to eq(1)
           expect(doc.search(audio_embed_attributes)).to be_empty
           expect(doc.search("iframe[@src=\"#{audio_embed_url}\"]").size).to eq(2) # one is a no-local-image example
           expect(doc.search(hyphen_video_embed_attributes)).to be_empty


### PR DESCRIPTION
HELIO-4048
Meaning only interactive maps use the button/modal embed style as
before. The new/beta troublesome styles for these in `./public`,
i.e. `./fulcrum/css/fulcrum_enhanced_display.css` are therefore no
longer needed.