### PR TITLE
HELIO-4580 - Fixup for Resource thumbnails in Gallery view

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -1302,6 +1302,8 @@ footer.press {
           
           img {
             border: 2px solid #eeeeee;
+            max-width: 100%;
+            height: auto;
           }
 
           img.svgicon {


### PR DESCRIPTION
Resolves fixup needed for HELIO-4580.

Makes resource thumbnail images in gallery view fluid/responsive to prevent overflow outside of document container.

![Screenshot 2024-02-09 at 4 36 27 PM](https://github.com/mlibrary/heliotrope/assets/1686111/cbbff0f8-ebfd-47a5-84fd-ba2b627f5ea1)
