### PR TITLE
height for A/V embeds with captions/descriptions

### DIFF
--- a/app/assets/stylesheets/embed/embed_styles.scss
+++ b/app/assets/stylesheets/embed/embed_styles.scss
@@ -173,10 +173,9 @@ figure:hover > div:nth-child(1), figure:active > div:nth-child(1) {
   }
 }
 
-// This should be outside the bounds of the visible "responsive" nested divs anyway, but hide it just to be sure...
-// until we decide on a way to show transcripts divs beside embedded videos in CSB, if we ever do that.
-// TODO: edit comment when working on https://tools.lib.umich.edu/jira/browse/HELIO-4167
-#video-transcript-container {
+// This should be outside the bounds of the visible "responsive" nested divs anyway, but hide it just to be sure.
+// If we run into problems we can remove it instead like we do for some Able Player preferences menu items.
+#video-hidden-transcript-container {
   display: none;
 }
 

--- a/app/presenters/concerns/embed_code_presenter.rb
+++ b/app/presenters/concerns/embed_code_presenter.rb
@@ -54,7 +54,7 @@ module EmbedCodePresenter
 
   def audio_embed_code
     # `height: 125px` allows for Able Player's controls. Both the controls and the audio-transcript-container div take up 375px of height, but the iframe should auto-adjust its height as required
-    "<iframe src='#{embed_link}' title='#{embed_code_title}' style='page-break-inside:avoid; -webkit-column-break-inside:avoid; break-inside:avoid; display:block; overflow:hidden; border-width:0; width:98%; max-width:98%; height:125px; margin:auto'></iframe>"
+    "<iframe src='#{embed_link}' title='#{embed_code_title}' style='page-break-inside:avoid; -webkit-column-break-inside:avoid; break-inside:avoid; display:block; overflow:hidden; border-width:0; width:98%; max-width:98%; height:#{audio_embed_height}px; margin:auto'></iframe>"
   end
 
   def embed_width
@@ -105,7 +105,13 @@ module EmbedCodePresenter
   end
 
   # The Able Player "interactive transcript" div will only be present if our `closed_captions` field is set
+  # this method is only used to allow height for the volume bar, it's used in the parent partial,...
+  # app/views/hyrax/file_sets/_media_embedded.html.erb, which is not audio-specific
   def audio_without_closed_captions?
     audio? && closed_captions.blank?
+  end
+
+  def audio_embed_height
+    closed_captions.present? ? 300 : 125
   end
 end

--- a/app/views/hyrax/file_sets/media_display_embedded/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display_embedded/_video.html.erb
@@ -15,10 +15,11 @@
        width="8000px" <%# https://tools.lib.umich.edu/jira/browse/HELIO-746?focusedCommentId=1074044&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1074044 %>
        data-able-player
        data-skin="2020"
+       data-captions-position="overlay" <%# Does not have the desired effect if the user has set a "Below video" caption position preference. Hence `checkElement()` fiddling below. %>
        data-include-transcript="false"
        data-allow-fullscreen="false"
        poster="<%= hyrax.download_path(file_set.id, file: 'jpeg') %>"
-       <%= raw file_set.closed_captions.present? ? 'data-transcript-div="video-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
+       <%= raw file_set.closed_captions.present? ? 'data-transcript-div="video-hidden-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
   <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
   <% if file_set.closed_captions.present? %><%# kind="subtitles" not "captions" due to https://github.com/mlibrary/heliotrope/issues/1234 %>
     <track kind="subtitles" src="<%= hyrax.download_path(file_set.id, file: 'captions_vtt') %>" srclang="en" label="English"  />
@@ -31,42 +32,50 @@
 <% if file_set.closed_captions.present? %>
   <%# There's no way to show this right now, due to the restrictive "responsive" nested divs on the iframe, nor is... %>
   <%# there a way to turn the interactive transcript off (without hacks). So keep it below the embedded iframe window. %>
-  <%# The extra room in the form of "percentage height" will need to be accounted for in EmbedCodeService at... %>
-  <%# unpack time, if we want to show it, but might be too much space to take up in two-column view. %>
-  <%# TODO: edit comment when working on https://tools.lib.umich.edu/jira/browse/HELIO-4167 %>
-  <div id="video-transcript-container"></div>
+  <div id="video-hidden-transcript-container"></div>
 <% end %>
 
 <script>
-  var timer;
+  // https://stackoverflow.com/a/53269990
+  const checkElement = async selector => {
+    while (!$(selector).length) {
+      await new Promise( resolve =>  requestAnimationFrame(resolve) )
+    }
+    return selector;
+  };
 
   $(document).ready(function() {
-    clearTimeout (timer);
-    // it can take up to a couple of seconds for Able Player's menus to be built
-    timer = setTimeout(hideTranscriptPreferencesOption, 2000);
+    // wait for each of these selectors to be present, then fiddle with them to constrain Able Player features for...
+    // embedding in the iframe
+    checkElement('.able-captions-wrapper').then((selector) => {
+      $(selector).removeClass('able-captions-below');
+      $(selector).addClass('able-captions-overlay');
+      $(selector).css({ "font-size":"100%", "background-color": "transparent", "opacity": "" });
+    });
+
+    // With these two embed-unsuitable preferences menu items, removal is better than hiding and having to mess with...
+    // classes. This way Able Player can still manage a11y items like active status, class='able-focus' and tabIndex...
+    // on the remaining menu items, facilitating tab navigation and active styles.
+    checkElement("#video-prefs-menu li:contains('Captions')").then((selector) => {
+      $(selector).remove();
+    });
+
+    checkElement("#video-prefs-menu li:contains('Transcript')").then((selector) => {
+      $(selector).remove();
+    });
+
     setupVideoAnalytics();
   });
 
   function setupVideoAnalytics() {
     if (typeof(ga) == typeof(Function)) {
-      var video = $('#video').get(0)
+      var video = $('#video').get(0);
       video.addEventListener("play", function() {
         press_tracker_event('e_reader', 'play_video', window.location.href);
       });
       video.addEventListener("pause", function() {
         press_tracker_event('e_reader', 'stop_video', window.location.href);
       });
-    }
-  }
-
-  <%# TODO: maybe remove this, depending on the outcome of https://tools.lib.umich.edu/jira/browse/HELIO-4167 %>
-  function hideTranscriptPreferencesOption() {
-    var ul = document.getElementById("video-prefs-menu");
-    var items = ul.getElementsByTagName("li");
-    for (var i = 0; i < items.length; ++i) {
-      if(items[i].innerText == "Transcript") {
-        items[i].style.display = 'none';
-      }
     }
   }
 

--- a/spec/presenters/concerns/embed_code_presenter_spec.rb
+++ b/spec/presenters/concerns/embed_code_presenter_spec.rb
@@ -163,8 +163,11 @@ RSpec.describe EmbedCodePresenter do
         </div>
       END
     }
-    let(:audio_embed_code) {
+    let(:audio_embed_code_without_transcript) {
       "<iframe src='#{presenter.embed_link}' title='#{presenter.embed_code_title}' style='page-break-inside:avoid; -webkit-column-break-inside:avoid; break-inside:avoid; display:block; overflow:hidden; border-width:0; width:98%; max-width:98%; height:125px; margin:auto'></iframe>"
+    }
+    let(:audio_embed_code_with_transcript) {
+      "<iframe src='#{presenter.embed_link}' title='#{presenter.embed_code_title}' style='page-break-inside:avoid; -webkit-column-break-inside:avoid; break-inside:avoid; display:block; overflow:hidden; border-width:0; width:98%; max-width:98%; height:300px; margin:auto'></iframe>"
     }
     let(:file_set_doc) { SolrDocument.new(id: 'fileset_id', has_model_ssim: ['FileSet'], mime_type_ssi: mime_type, resource_type_tesim: [resource_type], closed_captions_tesim: closed_captions) }
     let(:mime_type) { nil }
@@ -250,13 +253,13 @@ RSpec.describe EmbedCodePresenter do
       let(:mime_type) { 'audio/mp3' }
 
       context 'no closed_captions present' do
-        it { expect(presenter.embed_code).to eq audio_embed_code }
+        it { expect(presenter.embed_code).to eq audio_embed_code_without_transcript }
       end
 
       context 'closed_captions present' do
         let(:closed_captions) { ['STUFF'] }
 
-        it { expect(presenter.embed_code).to eq audio_embed_code }
+        it { expect(presenter.embed_code).to eq audio_embed_code_with_transcript }
       end
     end
 


### PR DESCRIPTION
HELIO-4167
PR number two for this issue (it had a previous hotfix v.2.87.1)
1) height is 300px for embedded captioned audio
2) always overlay embedded video captions