### PR TITLE
HELIO-4588 - Match Resource facet display to Publisher facet display

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -461,7 +461,7 @@ footer.press {
 
   }
 
-  .page_links {
+  .page-links {
     font-size: 14px;
   }
 
@@ -582,7 +582,7 @@ footer.press {
 ///////////////////////////////////
 
 // press catalog
-.facets-container {
+.facets-container, #facets {
   padding-top: 15px;
 
   .facets .facets-header {
@@ -653,6 +653,12 @@ footer.press {
 
 // monograph catalog
 .fulcrum_sidebar {
+
+  #resources-search-submit {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   .facets .facets-header {
     // this comes from blacklight and we don't use it.
     display: none;
@@ -676,8 +682,6 @@ footer.press {
       margin-top: 0px;
       .btn {
         font-weight: 700;
-        margin-top: .5em;
-        margin-bottom: .5em;
       }
     }
   }
@@ -754,7 +758,7 @@ footer.press {
     font-size: 1.2em;
   }
 
-  .page_links {
+  .page-links {
     display: inline-block;
     vertical-align: middle;
     margin-top: .4em;
@@ -2338,7 +2342,7 @@ footer.press {
 ///////////////////////////////////
 @media only screen and (max-width: 992px) {
   .press {
-    .page_links {
+    .page-links {
       display: block;
       float: right;
       padding: 10px 12px;

--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -1113,7 +1113,7 @@ $aperio-white: #fff;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include gibson;
   }
 
@@ -3112,7 +3112,7 @@ $bigten-black: #000;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include pt-sans;
   }
 
@@ -3617,7 +3617,7 @@ $bridwell-black-80: #342f2e;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include trade-gothic;
   }
 
@@ -5643,7 +5643,7 @@ $um-white: #fff;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include muli;
   }
 
@@ -6157,7 +6157,7 @@ $um-white: #fff;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include muli;
   }
 
@@ -6688,7 +6688,7 @@ $gabii-link-hover:    #1e5667;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include lato;
   }
 
@@ -7697,7 +7697,7 @@ $mps-teal-100: #e9f2f5;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include muli;
   }
 
@@ -8149,7 +8149,7 @@ $a2ru-white: #fafafa;
     }
 
   // pagination
-  .page_links {
+  .page-links {
     @include rubik;
   }
   .pagination {
@@ -8634,7 +8634,7 @@ $fia-teal-100: #e9f2f5;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include proxima-nova;
   }
 
@@ -9320,7 +9320,7 @@ $maize-black-80: #342f2e;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include benton;
   }
 
@@ -9698,7 +9698,7 @@ $pccn-black-80: #342f2e;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include roboto;
   }
 
@@ -10112,7 +10112,7 @@ $seas-black-80: #342f2e;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include montserrat;
   }
 
@@ -10437,7 +10437,7 @@ $umn-white: #fff;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include brandon;
   }
 
@@ -11040,7 +11040,7 @@ $fulcrum-light-2: #bec4cc;
     }
 
     // pagination
-    .page_links {
+    .page-links {
       @include freight-sans-book;
     }
 
@@ -11345,7 +11345,7 @@ $ncid-black-80: #342f2e;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include proxima-nova;
   }
 
@@ -11964,7 +11964,7 @@ $psu-gray-1: #3F4550;
   }
 
   // pagination
-  .page_links {
+  .page-links {
     @include proxima-nova;
   }
 


### PR DESCRIPTION
Resolves HELIO-4588.

Modifies CSS files to match resource facet card display to publisher facet display:

- fix resource facet display 
- update `page_links` selector to `page-links` so page links are styled properly across platform and themes 
- restore resource search button to have no left radius so it sits flush with search input box

![Screenshot 2024-02-09 at 11 07 07 AM](https://github.com/mlibrary/heliotrope/assets/1686111/de9d5a7c-82c3-4f06-aa05-17a1db311649)
