### PR TITLE
Resolves HELIO-4101 WAYFless URLs should force authentication

### DIFF
--- a/app/controllers/counter_reports_controller.rb
+++ b/app/controllers/counter_reports_controller.rb
@@ -3,7 +3,7 @@
 class CounterReportsController < ApplicationController
   before_action :set_counter_report_service, only: %i[index show edit update]
   before_action :set_counter_report, only: %i[show update]
-  before_action :wayfless, only: %i[index]
+  before_action :wayfless_redirect_to_shib_login, only: %i[index]
   before_action :set_presses_and_institutions, only: %i[index show]
 
   COUNTER_REPORT_TITLE = {
@@ -107,9 +107,5 @@ class CounterReportsController < ApplicationController
     def counter_report_params
       params.require(:counter_report).permit
       params.permit(:institution, :press, :start_date, :end_date, :metric_type, :access_type, :access_method, :data_type, :yop)
-    end
-
-    def wayfless
-      wayfless_redirect_to_shib_login
     end
 end

--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -5,7 +5,7 @@ class EPubsController < CheckpointController
 
   protect_from_forgery except: :file
   before_action :setup
-  before_action :wayfless, only: %i[show]
+  before_action :wayfless_redirect_to_shib_login, only: %i[show]
 
   def show # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return redirect_to epub_access_url unless @policy.show?
@@ -252,9 +252,5 @@ class EPubsController < CheckpointController
       File.mtime(UnpackService.root_path_from_noid(@entity.noid, 'pdf_ebook_chapters')).to_i
     rescue StandardError => _e
       ''
-    end
-
-    def wayfless
-      wayfless_redirect_to_shib_login unless @policy.show?
     end
 end

--- a/app/controllers/ebooks_controller.rb
+++ b/app/controllers/ebooks_controller.rb
@@ -4,10 +4,10 @@ class EbooksController < CheckpointController
   include Watermark::Watermarkable
 
   before_action :setup
-  before_action :wayfless, only: %i[download]
+  before_action :wayfless_redirect_to_shib_login, only: %i[download]
 
   def download
-    raise NotAuthorizedError unless @ebook_download_operation_allowed
+    raise NotAuthorizedError unless EbookDownloadOperation.new(current_actor, @ebook).allowed?
     return redirect_to(hyrax.download_path(params[:id])) unless @ebook.watermarkable? && @ebook.publisher.watermark?
 
     # we'll send the linearized file in all cases, leave Fedora out of it. They should always exist, and do right now.
@@ -27,10 +27,5 @@ class EbooksController < CheckpointController
 
     def setup
       @entity = @ebook = Sighrax.from_noid(params[:id])
-      @ebook_download_operation_allowed = EbookDownloadOperation.new(current_actor, @ebook).allowed?
-    end
-
-    def wayfless
-      wayfless_redirect_to_shib_login unless @ebook_download_operation_allowed
     end
 end

--- a/app/controllers/monograph_catalog_controller.rb
+++ b/app/controllers/monograph_catalog_controller.rb
@@ -4,7 +4,7 @@ class MonographCatalogController < ::CatalogController
   before_action :load_presenter, only: %i[index facet purchase]
   before_action :load_press_presenter, only: %i[purchase]
   before_action :load_stats, only: %i[index facet]
-  before_action :wayfless, only: %i[index]
+  before_action :wayfless_redirect_to_shib_login, only: %i[index]
   after_action :add_counter_stat, only: %i[index]
 
   self.theme = 'hyrax'
@@ -118,9 +118,5 @@ class MonographCatalogController < ::CatalogController
       # HELIO-2292
       return unless @presenter.epub? || @presenter.pdf_ebook? || @presenter.mobi?
       CounterService.from(self, @presenter).count
-    end
-
-    def wayfless
-      wayfless_redirect_to_shib_login if disable_read_button?
     end
 end

--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -6,7 +6,7 @@ class PressCatalogController < ::CatalogController
   before_action :load_allow_read_product_ids
   before_action :has_open_access
   before_action :conditional_blacklight_configuration
-  before_action :wayfless, only: %i[index]
+  before_action :wayfless_redirect_to_shib_login, only: %i[index]
 
   self.theme = 'hyrax'
   with_themed_layout 'catalog'
@@ -153,9 +153,5 @@ class PressCatalogController < ::CatalogController
       blacklight_config.add_sort_field 'year asc', sort: "#{Solrizer.solr_name('date_created', :sortable)} asc, #{Solrizer.solr_name('date_published', :sortable)} asc", label: "Publication Date (Oldest First)"
       blacklight_config.add_sort_field 'title asc', sort: "#{Solrizer.solr_name('title', :sortable)} asc", label: "Title (A-Z)"
       blacklight_config.add_sort_field 'title desc', sort: "#{Solrizer.solr_name('title', :sortable)} desc", label: "Title (Z-A)"
-    end
-
-    def wayfless
-      wayfless_redirect_to_shib_login
     end
 end

--- a/app/overrides/hyrax/file_sets_controller_overrides.rb
+++ b/app/overrides/hyrax/file_sets_controller_overrides.rb
@@ -9,8 +9,8 @@ Hyrax::FileSetsController.class_eval do # rubocop:disable Metrics/BlockLength
       (redirect_to Rails.application.routes.url_helpers.monograph_catalog_path(presenter&.parent&.id)) && return if bounce_from_representatives?
 
       # Presently resources are not restricted but if someone is following a WAYFless URL
-      # then redirect them to shib login unless open access monograph.
-      wayfless_redirect_to_shib_login unless presenter&.parent&.open_access?
+      # then redirect them to shib login.
+      wayfless_redirect_to_shib_login
 
       redirect_to redirect_link, status: :moved_permanently if redirect_link.present?
       if presenter.multimedia?

--- a/spec/requests/wayfless_spec.rb
+++ b/spec/requests/wayfless_spec.rb
@@ -87,9 +87,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
       it do
         subject
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:index)
-        expect(response.body).not_to match(/You do not have access to this book/)
+        expect(response).to redirect_to(shib_login_path(monograph_catalog_path(monograph.id), params: entity_id))
       end
 
       context 'restricted' do
@@ -111,9 +109,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
           it do
             subject
-            expect(response).to have_http_status(:ok)
-            expect(response).to render_template(:index)
-            expect(response.body).not_to match(/You do not have access to this book/)
+            expect(response).to redirect_to(shib_login_path(monograph_catalog_path(monograph.id), params: entity_id))
           end
         end
 
@@ -191,8 +187,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
         it do
           subject
-          expect(response).to have_http_status(:ok)
-          expect(response).to render_template(:show)
+          expect(response).to redirect_to(main_app.shib_login_path(main_app.hyrax_file_set_path(resource.id), params: entity_id))
         end
       end
 
@@ -299,7 +294,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
       it do
         subject
-        expect(response).to redirect_to(hyrax.download_path(epub.id))
+        expect(response).to redirect_to(shib_login_path(download_ebook_path(epub.id), params: entity_id))
       end
 
       context 'restricted' do
@@ -321,7 +316,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
           it do
             subject
-            expect(response).to redirect_to(hyrax.download_path(epub.id))
+            expect(response).to redirect_to(shib_login_path(download_ebook_path(epub.id), params: entity_id))
           end
         end
 
@@ -384,8 +379,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
       it do
         subject
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:show)
+        expect(response).to redirect_to(shib_login_path(epub_path(epub.id), params: entity_id))
       end
 
       context 'restricted' do
@@ -407,8 +401,7 @@ RSpec.describe "(Where Are You From)less", type: :request do
 
           it do
             subject
-            expect(response).to have_http_status(:ok)
-            expect(response).to render_template(:show)
+            expect(response).to redirect_to(shib_login_path(epub_path(epub.id), params: entity_id))
           end
         end
 


### PR DESCRIPTION
To verify the fix:

1. Go Incognito and not on VPN or campus.
2. Go to https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/kk91fm31s?locale=en&entityID=https://registry.shibboleth.ox.ac.uk/idp - It will redirect as expected.
3. Go to https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/kk91fm31s?locale=en&entityID=https://shibboleth.umich.edu/idp/shibboleth - It will redirect as expected.  
4. Authenticate @ umich.edu
5. Go to https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/kk91fm31s?locale=en&entityID=https://registry.shibboleth.ox.ac.uk/idp - It will redirect as expected.