### PR TITLE
HELIO-3892 - Move Yabeda/Prometheus to its own port

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,8 +4,6 @@
 
 require_relative 'config/environment'
 
-use Yabeda::Prometheus::Exporter
-
 Dir[File.join(ENV.fetch("PROMETHEUS_MONITORING_DIR"), "*.bin")].each do |file_path|
   File.unlink(file_path)
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -68,6 +68,8 @@ require 'prometheus/client/data_stores/direct_file_store'
 
 activate_control_app
 plugin :yabeda
+plugin :yabeda_prometheus
+prometheus_exporter_url "tcp://0.0.0.0:9394/metrics"
 
 before_fork do
   Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: ENV.fetch('PROMETHEUS_MONITORING_DIR'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,9 +80,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # puma monitoring see HELIO-2604
-  mount Yabeda::Prometheus::Exporter => "/metrics"
-
   constraints platform_administrator_constraint do
     namespace :greensub do
       resources :individuals do


### PR DESCRIPTION
We want to move the Prometheus exporter out of the application routes
for two reasons:

- So we can readily manage access to metrics by firewall/IP
- So metrics requests are still served if the puma thread pool becomes
  saturated

In testing, puma does not launch a separate process for the exporter, so
we will have to confirm whether it remains responsive when all
application worker threads are taken.