### PR TITLE
HELIO-3767 - Style Belin

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -6543,6 +6543,7 @@ $a2ru-white: #fafafa;
 //
 // Michigan Publishing Services
 // Frankel Institute Annual
+// Belin Lecture Series (belin)
 //
 ///////////////////////////////////////////////
 // colors
@@ -6576,7 +6577,7 @@ $fia-teal-100: #e9f2f5;
 }
 
 
-.fia {
+.fia, .belin {
 
   // svgicon
   #documents {


### PR DESCRIPTION
Resolves HELIO-3767

Belin to use same styles as FIA to maintain branding continuity between the two collections, which are part of the Frankel Institute.