### PR TITLE
HELIO-4330 - Update Notes Panel Content

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -1860,6 +1860,14 @@ footer.press {
       transition: background 0.1s cubic-bezier(.33,.66,.66,1);
     }
 
+    main#modal-notes-content section#historical_characters section.Heading2 h5 button {
+      display: inline-block;
+    }
+
+    main#modal-notes-content section#historical_characters section.Heading2 h5 button svg {
+      float: right;
+    }
+
 
 .cozy-container i[class^='icon-'] {
     font-size: 2rem !important;

--- a/app/views/epub_ebooks/_cozy_controls_notes.html.erb
+++ b/app/views/epub_ebooks/_cozy_controls_notes.html.erb
@@ -251,7 +251,7 @@
         // with the SVG plus/minus icon
         character.innerHTML = `
           <button aria-expanded="false">
-            ${character.textContent}
+            ${character.innerHTML}
             <svg aria-hidden="true" focusable="false" viewBox="0 0 10 10">
               <rect class="vert" height="8" width="2" y="1" x="4"/>
               <rect height="2" width="8" y="4" x="1"/>

--- a/app/views/epub_ebooks/_cozy_pdec_notes.html.erb
+++ b/app/views/epub_ebooks/_cozy_pdec_notes.html.erb
@@ -11,7 +11,7 @@
                             epub:type="endnotes" data-note-section="definitions">
                             <h4>Definitions</h4>
                             <p class="intro">(F) = <i>Dictionnaire universel</i> de Furetière</p>
-                            <p class="intro">(AF) = la définition provient de <i>l’Académie Française</i></p>
+                            <p class="intro">(AF) = <i>Dictionnaire de l’Académie française</i></p>
                             <p class="intro">(L) = Dictionnaire Larousse</p>
                             <p class="intro">Quand il n’y a pas d’attribution, la définition n’est pas tirée d’un des dictionnaires et
                                 il s’agit d’une définition formulée par les auteurs de la présente édition.</p>
@@ -2434,7 +2434,7 @@
                         </div>
                     </section>
                     <section class="Heading2" id="hc_26">
-                        <h5>Empereur, Charles Quint (Charles V, Holy Roman Emperor)</h5>
+                        <h5>L'empereur, Charles Quint (Charles V, Holy Roman Emperor)</h5>
                         <p>(1500-1558)</p>
                         <figure class="Resource" id="Figure_HC_36"><!-- Resource Figure_HC_36.jpg -->
                                 <%= image_tag "pdec/Figure_HC_36.jpg", class: 'historical-char-img', id: 'Image_Figure_HC_36', alt: 'Figure_HC_36.jpg', height: 'auto', width: '90%' %>
@@ -2569,7 +2569,7 @@
                         </div>
                     </section>
                     <section class="Heading2" id="hc_30">
-                        <h5>Philippe II (King of Spain) </h5>
+                        <h5>Philippe II (Philip II, King of Spain)</h5>
                         <p>(1527-1598) </p>
                         <figure class="Resource" id="Figure_HC_42"><!-- Resource Figure_HC_42.jpg -->
                                 <%= image_tag "pdec/Figure_HC_42.jpg", class: 'historical-char-img', id: 'Image_Figure_HC_42', alt: 'Figure_HC_42.jpg', height: 'auto', width: '90%' %>
@@ -2726,7 +2726,7 @@
                         </div>
                     </section>
                     <section class="Heading2" id="hc_34">
-                        <h5>Elizabeth I (Queen of England)</h5>
+                        <h5>La reine Élisabeth (Elizabeth I, Queen of England)</h5>
                         <p>(1533-1603) </p>
                         <figure class="Resource" id="Figure_HC_47"><!-- Resource Figure_HC_47.jpg -->
                                 <%= image_tag "pdec/Figure_HC_47.jpg", class: 'historical-char-img', id: 'Image_Figure_HC_47', alt: 'Figure_HC_47.jpg', height: 'auto', width: '90%' %>
@@ -3305,7 +3305,7 @@
                                         >Image information</a></p></figcaption></figure>
                     </section>
                     <section class="Heading2" id="hc_53">
-                        <h5>Anne Boleyn </h5>
+                        <h5>Anne de Boulen (Anne Boleyn)</h5>
                         <p>(1501-1536)</p>
                         <div id="hc_53_desc">
                             <div id="hc_53_desc_en" lang="en">
@@ -3425,7 +3425,7 @@
                         </div>
                     </section>
                     <section class="Heading2" id="hc_57">
-                        <h5>Le comte de Montgomery</h5>
+                        <h5>Comte de Montgomery</h5>
                         <p>(1530-1574)</p>
                         <figure class="Resource" id="Figure_HC_69"><!-- Resource Figure_HC_69.jpg -->
                                 <%= image_tag "pdec/Figure_HC_69.jpg", class: 'historical-char-img', id: 'Image_Figure_HC_69', alt: 'Figure_HC_69.jpg', height: 'auto', width: '90%' %>


### PR DESCRIPTION
Resolves HELIO-4330, a sub-task of HELIO-3803.

Update historical character names that contain superscript (JS use of `textContent` was dropping formatting); adjust display of names with superscript; correct historical character names based on author input; and adjust definitions legend based on author input