### PR TITLE
HELIO-4474 - Suppress Legend on Big Ten Collection

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -2410,6 +2410,10 @@ $bigten-black: #000;
     text-decoration-thickness: 2px;
   }
 
+  #facets .access-legend {
+    display: none;
+  }
+
   // monograph catalog
   #sort-dropdown .dropdown-toggle, #per_page-dropdown .dropdown-toggle {
     color: $bigten-white;

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -2410,6 +2410,8 @@ $bigten-black: #000;
     text-decoration-thickness: 2px;
   }
 
+  // HELIO-4474 
+  // hide the access legend on big ten's publisher catalog
   #facets .access-legend {
     display: none;
   }


### PR DESCRIPTION
Removes access legend from DOM via CSS so it does not display on Big Ten's publisher catalog page.