### PR TITLE
HELIO-4052 - Add an expand / full screen icon and event tracking to WebGL container

### DIFF
--- a/app/assets/javascripts/application/ga_event_tracking.js
+++ b/app/assets/javascripts/application/ga_event_tracking.js
@@ -232,6 +232,19 @@ $(document).on('turbolinks:load', function() {
     $("body").on('click', '.cozy-modal-contents ul li a', function(e) {
       press_tracker_event('e_reader', 'toc', this.href);
     });
+
+    // WebGL open and close
+    $("body").on('click', '.special-panel .panel-control button.webgl-close', function(e) {
+      press_tracker_event('e_reader', 'webgl', 'close');
+    });
+    $("body").on('click', 'button#webgl', function(e) {
+      press_tracker_event('e_reader', 'webgl', 'open');
+    });
+
+    // WebGL fullscreen mode
+    $("body").on('click', '.special-panel .panel-control a.webgl-fullscreen', function(e) {
+      press_tracker_event('e_reader', 'webgl', 'fullscreen');
+    });
   }
 
   function which_category() {

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -4114,10 +4114,11 @@ $gabii-link-hover:    #1e5667;
     .special-panel {
       overflow: auto;
 
-      .panel-control button.button--sm.webgl-close {
-      background: transparent;
-      color: #333;
-      padding: 2em;
+      .panel-control button.button--sm.webgl-close,
+      .panel-control a.button--sm.webgl-fullscreen {
+        background: transparent;
+        color: #333;
+        padding: 2em;
 
         &:hover,
         &:active,

--- a/app/views/e_pubs/_webgl_specific.html.erb
+++ b/app/views/e_pubs/_webgl_specific.html.erb
@@ -36,8 +36,8 @@
                 var $3d_title = "Gabii Area B 3D Model";
                 var $3d_doi = "https://doi.org/10.3998/mpub.9231782.model";
               } else {
-                var $3d_title = "Gabii Area A 3D Model";
-                var $3d_doi = "https://doi.org/10.3998/mpub.";
+                var $3d_title = "Gabii Area A/B 3D Model";
+                var $3d_doi = "https://doi.org/10.3998/mpub.11885571.cmp.webgl";
               }
             
             var $panelContent =
@@ -46,6 +46,7 @@
                   '<button class="button--sm webgl-close" data-toggle="button" data-slot="label" aria-label="Close 3-D Model" onclick="close_panel();">' +
                     '<i class="icon-x oi" data-glyph="x" aria-hidden="true"></i>' +
                   '</button>' +
+                  '<a class="button--sm webgl-fullscreen" href="'+$3d_doi+'" target="_blank"><i class="icon-fullscreen-enter oi" data-glyph="fullscreen-enter" aria-label="View 3D model in fullscreen standalone mode"></i></a>' +
                 '</div>' +
                 '<div id="unity-container" style="position:relative" tabindex="0">' +
                   '<canvas id="unity-canvas"></canvas>' +


### PR DESCRIPTION
Resolves HELIO-4052

Adds fullscreen mode/standalone link to webgl panel; 
Adds GA event tracking for open/close 3d model and 3d model fullscreen mode