### PR TITLE
Update copyright year in fulcrum footer

### DIFF
--- a/fulcrum/_includes/footer.html
+++ b/fulcrum/_includes/footer.html
@@ -35,7 +35,7 @@
     </div>
     <div class="footer-copyright right-align">
       <div class="container">
-      <a href="/accessibility/">Accessibility</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/preservation/">Preservation</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/privacy/">Privacy</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/terms/">Terms of Service</a> &nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp; &copy; 2023 Regents of the University of Michigan
+      <a href="/accessibility/">Accessibility</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/preservation/">Preservation</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/privacy/">Privacy</a>&nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp;<a href="/terms/">Terms of Service</a> &nbsp;&nbsp;&nbsp;&nbsp; &middot; &nbsp;&nbsp;&nbsp;&nbsp; &copy; 2024 Regents of the University of Michigan
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Resolves FOPS-475

Change copyright year to 2024 in the footer for the Fulcrum website.