### PR TITLE
HELIO-4268 stop sqlite3 warnings: rb_check_safe_obj will be removed i…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1028,7 +1028,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     ssrf_filter (1.0.7)
     sxp (1.1.0)
       rdf (~> 3.1)


### PR DESCRIPTION
…n Ruby 3.0