### PR TITLE
HELIO-4578 - Filtered results: change drop down icon to X 

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -627,6 +627,30 @@ footer.press {
   }
 }
 
+// filter/constraints
+
+  #appliedParams.constraints-container {
+    padding: 1em;
+    margin-bottom: 2em !important;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+  
+    #startOverLink {
+      padding-left: 1em;
+    }
+
+    .search-feedback {
+      padding-top: 2em;
+    
+      p {
+        margin-bottom: 0;
+      }
+    }
+  }
+
 // monograph catalog
 .fulcrum_sidebar {
   .facets .facets-header {

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -2,8 +2,8 @@
   <div id="appliedParams" class="clearfix constraints-container">
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
     <%= render_constraints(params) %>
-    <div class="pull-right">
-      <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-sm btn-text", id: "startOverLink" %>
+    <div class="float-md-right">
+      <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink", id: "startOverLink" %>
     </div>
     <div class="search-feedback">
       <p>Not finding what you are looking for? Help improve Fulcrum's search and <a target="_blank" href="https://umich.qualtrics.com/jfe/form/SV_3KSLynPij0fqrD7?publisher=<%= press.subdomain %>&search_location=catalog&url=<%= request.original_url %>">share your feedback</a>.</p>

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -26,8 +26,8 @@
     end
     %>
 
-    <%= link_to(content_tag(:span, '', class: 'fa fa-minus') + accessible_remove_label,
-                options[:remove], class: 'btn btn-default btn-sm remove dropdown-toggle', role: 'button'
+    <%= link_to(content_tag(:span, '', class: 'fa fa-close') + accessible_remove_label,
+                options[:remove], class: 'btn btn-default btn-sm remove', role: 'button'
         ) %>
   <%- end -%>
 </span>


### PR DESCRIPTION
Resolves [HELIO-4578](https://mlit.atlassian.net/browse/HELIO-4578).

Modifies search results UI: 

- Changes the applied filter icon to use X to remove the filter and removes the dropdown caret
- Restores styling for constraint container and and changes start over button to a link

![Screenshot 2024-02-08 at 3 54 13 PM](https://github.com/mlibrary/heliotrope/assets/1686111/461b65ef-5a0c-4ea0-95df-fe582bf27161)
