### PR TITLE
bad has_model_ssim check breaks Monograph handles

### DIFF
--- a/app/jobs/handle_job.rb
+++ b/app/jobs/handle_job.rb
@@ -107,7 +107,7 @@ class HandleJob < ApplicationJob
 
     handles = {}
     docs.each do |doc|
-      handles[HandleNet::FULCRUM_HANDLE_PREFIX + doc['id']] = if doc['has_model_ssim'] == 'Monograph'
+      handles[HandleNet::FULCRUM_HANDLE_PREFIX + doc['id']] = if doc['has_model_ssim']&.first == 'Monograph' # NB: `has_model_ssim` cardinality!
                                                                 Rails.application.routes.url_helpers.hyrax_monograph_url(doc['id'])
                                                               else
                                                                 Rails.application.routes.url_helpers.hyrax_file_set_url(doc['id'])


### PR DESCRIPTION
Hotfix relating to HELIO-4327. Currently running in production as [release 3.6.1](https://github.com/mlibrary/heliotrope/releases/tag/3.6.1).
Monograph handles fix was successful using this change.
