### PR TITLE
HELIO-4031 Make URL in citation_pdf_url meta tag absolute

### DIFF
--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -41,15 +41,15 @@
   <% end %>
 
   <% if @presenter.representative_id.present? %>
-    <meta name="og:image" content="<%= Riiif::Engine.routes.url_helpers.image_path(@presenter.cache_buster_id, "225,") %>">
-    <meta name="twitter:image" content="<%= Riiif::Engine.routes.url_helpers.image_path(@presenter.cache_buster_id, "225,") %>">
+    <meta name="og:image" content="<%= Rails.application.routes.default_url_options[:protocol] + "://" + Rails.application.routes.default_url_options[:host] + Riiif::Engine.routes.url_helpers.image_path(@presenter.cache_buster_id, "225,") %>">
+    <meta name="twitter:image" content="<%= Rails.application.routes.default_url_options[:protocol] + "://" + Rails.application.routes.default_url_options[:host] + Riiif::Engine.routes.url_helpers.image_path(@presenter.cache_buster_id, "225,") %>">
     <%# this is terrible alt text. But like 99% of cover image file_set alt_text fields are blank... %>
     <meta name="og:image:alt" content="Cover Image for <%= @presenter.page_title %>">
   <% end %>
 
   <% if @ebook_download_presenter.present? && @ebook_download_presenter.pdf_ebook.present? && @ebook_download_presenter.downloadable?(@ebook_download_presenter.pdf_ebook) %>
     <%# for google scholar, HELIO-3951 %>
-    <meta name="citation_pdf_url" content="<%= Rails.application.routes.url_helpers.download_ebook_path(@ebook_download_presenter.pdf_ebook.id) %>">
+    <meta name="citation_pdf_url" content="<%= Rails.application.routes.url_helpers.download_ebook_url(@ebook_download_presenter.pdf_ebook.id) %>">
   <% end %>
 
 <% elsif controller_name == "file_sets" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  Rails.application.routes.default_url_options[:protocol] = 'http'
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,6 +24,8 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
   }
 
+  Rails.application.routes.default_url_options[:protocol] = 'http'
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/spec/views/shared/_metadata.html.erb_spec.rb
+++ b/spec/views/shared/_metadata.html.erb_spec.rb
@@ -164,7 +164,7 @@ describe 'shared/_metadata.html.erb' do
         allow(controller).to receive(:controller_name).and_return("monograph_catalog")
         render
 
-        expect(rendered).to match '\"citation_pdf_url\" content=\"/ebooks/file_set1/download\"'
+        expect(rendered).to match '\"citation_pdf_url\" content=\"http://test.host/ebooks/file_set1/download\"'
       end
     end
 


### PR DESCRIPTION
Works in dev, on testing and should work in production (see notes in the ticket).