### PR TITLE
use force_encoding("UTF-8") on original_name

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -41,7 +41,11 @@ class CharacterizeJob < ApplicationJob
       # actual file has changed, change the mod timestamp on the FileSet object (for APTrust bagging etc)
       file_set.date_modified = Hyrax::TimeService.time_in_utc
     end
-    file_set.title = [file_set.characterization_proxy.original_name] if reset_title
+
+    # set title to label if that's how it was before this characterization
+    # for the encoding issue see https://tools.lib.umich.edu/jira/browse/HELIO-4226 (and Hyrax #5670 and #5671)
+    file_set.title = [file_set.characterization_proxy.original_name.force_encoding("UTF-8")] if reset_title
+
     file_set.label = file_set.characterization_proxy.original_name
     # save will do this now that we're updating the FileSet
     # file_set.update_index

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -6,9 +6,17 @@ require 'fakefs/spec_helpers'
 # Since we lifted this out of CC 1.6.2, we'll need to run the tests too
 
 describe CharacterizeJob do
-  let(:file_set) { FileSet.new(id: file_set_id, title: ['previous_file.jpg'], label: 'previous_file.jpg', date_modified: 'previous_mod_date', resource_type: [resource_type]) }
+  # let(:file_set) { FileSet.new(id: file_set_id, title: ['previous_file.jpg'], label: 'previous_file.jpg', date_modified: 'old_mod_date', resource_type: [resource_type]) }
   let(:resource_type) { 'resource_type' }
   let(:file_set_id) { 'abc12345' }
+  let(:label) { 'previous_file.jpg' }
+  let(:title) { ['My User-Entered Title'] }
+  let(:file_set) do
+    FileSet.new(id: file_set_id, title: title, label: label, date_modified: 'old_mod_date', resource_type: [resource_type]).tap do |fs|
+      allow(fs).to receive(:original_file).and_return(file)
+      allow(fs).to receive(:update_index)
+    end
+  end
   let(:file_path)   { Rails.root + 'tmp' + 'uploads' + 'ab' + 'c1' + '23' + '45' + 'abc12345' + 'picture.png' }
   let(:filename)    { file_path.to_s }
   let(:file) do
@@ -63,27 +71,6 @@ describe CharacterizeJob do
     it "reindexes the collection" do
       expect(collection).to receive(:update_index)
       described_class.perform_now(file_set, file.id)
-    end
-  end
-
-  context "FileSet with unwanted, preexisting characterization metadata getting new version" do
-    it "resets the height and width" do
-      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      expect(file).to receive(:save!)
-      expect(file_set).to receive(:update_index)
-      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-      allow(file_set).to receive(:original_checksum).and_return(['qwerty789'])
-      allow(Hyrax::TimeService).to receive(:time_in_utc).and_return('Tue, 10 Apr 2019 20:20:20 +0000')
-      described_class.perform_now(file_set, file.id)
-
-      expect(file_set.original_file.height).to eq []
-      expect(file_set.original_file.width).to eq []
-      expect(file_set.original_file.original_checksum).to eq []
-      expect(file_set.original_file.file_size).to eq []
-      expect(file_set.original_file.format_label).to eq []
-      expect(file_set.label).to eq 'picture.png'
-      expect(file_set.title).to eq ['picture.png']
-      expect(file_set.date_modified).to eq 'Tue, 10 Apr 2019 20:20:20 +0000'
     end
   end
 
@@ -183,6 +170,120 @@ describe CharacterizeJob do
           else
             expect(UnpackJob).not_to have_received(:perform_later).with(file_set.id, resource_type)
           end
+        end
+      end
+    end
+  end
+
+  context 'FileSet with preexisting characterization metadata getting a new version' do
+    before do
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    end
+
+    it 'resets height, width, checksum, file_size and format_label' do
+      expect(file).to receive(:save!)
+      expect(file_set).to receive(:update_index)
+      described_class.perform_now(file_set, file.id)
+
+      expect(file_set.characterization_proxy.height).to eq []
+      expect(file_set.original_file.width).to eq []
+      expect(file_set.original_file.original_checksum).to eq []
+      expect(file_set.original_file.file_size).to eq []
+      expect(file_set.original_file.format_label).to eq []
+      expect(file_set.label).to eq 'picture.png'
+    end
+
+    describe 'title and label' do
+      before do
+        allow(file_set).to receive(:characterization_proxy).and_call_original
+      end
+
+      context 'title and label were previously the same' do
+        let(:title) { ['old_filename.jpg'] }
+        let(:label) { 'old_filename.jpg' }
+
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_name)
+                                 .and_return(String.new('new_filename.jpg', encoding: 'ASCII-8BIT')) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'sets title to label' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.title).to eq ['new_filename.jpg']
+          expect(file_set.label).to eq 'new_filename.jpg'
+        end
+
+        # see https://tools.lib.umich.edu/jira/browse/HELIO-4226 (and Hyrax #5670 and #5671)
+        context 'original_name, which is ASCII-8BIT, contains non-ASCII characters' do
+          before do
+            allow(file_set).to receive_message_chain(:characterization_proxy, :original_name)
+                                   .and_return(String.new('ファイル.txt', encoding: 'ASCII-8BIT')) # rubocop:disable RSpec/MessageChain
+          end
+
+          it 'does not raise an error, and still sets title to label' do
+            expect(file).to receive(:save!)
+            expect(file_set).to receive(:update_index)
+            expect { described_class.perform_now(file_set, file.id) }
+                .not_to raise_error(Encoding::UndefinedConversionError, '"\xE3" from ASCII-8BIT to UTF-8')
+            expect(file_set.title).to eq ['ファイル.txt']
+            expect(file_set.label).to eq 'ファイル.txt'
+          end
+        end
+      end
+
+      context 'title and label were not previously the same' do
+        let(:title) { ['My User-Entered Title'] }
+        let(:label) { 'old_filename.jpg' }
+
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_name)
+                                 .and_return(String.new('new_filename.jpg', encoding: 'ASCII-8BIT')) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'assumes a user-entered title value and leaves title as-is' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.title).to eq ['My User-Entered Title']
+          expect(file_set.label).to eq 'new_filename.jpg'
+        end
+      end
+    end
+
+    describe 'date_modified' do
+      before do
+        allow(file_set).to receive(:characterization_proxy).and_call_original
+        allow(Hyrax::TimeService).to receive(:time_in_utc).and_return('new_mod_date')
+      end
+
+      context 'the new checksum is the same as the previous one' do
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_checksum).and_return(['old_checksum']) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'leaves it as-is' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+        end
+      end
+
+      context 'the new checksum is not the same as the previous one' do
+        before do
+          allow(file_set).to receive_message_chain(:characterization_proxy, :original_checksum).and_return(['old_checksum'], ['new_checksum']) # rubocop:disable RSpec/MessageChain
+        end
+
+        it 'sets it to now()' do
+          expect(file).to receive(:save!)
+          expect(file_set).to receive(:update_index)
+          expect(file_set.date_modified).to eq 'old_mod_date'
+          described_class.perform_now(file_set, file.id)
+          expect(file_set.date_modified).to eq 'new_mod_date'
         end
       end
     end


### PR DESCRIPTION
@sethaj The tiny change and relevant spec change are more easily seen [here](https://github.com/samvera/hyrax/pull/5673).
The relevant tests in Hyrax (which I wrote a few months ago) were unceremoniously dumped into CharacterizeJobSpec in heliotrope with this branch's change also in the same commit.