### PR TITLE
remove sourceMappingURL lines

### DIFF
--- a/fulcrum/mozilla-pdf-viewer/build/pdf.js
+++ b/fulcrum/mozilla-pdf-viewer/build/pdf.js
@@ -15519,7 +15519,7 @@ class PDFFetchStreamRangeReader {
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __w_pdfjs_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -15533,14 +15533,14 @@ class PDFFetchStreamRangeReader {
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __w_pdfjs_require__);
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
@@ -15803,4 +15803,3 @@ const pdfjsBuild = '399a0ec60';
 /******/ })()
 ;
 });
-//# sourceMappingURL=pdf.js.map

--- a/fulcrum/mozilla-pdf-viewer/build/pdf.sandbox.js
+++ b/fulcrum/mozilla-pdf-viewer/build/pdf.sandbox.js
@@ -175,7 +175,7 @@ class SandboxSupportBase {
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __w_pdfjs_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -189,14 +189,14 @@ class SandboxSupportBase {
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __w_pdfjs_require__);
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
@@ -306,4 +306,3 @@ function QuickJSSandbox() {
 /******/ })()
 ;
 });
-//# sourceMappingURL=pdf.sandbox.js.map

--- a/fulcrum/mozilla-pdf-viewer/build/pdf.worker.js
+++ b/fulcrum/mozilla-pdf-viewer/build/pdf.worker.js
@@ -73747,7 +73747,7 @@ class PDFWorkerStreamRangeReader {
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __w_pdfjs_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -73761,14 +73761,14 @@ class PDFWorkerStreamRangeReader {
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __w_pdfjs_require__);
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
@@ -73781,12 +73781,12 @@ class PDFWorkerStreamRangeReader {
 /******/ 			}
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__w_pdfjs_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
@@ -73797,7 +73797,7 @@ class PDFWorkerStreamRangeReader {
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
@@ -73825,4 +73825,3 @@ const pdfjsBuild = '399a0ec60';
 /******/ })()
 ;
 });
-//# sourceMappingURL=pdf.worker.js.map

--- a/fulcrum/mozilla-pdf-viewer/web/viewer.js
+++ b/fulcrum/mozilla-pdf-viewer/web/viewer.js
@@ -15820,4 +15820,3 @@ if (document.readyState === "interactive" || document.readyState === "complete")
 
 /******/ })()
 ;
-//# sourceMappingURL=viewer.js.map


### PR DESCRIPTION
Small follow-up to pdf.js upgrade, just to stop the browser looking for non-existent map files.
Whether we begin minimizing our pdf.js and associated files is a discussion for another time.