### PR TITLE
HELIO-3620 Handle Permission Bug Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,11 +101,19 @@ gem 'config'
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7'
 
-gem 'faraday', '~> 0.17.3'
+# Bundler could not find compatible versions for gem "faraday":
+#   In Gemfile:
+#     faraday (~> 2)
+#
+#     hyrax (= 2.9.5) was resolved to 2.9.5, which depends on
+#       signet was resolved to 0.12.0, which depends on
+#         faraday (~> 0.9)
+gem 'faraday', '~> 0.9'
+# NOTE: This is the last minor release in the v0.x series, next release will be 1.0 to match Faraday v1.0 release and from then on only fixes will be applied to v0.14.x!
 gem 'faraday_middleware', '~> 0.14.0'
-
-# Use gem version of handle_rest
-gem 'handle_rest', git: 'https://github.com/mlibrary/handle_rest', ref: '944fa06a119072f060d986862c34dea7215ebd29'
+#
+# # Use gem version of handle_rest
+gem 'handle_rest', git: 'https://github.com/mlibrary/handle_rest', ref: '483cf71257d96c7f27ab1d40ef067f48ee37f8a5'
 
 gem 'hyrax', '2.9.5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/mlibrary/handle_rest
-  revision: 944fa06a119072f060d986862c34dea7215ebd29
-  ref: 944fa06a119072f060d986862c34dea7215ebd29
+  revision: 483cf71257d96c7f27ab1d40ef067f48ee37f8a5
+  ref: 483cf71257d96c7f27ab1d40ef067f48ee37f8a5
   specs:
-    handle_rest (0.0.1)
-      faraday
+    handle_rest (0.0.2)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.14.0)
 
 GIT
   remote: https://github.com/mlibrary/irus_analytics
@@ -658,6 +659,8 @@ GEM
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-linux)
+      racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     oai (1.1.0)
@@ -1108,6 +1111,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
@@ -1129,7 +1133,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   faker
-  faraday (~> 0.17.3)
+  faraday (~> 0.9)
   faraday_middleware (~> 0.14.0)
   fcrepo_wrapper (= 0.5.2)
   handle_rest!

--- a/app/services/aptrust/service.rb
+++ b/app/services/aptrust/service.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'faraday_middleware'
-require 'json'
-
 module Aptrust
   class Service
     def ingest_status(identifier) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/services/restful_fedora/service.rb
+++ b/app/services/restful_fedora/service.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'faraday_middleware'
-require 'json'
-
 module RestfulFedora
   class Service
     def contains

--- a/app/services/restful_solr/service.rb
+++ b/app/services/restful_solr/service.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'faraday_middleware'
-require 'json'
-
 module RestfulSolr
   class Service
     def contains

--- a/app/services/turnsole/service.rb
+++ b/app/services/turnsole/service.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'faraday_middleware'
-require 'json'
-
 module Turnsole
   class Service
     #

--- a/lib/e_pub/bridge_to_webgl.rb
+++ b/lib/e_pub/bridge_to_webgl.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module EPub
   class BridgeToWebgl
     @mapping = []

--- a/spec/controllers/e_pubs_controller_spec.rb
+++ b/spec/controllers/e_pubs_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'json'
 
 RSpec.describe EPubsController, type: :controller do
   it { is_expected.to be_a_kind_of(CheckpointController) }


### PR DESCRIPTION
Upgrade to new Handle_Rest gem and changes to HandleNet module to use new gem and create handles with admin value lines.

Going forward this should create url handles that are modifiable and deletable.  Previously made url handles will still be un-modifiable and un-deletable.

Once verified in production the admin value lines will have to be added to all the previously made url handles.  This would be most easily be done by executing an SQL script against the handle database directly by someone in A&E.