### PR TITLE
serve one test pdf_ebook with browser caching

### DIFF
--- a/app/controllers/e_pubs_controller.rb
+++ b/app/controllers/e_pubs_controller.rb
@@ -65,7 +65,8 @@ class EPubsController < CheckpointController
       pdf = UnpackService.root_path_from_noid(@noid, 'pdf_ebook') + ".pdf"
       if File.exist? pdf
         # HELIO-4444 never cache 206 Range requests as it makes Chromium browsers act weird over EZproxy
-        response.headers['Cache-Control'] = 'no-cache, no-store' if request.headers['Range'].present?
+        # The NOID part of the conditional is to allow the OCLC folks to continue their testing (HELIO-4448)
+        response.headers['Cache-Control'] = 'no-cache, no-store' if request.headers['Range'].present? && @noid != 'kw52jb973'
         response.headers['Accept-Ranges'] = 'bytes'
 
         pdf.gsub!(/releases\/\d+/, "current")


### PR DESCRIPTION
HELIO-4448
there will likely be another PR against this ticket at some future point to remove this change, which is purely to assist OCLC in diagnosing EZproxy causing issues with Chrome/Chromium 206 range request caching