### PR TITLE
HELIO-4467 don't parse pdfs on the fly if the toc is cached

### DIFF
--- a/app/presenters/concerns/featured_representatives/monograph_presenter.rb
+++ b/app/presenters/concerns/featured_representatives/monograph_presenter.rb
@@ -171,7 +171,7 @@ module FeaturedRepresentatives
 
     instrument_method
     def pdf_ebook_presenter
-      @pdf_ebook_presenter ||= PDFEbookPresenter.new(PDFEbook::Publication.from_path_id(UnpackService.root_path_from_noid(pdf_ebook_id, 'pdf_ebook') + ".pdf", pdf_ebook_id))
+      @pdf_ebook_presenter ||= PDFEbookPresenter.new(pdf_ebook_id)
     end
 
     def mobi?

--- a/app/presenters/pdf_ebook_presenter.rb
+++ b/app/presenters/pdf_ebook_presenter.rb
@@ -1,15 +1,24 @@
 # frozen_string_literal: true
 
 class PDFEbookPresenter < ApplicationPresenter
+  attr_reader :id
   include Skylight::Helpers
 
   instrument_method
-  def initialize(pdf_ebook)
-    @pdf_ebook = pdf_ebook
+  def initialize(id)
+    @id = id
+    @cached = EbookTableOfContentsCache.find_by(noid: @id)
+    load_pdf if @cached.blank?
   end
 
-  def id
-    @pdf_ebook.id
+  instrument_method
+  def load_pdf
+    # HELIO-4467
+    # Parsing the entire pdf can be very expensive so don't do it unless we need it
+    # We shouldn't ever need it in this presenter, but there are times when a pdf doesn't have a cached ToC
+    # It's really considered an error, but not really worth giving users a 500
+    Rails.logger.error("[FIXME ERROR PDFEbookPresenter: EbookTableOfContentsCache] No Cached TOC for #{@id}")
+    @pdf_ebook ||= PDFEbook::Publication.from_path_id(UnpackService.root_path_from_noid(@id, 'pdf_ebook') + ".pdf", @id)
   end
 
   def multi_rendition?
@@ -18,18 +27,17 @@ class PDFEbookPresenter < ApplicationPresenter
 
   instrument_method
   def intervals?
-    return true if EbookTableOfContentsCache.find_by(noid: @pdf_ebook.id).present?
+    return true if @cached.present?
     @pdf_ebook&.intervals&.count&.positive?
   end
 
   instrument_method
   def intervals
     @intervals ||= begin
-      record = EbookTableOfContentsCache.find_by(noid: @pdf_ebook.id)
+      record = @cached
       if record.present?
         JSON.parse(record.toc).map { |i| EBookIntervalPresenter.new(i.symbolize_keys) }
       else
-        Rails.logger.error("[FIXME ERROR PDFEbookPresenter: EbookTableOfContentsCache] No Cached TOC for #{@pdf_ebook.id}")
         @pdf_ebook.intervals.map { |interval| RemoveMeEPubIntervalPresenter.new(interval) }
       end
     end

--- a/spec/presenters/pdf_ebook_presenter_spec.rb
+++ b/spec/presenters/pdf_ebook_presenter_spec.rb
@@ -3,34 +3,44 @@
 require 'rails_helper'
 
 RSpec.describe PDFEbookPresenter do
-  subject(:presenter) { described_class.new(pdf_ebook) }
+  subject(:presenter) { described_class.new(id) }
 
-  let(:pdf_ebook) { instance_double(PDFEbook::Publication, 'pdf_ebook', id: 'id', intervals: intervals) }
-  let(:intervals) { [] }
+  let(:id) { '999999999' }
 
   describe '#id' do
-    subject { presenter.id }
-
-    it { is_expected.to eq(pdf_ebook.id) }
+    it "returns the id" do
+      expect(described_class.new(id).id).to eq id
+    end
   end
 
   describe '#multi_rendition?' do
-    subject { presenter.multi_rendition? }
-
-    it { is_expected.to be false }
+    it "always returns false, pdfs don't have multiple renditions" do
+      expect(described_class.new(id).multi_rendition?).to be false
+    end
   end
 
   describe '#intervals?' do
     context "with a valid/not broken pdf" do
-      subject { presenter.intervals? }
+      context "with a EbookTableOfContentsCache cache" do
+        before do
+          EbookTableOfContentsCache.create(noid: id, toc: [{ title: "A", depth: 1, cfi: "/6/2[Chapter01]!/4/1:0", download?: false }].to_json)
+        end
 
-      it { is_expected.to be false }
+        it "gets the intervals from the cache, returns true" do
+          expect(described_class.new(id).intervals?).to be true
+        end
+      end
 
-      context 'with actual intervals' do
-        let(:intervals) { [interval] }
-        let(:interval) { double('interval') }
+      context "without a EbookTableOfContentsCache cache" do
+        let(:pdf_ebook) { instance_double(PDFEbook::Publication, 'pdf_ebook', id: 'id', intervals: intervals) }
+        let(:intervals) { ['interval'] }
+        before do
+          allow(PDFEbook::Publication).to receive(:from_path_id).and_return(pdf_ebook)
+        end
 
-        it { is_expected.to be true }
+        it "parses the pdf for the intervals, returns true" do
+          expect(described_class.new(id).intervals?).to be true
+        end
       end
     end
 
@@ -44,16 +54,47 @@ RSpec.describe PDFEbookPresenter do
   end
 
   describe '#intervals' do
-    subject { presenter.intervals.first }
+    context "with a valid/not broken pdf" do
+      context "with a EbookTableOfContentsCache cache" do
+        before do
+          EbookTableOfContentsCache.create(noid: id, toc: [{ title: "A", depth: 1, cfi: "/6/2[Chapter01]!/4/1:0", download?: false }].to_json)
+        end
 
-    it { is_expected.to be_nil }
-
-    context 'intervals' do
-      before do
-        EbookTableOfContentsCache.create(noid: pdf_ebook.id, toc: [{ title: "A", depth: 1, cfi: "/6/2[Chapter01]!/4/1:0", download?: false }].to_json)
+        it "returns the intervals" do
+          expect(described_class.new(id).intervals.first).to be_an_instance_of(EBookIntervalPresenter)
+          expect(described_class.new(id).intervals.first.cfi).to eq "/6/2[Chapter01]!/4/1:0"
+        end
       end
 
-      it { is_expected.to be_an_instance_of(EBookIntervalPresenter) }
+      context "without a EbookTableOfContentsCache cache" do
+        # When this happens, it's a problem. We know it's bad. We do not want to parse entire pdfs on the fly just to
+        # get the table of contents. But it still happens sometimes. Sometimes a pdf has some kind of problem and the
+        # ToC doesn't get cached. Instead of an error, we parse the pdf on the fly. It can take many seconds.
+        # We'll do this spec without mocks to make sure all the pieces still work.
+        # HELIO-4467
+        let(:monograph) { create(:public_monograph) }
+        let(:pdf_ebook) { create(:public_file_set) }
+
+        before do
+          Hydra::Works::AddFileToFileSet.call(pdf_ebook, File.open(fixture_path + '/lorum_ipsum_toc.pdf'), :original_file)
+          monograph.ordered_members << pdf_ebook
+          monograph.save!
+          UnpackJob.perform_now(pdf_ebook.id, 'pdf_ebook')
+          FeaturedRepresentative.create(work_id: monograph.id, file_set_id: pdf_ebook.id, kind: 'pdf_ebook')
+          # Remove the cache to force the pdf to be parsed
+          EbookTableOfContentsCache.destroy_all
+        end
+
+        it "returns the intervals" do
+          presenter = described_class.new(pdf_ebook.id)
+          expect(presenter.intervals[0]).to be_an_instance_of(RemoveMeEPubIntervalPresenter)
+          expect(presenter.intervals[0].title).to eq "The standard Lorem Ipsum passage, used since the 1500s"
+          expect(presenter.intervals[0].cfi).to eq "page=3"
+          expect(presenter.intervals[0].level).to be 1
+          expect(presenter.intervals[3].level).to be 2
+          expect(presenter.intervals[6].title).to eq "1914 translation by H. Rackham"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This was tested on staging and works ok. It makes a pretty big difference for the loading speed of the monograph_catalog page.