### PR TITLE
HELIO-4105 fix sitemap paths

### DIFF
--- a/config/jekyll.yml
+++ b/config/jekyll.yml
@@ -18,7 +18,7 @@ encoding: "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 # Jekyll will delete everything under public for security reasons. We want to keep these symlinks into `shared/public/`
-keep_files: ["assets", "media", "packs", "sitemaps", "system", "upload", "robots.txt"]
+keep_files: ["assets", "media", "packs", "system", "upload", "robots.txt"]
 
 # Conversion
 markdown: kramdown

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -6,10 +6,6 @@ require 'sitemap_generator'
 # Set the host name for URL creation
 SitemapGenerator::Sitemap.default_host = "https://fulcrum.org"
 
-# we want these in the shared directory where they won't get blown away each time
-# see https://github.com/kjvarga/sitemap_generator#deployments--capistrano
-SitemapGenerator::Sitemap.public_path = 'public/sitemaps'
-
 # HELIO-3953 sitemaps should be uncompressed
 # HELIO-4105 sitemaps should be no larger than 5MB
 SitemapGenerator::Sitemap.create(compress: false, create_index: true, max_sitemap_links: 20_000) do


### PR DESCRIPTION
See notes in HELIO-4105, we're no longer "saving" sitemaps in shared/sitemaps (public/sitemaps) since they are re-generated on every deploy and have been for some time now. They will now all live directly in /pubic. robots.txt has been updated to reflect this on the production deploy.