### PR TITLE
Make Sighrax::NullEntity restricted so orphan FileSets and FileSets t…

### DIFF
--- a/app/models/sighrax/null_entity.rb
+++ b/app/models/sighrax/null_entity.rb
@@ -110,7 +110,7 @@ module Sighrax
     end
 
     def restricted?
-      false
+      true
     end
 
     def series

--- a/spec/models/sighrax/null_enitty_spec.rb
+++ b/spec/models/sighrax/null_enitty_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Sighrax::NullEntity, type: :model do
     it { expect(subject.published?)       .to be false }
     it { expect(subject.publisher)        .to be_an_instance_of(Sighrax::NullPublisher) }
     it { expect(subject.publishing_house) .to eq('') }
-    it { expect(subject.restricted?)      .to be false }
+    it { expect(subject.restricted?)      .to be true }
     it { expect(subject.timestamp)        .to be nil }
     it { expect(subject.series)           .to eq('') }
     it { expect(subject.subjects)         .to eq([]) }
@@ -135,7 +135,10 @@ RSpec.describe Sighrax::NullEntity, type: :model do
             it { expect(subject.publication_year) .to eq instance.publication_year }
             it { expect(subject.published)        .to eq instance.published }
             it { expect(subject.publishing_house) .to eq instance.publishing_house }
-            it { expect(subject.restricted?)      .to eq instance.restricted? }
+            # NOTE: A NullEntity is restricted because a FileSets without a Monograph
+            # has a NullEntity parent therefore the FileSet needs to be reindex
+            # or it is an orphan, in both cases we want the FileSet to be restricted.
+            it { expect(subject.restricted?)      .not_to eq instance.restricted? }
             it { expect(subject.series)           .to eq instance.series }
             it { expect(subject.subjects)         .to eq instance.subjects }
           end

--- a/spec/presenters/e_book_download_presenter_spec.rb
+++ b/spec/presenters/e_book_download_presenter_spec.rb
@@ -9,17 +9,18 @@ RSpec.describe EBookDownloadPresenter do
   let(:current_ability) { Ability.new(user) }
   let(:current_actor) { user }
 
-  let(:mono) { Hyrax::MonographPresenter.new(SolrDocument.new(id: 'mono_id', visibility_ssi: 'open', has_model_ssim: ['Monograph']), current_ability) }
-  let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'yes') }
-  let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'yes') }
-  let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'yes') }
-  let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 50_000, allow_download_ssim: 'yes') }
+  let(:mono) { Hyrax::MonographPresenter.new(SolrDocument.new(id: 'validnoid', visibility_ssi: 'open', has_model_ssim: ['Monograph']), current_ability) }
+  let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'yes') }
+  let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'yes') }
+  let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'yes') }
+  let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 50_000, allow_download_ssim: 'yes') }
 
   before do
-    create(:featured_representative, file_set_id: '111111111', work_id: 'mono_id', kind: 'epub')
-    create(:featured_representative, file_set_id: '222222222', work_id: 'mono_id', kind: 'mobi')
-    create(:featured_representative, file_set_id: '333333333', work_id: 'mono_id', kind: 'pdf_ebook')
-    create(:featured_representative, file_set_id: '444444444', work_id: 'mono_id', kind: 'audiobook')
+    allow(Sighrax).to receive(:from_noid).with('validnoid').and_return(Sighrax.from_presenter(mono))
+    create(:featured_representative, file_set_id: '111111111', work_id: 'validnoid', kind: 'epub')
+    create(:featured_representative, file_set_id: '222222222', work_id: 'validnoid', kind: 'mobi')
+    create(:featured_representative, file_set_id: '333333333', work_id: 'validnoid', kind: 'pdf_ebook')
+    create(:featured_representative, file_set_id: '444444444', work_id: 'validnoid', kind: 'audiobook')
     ActiveFedora::SolrService.add([epub_doc.to_h, mobi_doc.to_h, pdfe_doc.to_h, audiobook_doc.to_h])
     ActiveFedora::SolrService.commit
   end
@@ -68,10 +69,10 @@ RSpec.describe EBookDownloadPresenter do
     end
 
     context "with a downloadable ebook" do
-      let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'restricted', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'no') }
-      let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'restricted', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'no') }
-      let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'yes') }
-      let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
+      let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'restricted', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'no') }
+      let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'restricted', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'no') }
+      let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'yes') }
+      let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
 
       it "returns true" do
         expect(subject.downloadable_ebooks?).to be true
@@ -79,10 +80,10 @@ RSpec.describe EBookDownloadPresenter do
     end
 
     context "with no downloadable ebooks" do
-      let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'restricted', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'no') }
-      let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'restricted', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'no') }
-      let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
-      let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'mono_id', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
+      let(:epub_doc) { SolrDocument.new(id: '111111111', visibility_ssi: 'restricted', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 20_000, allow_download_ssim: 'no') }
+      let(:mobi_doc) { SolrDocument.new(id: '222222222', visibility_ssi: 'restricted', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 30_000, allow_download_ssim: 'no') }
+      let(:pdfe_doc) { SolrDocument.new(id: '333333333', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
+      let(:audiobook_doc) { SolrDocument.new(id: '444444444', visibility_ssi: 'open', monograph_id_ssim: 'validnoid', has_model_ssim: ['FileSet'], file_size_lts: 40_000, allow_download_ssim: 'no') }
 
       it "returns false" do
         expect(subject.downloadable_ebooks?).to be false


### PR DESCRIPTION
…hat need to be reindexed are restricted.  That is to say when a Sighrax::Resource's parent (monograph) is the NullEntity.