### PR TITLE
HELIO-4496 - Style content warnings

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -918,6 +918,8 @@ footer.press {
         background-color: #fcf8e3;
         font-size: 16px;
         border-bottom: 3px solid #ffc107;
+        margin-top: 2em;
+        padding: 1em;
 
         // for the show/hide links with no href
         a:hover {
@@ -937,6 +939,12 @@ footer.press {
 
       #content-warning-text {
         flex: 90%;
+        #warning-button[aria-expanded=false] .text-expanded {
+          display: none;
+        }
+        #warning-button[aria-expanded=true] .text-collapsed {
+          display: none;
+        }
       }
 
       #content-warning-information-buffer {
@@ -945,6 +953,10 @@ footer.press {
 
       #content-warning-information {
         flex: 90%;
+        margin-top: 1em;
+        span {
+          display: block;
+        }
       }
 
       #content-warning-information-expand {

--- a/app/assets/stylesheets/common/heliotrope-content-warning.css
+++ b/app/assets/stylesheets/common/heliotrope-content-warning.css
@@ -14,6 +14,7 @@
     border-bottom: 3px solid #ffc107;
     font-size: 16px;
     width: 80%;
+    height: 50%;
     max-width: 1000px;
     left: 10%;
     top: 10%;
@@ -26,7 +27,8 @@
 #content-warning-icon-text {
     padding: 1em 0 0 1em;
     vertical-align: middle;
-    display: flex;       
+    display: flex;    
+    font-family: "effra", Effra-regular, AvenirNext-Medium, Avenir-Medium, avenir, sans-serif;   
 }
 
 #content-warning-icon-text img {
@@ -43,7 +45,6 @@
 #content-warning-buttons .btn {
     margin: 20px;
     display: inline-block;
-    margin-bottom: 0;
     font-weight: normal;
     text-align: center;
     white-space: nowrap;
@@ -67,6 +68,7 @@
     color: #fff;
     background-color: #337ab7;
     border-color: #2e6da4;
+    font-family: "effra", Effra-regular, AvenirNext-Medium, Avenir-Medium, avenir, sans-serif;
 }
 
 #content-warning-buttons .btn:hover {
@@ -87,5 +89,5 @@
     padding: 2em;
     background-color: #e5e5e5;
     color: black;
-    font-family: "Crete Round", Merriweather, georgia, serif;
+    font-family: "effra", Effra-regular, AvenirNext-Medium, Avenir-Medium, avenir, sans-serif;
 }

--- a/app/assets/stylesheets/common/heliotrope-content-warning.css
+++ b/app/assets/stylesheets/common/heliotrope-content-warning.css
@@ -17,37 +17,75 @@
     max-width: 1000px;
     left: 10%;
     top: 10%;
+}
 
-    > input {
-        margin: 20px;
-    }
+#content-warning-media-consent input {
+    margin: 20px;
+}
 
-    #content-warning-icon-text {
-        padding: 20px 0px 0px 20px;
-        vertical-align: middle;
-        > img {
-            vertical-align: middle;
-            height: 30px;
-            width: 30px;
-            margin: 10px;
-        }
-    }
+#content-warning-icon-text {
+    padding: 1em 0 0 1em;
+    vertical-align: middle;
+    display: flex;       
+}
 
-    #content-warning-buttons {
-        text-align: center;
-        .btn {
-          margin: 20px;
-        }
-    }
+#content-warning-icon-text img {
+    vertical-align: middle;
+    height: 30px;
+    width: 30px;
+    margin: 5px 1em;
+}
 
-    /* an alternative to "browser back button" behavior for use within embedded FileSets */
-    #content-hidden-message {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        align-content: center;
-        font-size: 24px;
-        color: white;
-        height: 100%;
-    }
+#content-warning-buttons {
+    text-align: center;
+}
+
+#content-warning-buttons .btn {
+    margin: 20px;
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: normal;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    border-left-color: transparent;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.428571429;
+    border-radius: 4px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    color: #fff;
+    background-color: #337ab7;
+    border-color: #2e6da4;
+}
+
+#content-warning-buttons .btn:hover {
+    color: #fff;
+    background-color: #286090;
+    border-color: #204d74;
+  }
+
+/* an alternative to "browser back button" behavior for use within embedded FileSets */
+#content-hidden-message {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: center;
+    font-size: 24px;
+    color: white;
+    height: 100%;
+    padding: 2em;
+    background-color: #e5e5e5;
+    color: black;
+    font-family: "Crete Round", Merriweather, georgia, serif;
 }

--- a/app/views/hyrax/file_sets/_media.html.erb
+++ b/app/views/hyrax/file_sets/_media.html.erb
@@ -17,8 +17,8 @@
               <%= image_tag "exclamation-triangle-fill.svg", alt: "Warning Icon", 'aria-hidden': "true" %><%= @presenter.content_warning %>
           </div>
         <div id="content-warning-buttons">
-          <input type="button" class="btn btn-primary" value="Go back" aria-label="Go back" onclick="history.back()" tabindex="-1">
-          <input type="button" class="btn btn-primary" value="Proceed" aria-label="Show the sensitive content" onclick="showContent()" tabindex="-1">
+          <input type="button" class="btn btn-primary" value="Go back" aria-label="Go back" onclick="history.back()" tabindex="0">
+          <input type="button" class="btn btn-primary" value="Display content" aria-label="Show the sensitive content" onclick="showContent()" tabindex="0">
         </div>
       </div>
       <div id="content-warning-media" style="visibility:hidden">

--- a/app/views/hyrax/file_sets/_media_embedded.html.erb
+++ b/app/views/hyrax/file_sets/_media_embedded.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div id="content-warning-buttons">
         <input type="button" class="btn btn-primary" value="Hide content" aria-label="Hide content" onclick="hideContent()" tabindex="-1">
-        <input type="button" class="btn btn-primary" value="Proceed" aria-label="Show the sensitive content" onclick="showContent()" tabindex="-1">
+        <input type="button" class="btn btn-primary" value="Display content" aria-label="Show the sensitive content" onclick="showContent()" tabindex="-1">
       </div>
     </div>
     <div id="content-warning-media" style="visibility:hidden">

--- a/app/views/monograph_catalog/_index_monograph.html.erb
+++ b/app/views/monograph_catalog/_index_monograph.html.erb
@@ -108,30 +108,19 @@
         </div><!-- /.btn-toolbar -->
       <% if @presenter.content_warning.present? %>
         <% content_warning_information = @presenter.content_warning_information || press_presenter.content_warning_information %>
-        <div role="dialog" id="content-warning-ebook" aria-label="Ebook Content Warning">
+        <div id="content-warning-ebook" aria-label="Ebook Content Warning">
           <div id="content-warning-icon">
             <%= image_tag "exclamation-triangle-fill.svg", alt: "Warning Icon", 'aria-hidden': "true" %>
           </div>
           <div id="content-warning-text"><%= @presenter.content_warning %>
           <% if content_warning_information.present? %>
-            <span id="content-warning-information-expand"><a id="toggle-content-warning-information-expand" onclick="toggleContentInformation()">Expand to read full warning statement...</a></span>
+            <a id="warning-button" role="button" data-toggle="collapse" href="#content-warning-information" aria-expanded="false" aria-controls="content-warning-information">
+              <span class="text-collapsed">Expand to read full warning statement...</span>
+              <span class="text-expanded">Close warning statement</span>
+              </a>
             </div>
             <div id="content-warning-information-buffer"></div>
-            <div id="content-warning-information" style="display: none"><%= raw content_warning_information %>
-              <span><a onclick="toggleContentInformation()"><br />Close warning statement</a></span>
-
-              <script>
-                function toggleContentInformation() {
-                  if(document.getElementById("content-warning-information").style.display == 'none') {
-                    document.getElementById("content-warning-information").style.display = 'inline-block';
-                    document.getElementById("content-warning-information-expand").style.visibility = 'hidden'
-                  }
-                  else {
-                    document.getElementById("content-warning-information").style.display = 'none';
-                    document.getElementById("content-warning-information-expand").style.visibility = 'visible'
-                  }
-                }
-              </script>
+            <div class="collapse" id="content-warning-information"><%= raw content_warning_information %>
           <% end %>
           </div>
         </div>

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -163,7 +163,7 @@ describe 'Create a monograph' do
       # back on Monograph catalog page
       expect(page).to have_content 'Monograph content warning text'
       # the content warning information is shown only when this JS-triggering link is clicked, hence `visible:false`
-      expect(page).to have_link('Expand to read full warning statement...', href: nil)
+      expect(page).to have_link('Expand to read full warning statement...', href: '#content-warning-information')
       expect(page).to have_css("div#content-warning-information", visible: false, text: "Monograph's specific content warning information text, with a link.")
       expect(page).to have_link('link', href: 'https://www.google.com', visible: false)
 

--- a/spec/features/create_monograph_spec.rb
+++ b/spec/features/create_monograph_spec.rb
@@ -149,7 +149,7 @@ describe 'Create a monograph' do
 
       expect(page).to have_content 'Monograph content warning text'
       # the content warning information is shown only when this JS-triggering link is clicked, hence `visible:false`
-      expect(page).to have_link('Expand to read full warning statement...', href: nil)
+      expect(page).to have_link('Expand to read full warning statement...', href: '#content-warning-information')
       expect(page).to have_css("div#content-warning-information", visible: false, text: 'Some Press-level content warning information, with a link.')
       expect(page).to have_link('link', href: 'https://www.bing.com', visible: false)
 


### PR DESCRIPTION
- Adds styling to content warnings on monograph, fileset, and media embeds
- Adjusts monograph content warning display for accessibility issues (links did not provide keyboard focus, did not respond on enter keystroke). Removed inline JS and replaced with Bootstrap 3 collapse functions to resolve.
- Adjust spec to look for populated href attribute

![Screenshot 2023-08-17 at 5 34 10 PM](https://github.com/mlibrary/heliotrope/assets/1686111/cef1f693-d810-4004-a9a7-fe198a6c93b2)
![Screenshot 2023-08-17 at 5 24 09 PM](https://github.com/mlibrary/heliotrope/assets/1686111/f6e47093-274b-4958-aede-6765aaadb6d7)
![Screenshot 2023-08-17 at 5 24 05 PM](https://github.com/mlibrary/heliotrope/assets/1686111/b34e7ea9-20e8-4672-aaac-e0492859308c)
![Screenshot 2023-08-17 at 5 23 36 PM](https://github.com/mlibrary/heliotrope/assets/1686111/b8ef1212-f0de-43e6-acc5-0e889b79cb29)
![Screenshot 2023-08-17 at 5 23 20 PM](https://github.com/mlibrary/heliotrope/assets/1686111/dfb825e6-b001-4cc3-9d37-88528c6ca0ce)
