### PR TITLE
HELIO-4345 monographs with more than 200 file_sets need to be deleted

### DIFF
--- a/app/views/hyrax/monographs/_show_actions.html.erb
+++ b/app/views/hyrax/monographs/_show_actions.html.erb
@@ -4,7 +4,10 @@
   <% end %>
   <% if presenter.editor? %>
     <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-    <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+    <% if presenter.member_presenters.size < 200 %>
+      <%# HELIO-4345 only developers should delete large monographs %>
+      <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+    <% end %>
     <% if presenter.member_presenters.size.positive? %>
       <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
     <% end %>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -1,0 +1,49 @@
+<% ul_id = 'admin-set-action-dropdown-ul-' + document.id %>
+
+<div class="btn-group">
+
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+    <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
+    <%= t("hyrax.dashboard.my.action.select") %>
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <% if can? :edit, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to [main_app, :edit, document],
+                    id: 'action-edit-work' do %>
+          <%= t("hyrax.dashboard.my.action.edit_work") %>
+        <% end %>
+      </li>
+
+      <% if document.member_ids.count < 200 %>
+      <%# HELIO-4345 %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to [main_app, document],
+                      method: :delete,
+                      id: 'action-delete-work',
+                      data: {
+                        confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+            <%= t("hyrax.dashboard.my.action.delete_work") %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+
+    <li role="menuitem" tabindex="-1">
+      <%= display_trophy_link(current_user, document.id) do |text| %>
+        <%= text %>
+      <% end %>
+    </li>
+
+    <% if can? :transfer, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
+          <%= t("hyrax.dashboard.my.action.transfer") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
by developers on the backend, so hide delete buttons in the UI for large monographs.