### PR TITLE
HELIO-4106 - adjust text color for pagination buttons

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -4278,7 +4278,7 @@ $gabii-link-hover:    #1e5667;
   .pagination {
     @include lato;
      li a, li span {
-       color: $gabii-brand-color;
+       color: #fff;
      }
 
      .active>a,


### PR DESCRIPTION
Resolves HELIO-4106, part of hotfix 2.83.3 needing to be merged into master