### PR TITLE
HELIO-4577 - Hyrax 4: General Sitewide Issues

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -230,6 +230,8 @@ div.skip {
 .breadcrumbs {
   padding-top: 0 !important;
   padding-bottom: 0 !important;
+  padding-left: 15px !important;
+  padding-right: 15px !important;
   font-size: .9rem;
   .active {
     color: $gray-60 !important;
@@ -704,9 +706,18 @@ footer.press {
     padding: 10px 15px 0 15px;
   }
 
+  .facet_pagination {
+    display: flex;
+    justify-content: space-between;
+  }
+
   #helio-facet-modal-close {
     display: block;
     overflow: auto;
+  }
+
+  .modal-footer {
+    display: block;
   }
 }
 
@@ -737,8 +748,8 @@ footer.press {
 .monograph {
 
   .platform-admin {
-    float: right;
-    margin-top: -2.8em;
+    justify-content: end;
+    padding-bottom: 1.5em;
 
     a {
       padding-right: 25px;
@@ -1807,6 +1818,10 @@ footer.press {
       background-position: 0;
       transition: 0.2s ease-in;
     }
+  }
+
+  #shareMenuButton {
+    height: 100%;
   }
 }
 

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,4 +1,4 @@
-<div class="prev_next_links btn-group pull-left">
+<div class="prev_next_links btn-group">
   <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
     <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled', 'aria-hidden' => 'true' %>
   <% end %>
@@ -8,7 +8,7 @@
   <% end %>
 </div>
 
-<div class="sort_options btn-group pull-right" role="tablist">
+<div class="sort_options btn-group" role="tablist">
   <% if @pagination.sort == 'index' -%>
     <span class="active az btn btn-default" role="tab" aria-selected="true"><%= facet_pagination_sort_index_label(@facet) %></span>
     <%= link_to(facet_pagination_sort_count_label(@facet),

--- a/spec/features/monograph_catalog_facets_spec.rb
+++ b/spec/features/monograph_catalog_facets_spec.rb
@@ -102,7 +102,7 @@ describe "Monograph Catalog Facets" do
       expect(keyword_facet_counts[5]).to have_content '1'
 
       # HELIO-3688
-      expect(page).to have_css(".sort_options.btn-group.pull-right[role=tablist]")
+      expect(page).to have_css(".sort_options.btn-group[role=tablist]")
       expect(page).to have_css("span.active.numeric.btn.btn-default[role=tab][aria-selected=true]")
       expect(page).to have_css("a.sort_change.az.btn.btn-default[href*='keyword_sim?facet.sort=index'][role=tab][aria-selected=false]")
 
@@ -129,7 +129,7 @@ describe "Monograph Catalog Facets" do
       expect(keyword_facet_counts[5]).to have_content '1'
 
       # HELIO-3688
-      expect(page).to have_css(".sort_options.btn-group.pull-right[role=tablist]")
+      expect(page).to have_css(".sort_options.btn-group[role=tablist]")
       expect(page).to have_css("span.active.az.btn.btn-default[role=tab][aria-selected=true]")
       expect(page).to have_css("a.sort_change.numeric.btn.btn-default[href*='keyword_sim?facet.sort=count'][role=tab][aria-selected=false]")
     end


### PR DESCRIPTION
Resolves items listed in HELIO-4577:

- Alignment of buttons in Facet More Modal windows

![Screenshot 2024-02-13 at 12 00 14 PM](https://github.com/mlibrary/heliotrope/assets/1686111/6e7988ec-d03f-4179-b83c-6f925770368c)

- Padding for breadcrumbs on smaller screens

![Screenshot 2024-02-13 at 11 59 49 AM](https://github.com/mlibrary/heliotrope/assets/1686111/94bde6b6-d912-462b-9858-1893146caa63)


- Height of share button in EReader

![Screenshot 2024-02-13 at 11 59 55 AM](https://github.com/mlibrary/heliotrope/assets/1686111/bd62bbb0-9ee5-49f0-a0d2-0490186a0ec0)


- Prevent Monograph Admin tools overlapping with breadcrumbs


![Screenshot 2024-02-13 at 11 59 35 AM](https://github.com/mlibrary/heliotrope/assets/1686111/1ffe60ce-c370-45aa-9d58-ddf416aabb50)

