### PR TITLE
HELIO-4187 - Gabii User Survey

### DIFF
--- a/app/assets/javascripts/application_survey.js
+++ b/app/assets/javascripts/application_survey.js
@@ -25,7 +25,13 @@ function displayModalSurvey() {
 // cookie surveyStatus = 'ignore' or 'clicked'
 function displayNonModalSurvey() {
   var surveyStatus = Cookies.get('survey');
+  var gabiiSurveyStatus = Cookies.get('survey_gabii');
   if (( surveyStatus == 'ignore') || (surveyStatus == 'clicked')) {
+    $('div.alert.survey').hide();
+  } else {
+    $('div.alert.survey').show();
+  }
+  if (( gabiiSurveyStatus == 'ignore') || (gabiiSurveyStatus == 'clicked')) {
     $('div.alert.survey').hide();
   } else {
     $('div.alert.survey').show();

--- a/app/views/e_pubs/show.html.erb
+++ b/app/views/e_pubs/show.html.erb
@@ -62,7 +62,11 @@
     <span class="Z3988" title="<%= @presenter.file_set_coins_title %>" aria-hidden="true"></span>
   <% end %>
   <% if @parent_presenter.open_access? || @parent_presenter.access_level(@actor_product_ids, @allow_read_product_ids).level == :free %>
-    <%= render 'shared/survey_nonmodal' %>
+    <% if @parent_presenter.webgl?%>
+      <%= render 'shared/survey_nonmodal_gabii' %>
+    <% else %>
+      <%= render 'shared/survey_nonmodal' %>
+    <% end %>
   <% end %>
   <div class="skip"></div>
   <%= tag.div id: 'epub', class: press_presenter.present? ? press_presenter.press_subdomains : '' do %>

--- a/app/views/shared/_survey_nonmodal_gabii.erb
+++ b/app/views/shared/_survey_nonmodal_gabii.erb
@@ -1,0 +1,28 @@
+<!-- survey -->
+<% presenter = @presenter %>
+<div id="surveyNonModal" class="alert survey fade in" role="alert" aria-labelledby="surveyNonModalLabel" style="display:none;">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="surveyNonModalLabel">Share your feedback on Gabii Project Reports</h4>
+      </div>
+      <div class="modal-body">
+        <p>University of Michigan needs your feedback to better understand how readers are using enhanced digital publications like the Gabii Project Report Volumes. You can help by taking a short, privacy-friendly survey.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary btn-lg" data-dismiss="alert" onclick="survey_button_yes()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="open_survey">Yes, I can help</button>
+        <button type="button" class="btn btn-default btn-lg" data-dismiss="alert" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey">No thanks</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+  function survey_button_yes(){
+    Cookies.set('survey_gabii', 'clicked', { expires: 365<%= ', secure: true' if Rails.env == 'production' %> });
+    window.open("https://umich.qualtrics.com/jfe/form/SV_cUxW1oqMCHTHwii", "_blank");
+  }
+  function survey_button_no(){
+    Cookies.set('survey_gabii', 'ignore', { expires: 180<%= ', secure: true' if Rails.env == 'production' %> });
+  }
+</script>


### PR DESCRIPTION
Resolves HELIO-4187

- Adds a gabii specific user survey for readers of either Gabii Volume 1 or 2.
- Repurposes JS code and styling for the OA survey.
- Works in the same way, but only displays on Gabii publications.
- Stores a `survey_gabii` cookie to regulate display of the modal window (if clicked, doesn't display, if not, continues to display).