### PR TITLE
HELIO-4601 - Fix layout and display of Open Access Survey

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -275,8 +275,13 @@ div.skip {
 ///////////////////////////////////
 // Modal survey on monograph page
 .modal.survey {
-  h4 {
-    font-size: 2rem;
+
+  .modal-dialog {
+    max-width: 600px;
+  }
+
+  h4.modal-title {
+    font-size: 20px;
   }
 
   .close {
@@ -290,7 +295,7 @@ div.skip {
       height: 170px;
     }
     p {
-      font-size: 1.85rem;
+      font-size: 1.2em;
     }
   }
   .modal-footer {
@@ -312,16 +317,22 @@ div.skip {
   }
 }
 
+// Alert/Non-Modal survey in EReader
+
+.alert.survey.fade:not(.show) {
+  opacity: 1;
+}
+
 .alert.survey {
   position: fixed;
   z-index: 5001;
   bottom: 0px;
-  right: 0px;
+  right: 35px;
   padding: 0;
   margin-bottom: 0;
 
   .modal-dialog {
-    width: 450px;
+    max-width: 525px;
   }
 
   h4 {

--- a/app/views/shared/_survey_modal.html.erb
+++ b/app/views/shared/_survey_modal.html.erb
@@ -1,10 +1,12 @@
 <!-- survey -->
 <div id="surveyModal" class="modal fade survey" tabindex="-1" role="dialog" aria-labelledby="surveyModalLabel">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="monograph_page" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="surveyModalLabel">Share the story of what Open Access means to you</h4>
+        <h4 class="modal-title" id="surveyModalLabel">Share the story of what Open Access means to you</h4>  
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="monograph_page" data-ga-event-action="survey" data-ga-event-label="ignore_survey">
+          <span aria-hidden="true">&times;</span>
+        </button>       
       </div>
       <div class="modal-body">
         <%= image_tag 'oa-lock-logo-lg.png', alt: 'a graphic of a lock that is open, the universal logo for open access'  %>

--- a/app/views/shared/_survey_modal_bigten.html.erb
+++ b/app/views/shared/_survey_modal_bigten.html.erb
@@ -1,11 +1,13 @@
 <!-- survey -->
 <% presenter = @presenter %>
 <div id="surveyBigTenModal" class="modal fade survey" tabindex="-1" role="dialog" aria-labelledby="surveyModalLabel">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="monograph_page" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
+      <div class="modal-header">        
         <h4 class="modal-title" id="surveyModalLabel">Share the story of what Open Access means to you</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="monograph_page" data-ga-event-action="survey" data-ga-event-label="ignore_survey">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class="modal-body">
         <%= image_tag 'oa-lock-logo-lg.png', alt: 'a graphic of a lock that is open, the universal logo for open access'  %>

--- a/app/views/shared/_survey_nonmodal.erb
+++ b/app/views/shared/_survey_nonmodal.erb
@@ -2,9 +2,11 @@
 <div id="surveyNonModal" class="alert survey fade in" role="alert" aria-labelledby="surveyNonModalLabel" style="display:none;">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
+      <div class="modal-header">        
         <h4 class="modal-title" id="surveyNonModalLabel">Share the story of what Open Access means to you</h4>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class="modal-body">
         <%= image_tag 'oa-lock-logo-lg.png', alt: 'a graphic of a lock that is open, the universal logo for open access'  %>

--- a/app/views/shared/_survey_nonmodal_bigten.erb
+++ b/app/views/shared/_survey_nonmodal_bigten.erb
@@ -3,9 +3,11 @@
 <div id="surveyNonModalBigten" class="alert survey fade in" role="alert" aria-labelledby="surveyNonModalLabel" style="display:none;">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
+      <div class="modal-header">        
         <h4 class="modal-title" id="surveyNonModalLabel">Share the story of what Open Access means to you</h4>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class="modal-body">
         <%= image_tag 'oa-lock-logo-lg.png', alt: 'a graphic of a lock that is open, the universal logo for open access'  %>

--- a/app/views/shared/_survey_nonmodal_gabii.erb
+++ b/app/views/shared/_survey_nonmodal_gabii.erb
@@ -3,9 +3,11 @@
 <div id="surveyNonModalGabii" class="alert survey fade in" role="alert" aria-labelledby="surveyNonModalLabel" style="display:none;">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey"><span aria-hidden="true">&times;</span></button>
+      <div class="modal-header">        
         <h4 class="modal-title" id="surveyNonModalLabel">Share your feedback on Gabii Project Reports</h4>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="survey_button_no()" data-ga-event-category="e_reader" data-ga-event-action="survey" data-ga-event-label="ignore_survey">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class="modal-body">
         <p>University of Michigan needs your feedback to better understand how readers are using enhanced digital publications like the Gabii Project Report Volumes. You can help by taking a short, privacy-friendly survey.</p>


### PR DESCRIPTION
Resolves HELIO-4601.

- Restore display of OA survey within EReader; 
- modify styles and display of survey for both monograph page and ereader; 
- make same changes to BTAA and Gabii specific versions of OA survey;