### PR TITLE
HELIO-4611 add the www prefix to the oai base url to get

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -255,7 +255,7 @@ class CatalogController < ApplicationController
     config.oai = {
       provider: {
         repository_name: 'Fulcrum',
-        repository_url: 'https://fulcrum.org/catalog/oai',
+        repository_url: 'https://www.fulcrum.org/catalog/oai',
         record_prefix: 'oai:fulcrum.org',
         admin_email: 'fulcrum-info@umich.edu',
         sample_id: '9s1616317'


### PR DESCRIPTION
OAI validation to pass.