### PR TITLE
don't show duration values only in milliseconds

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -146,7 +146,19 @@ module Hyrax
     end
 
     def duration
-      solr_document['duration_ssim']
+      duration = solr_document['duration_ssim']&.first
+      # return if duration is blank or "contains no non-digit characters" is false, which implies a millisecond...
+      # value, e.g. from MediaInfo
+      return solr_document['duration_ssim'] if duration.blank? || (duration !~ /\D/) == false
+
+      s, ms = duration.to_i.divmod(1000)
+      m, s = s.divmod(60)
+      h, m = m.divmod(60)
+
+      # don't show the millisecond part if it's zero
+      s = ms.zero? ? "#{h}:#{m}:#{s}" : "#{h}:#{m}:#{s}:#{ms}"
+      # Array() as it's expected elsewhere to be a multivalued field (the 'm' in '_ssim')
+      Array(s)
     end
 
     def original_name

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -715,4 +715,40 @@ RSpec.describe Hyrax::FileSetPresenter do
       it { is_expected.to eq "1537294708" }
     end
   end
+
+  describe "#duration" do
+    subject { presenter.duration }
+
+    let(:fileset_doc) { SolrDocument.new(id: 'fileset_id', has_model_ssim: ['FileSet'], duration_ssim: duration) }
+
+    context "pre-formatted '20.84 s' value is left as-is" do
+      let(:duration) { ["20.84 s"] }
+
+      it { is_expected.to eq duration }
+    end
+
+    context "pre-formatted 'HH:mm:ss' value is left as-is" do
+      let(:duration) { ["0:23:33"] }
+
+      it { is_expected.to eq duration }
+    end
+
+    context "pre-formatted 'HH:mm:ss.SSS' value is left as-is" do
+      let(:duration) { ["0:3:46:213"] }
+
+      it { is_expected.to eq duration }
+    end
+
+    context "numeric value is assumed to be milliseconds and converted, non-zero milliseconds value is shown" do
+      let(:duration) { ["98498"] }
+
+      it { is_expected.to eq ["0:1:38:498"] }
+    end
+
+    context "numeric value is assumed to be milliseconds and converted, zero milliseconds value is removed" do
+      let(:duration) { ["36700000"] }
+
+      it { is_expected.to eq ["10:11:40"] }
+    end
+  end
 end


### PR DESCRIPTION
HELIO-3422