### PR TITLE
remove Press cruft from MonographPresenter

### DIFF
--- a/app/presenters/hyrax/monograph_presenter.rb
+++ b/app/presenters/hyrax/monograph_presenter.rb
@@ -187,18 +187,6 @@ module Hyrax
       Array(solr_document['press_name_ssim']).first
     end
 
-    def press_obj
-      Press.find_by(subdomain: subdomain)
-    end
-
-    def parent_press_subdomain
-      press_obj&.parent&.subdomain
-    end
-
-    def press_url # rubocop:disable Rails/Delegate
-      press_obj.press_url
-    end
-
     def monograph_tombstone_message
       monograph = Sighrax.from_presenter(self)
       monograph.tombstone_message ||

--- a/spec/presenters/hyrax/monograph_presenter_spec.rb
+++ b/spec/presenters/hyrax/monograph_presenter_spec.rb
@@ -474,36 +474,6 @@ RSpec.describe Hyrax::MonographPresenter do
 
       it { is_expected.to eq('name') }
     end
-
-    describe '#press_obj' do
-      subject { presenter.press_obj }
-
-      it { is_expected.to be press }
-    end
-
-    describe '#press_url' do
-      subject { presenter.press_url }
-
-      it { is_expected.to eq('url') }
-    end
-
-    describe '#parent_press_subdomain' do
-      subject { presenter.parent_press_subdomain }
-
-      context 'press has no parent' do
-        before { allow(press).to receive(:parent).and_return(nil) }
-
-        it { is_expected.to be nil }
-      end
-
-      context 'press has a parent' do
-        let(:parent_press) { instance_double(Press, 'parent_press', press_url: 'parent_press_url', subdomain: 'blah') }
-
-        before { allow(press).to receive(:parent).and_return(parent_press) }
-
-        it { is_expected.to be 'blah' }
-      end
-    end
   end
 
   describe '#bar_number' do


### PR DESCRIPTION
@sethaj I think this stuff is OK to remove. was originally added for #2307 but have could (and later did) use PressHelper instead, which makes this kind of stuff available everywhere in the views.

Only serves to confuse and I almost started using these myself for Press-level content warnings in MonographPresenter.
This would be inefficient seeing PressHelper is available in all views.