### PR TITLE
HELIO-4636 fix blacklight deprecation messages, keep a11y work

### DIFF
--- a/app/components/blacklight/response/view_type_button_component.html.erb
+++ b/app/components/blacklight/response/view_type_button_component.html.erb
@@ -1,0 +1,7 @@
+<%= link_to url, title: label, 
+                 class: "#{Array(@classes).join(' ')} view-type-#{ @key.to_s.parameterize } #{"active" if selected?}",
+                 role: 'tab',
+                 'aria-selected': "#{selected?}" do %>
+  <%= icon %>
+  <span class="caption"><%= label %></span>
+<% end %>

--- a/app/components/blacklight/response/view_type_button_component.rb
+++ b/app/components/blacklight/response/view_type_button_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Response
+    # Render spellcheck results for a search query
+    class ViewTypeButtonComponent < ViewComponent::Base
+      with_collection_parameter :view
+      # @param [Blacklight::Configuration::View] view
+      def initialize(view:, key: nil, selected: false, search_state: nil, classes: 'btn btn-outline-secondary btn-icon')
+        @view = view
+        @key = key || view.key
+        @selected = selected
+        @classes = classes
+        @search_state = search_state
+      end
+
+      def icon
+        return render(@view.icon.new) if @view.icon.is_a?(Class)
+        return render(@view.icon) if @view.icon.is_a?(ViewComponent::Base)
+
+        Deprecation.silence(Blacklight::CatalogHelperBehavior) do
+          helpers.render_view_type_group_icon(@view.icon || @key)
+        end
+      end
+
+      def label
+        Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
+          helpers.view_label(@key)
+        end
+      end
+
+      def url
+        helpers.url_for(@search_state.to_h.merge(view: @key))
+      end
+
+      def selected?
+        @selected
+      end
+    end
+  end
+end

--- a/app/components/blacklight/response/view_type_component.html.erb
+++ b/app/components/blacklight/response/view_type_component.html.erb
@@ -1,0 +1,8 @@
+<div class="view-type">
+  <span class="sr-only visually-hidden"><%= t('blacklight.search.view_title') %></span>
+  <div class="view-type-group btn-group" role="tablist">
+    <% views.each do |view| %>
+      <%= view %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/blacklight/response/view_type_component.rb
+++ b/app/components/blacklight/response/view_type_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Response
+    # Render spellcheck results for a search query
+    class ViewTypeComponent < ViewComponent::Base
+      renders_many :views, 'Blacklight::Response::ViewTypeButtonComponent'
+
+      # @param [Blacklight::Response] response
+      def initialize(response:, views: {}, search_state:, selected: nil)
+        @response = response
+        @views = views
+        @search_state = search_state
+        @selected = selected
+      end
+
+      def before_render
+        return if views.any?
+
+        @views.each do |key, config|
+          with_view(key: key, view: config, selected: @selected == key, search_state: @search_state)
+        end
+      end
+
+      def render?
+        Deprecation.silence(Blacklight::ConfigurationHelperBehavior) do
+          helpers.has_alternative_views?
+        end
+      end
+    end
+  end
+end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -20,7 +20,7 @@
 <%- elsif render_grouped_response? %>
   <%= render_grouped_document_index %>
 <%- else %>
-  <%= render_document_index %>
+  <%= render_document_index(@documents) %>
 <%- end %>
 
 <%= render 'results_pagination' %>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -1,17 +1,5 @@
-<% if show_sort_and_per_page? && has_alternative_views? %>
-  <div class="view-type btn-group">
-    <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
-    <div class="view-type-group btn-group" role="tablist">
-      <% document_index_views.each do |view, _config| %>
-        <%= link_to url_for(search_state.to_h.merge(view: view)),
-                    title: view_label(view),
-                    class: "btn btn-default view-type-#{ view.to_s.parameterize } #{'active' if document_index_view_type == view}",
-                    role: 'tab',
-                    'aria-selected': document_index_view_type == view do %>
-          <%= render_view_type_group_icon view %>
-          <span class="caption"><%= view_label(view) %></span>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+<%= render(Blacklight::Response::ViewTypeComponent.new(
+      response: @response,
+      views: document_index_view_controls,
+      search_state: search_state,
+      selected: document_index_view_type)) if show_sort_and_per_page? -%>

--- a/spec/features/monograph_catalog_search_spec.rb
+++ b/spec/features/monograph_catalog_search_spec.rb
@@ -113,15 +113,15 @@ describe 'Monograph Catalog Search' do
 
     # Monograph catalog defaults to list view
     expect(page).to have_css(".view-type-group.btn-group[role=tablist]")
-    expect(page).to have_css("a.btn.btn-default.view-type-list.active[href*='view=list'][role=tab][aria-selected=true]")
-    expect(page).to have_css("a.btn.btn-default.view-type-gallery[href*='view=gallery'][role=tab][aria-selected=false]")
+    expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-list.active[href*='view=list'][role=tab][aria-selected=true]")
+    expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-gallery[href*='view=gallery'][role=tab][aria-selected=false]")
 
     # also check gallery view
     visit monograph_catalog_path id: monograph.id, view: 'gallery'
 
     expect(page).to have_css(".view-type-group.btn-group[role=tablist]")
-    expect(page).to have_css("a.btn.btn-default.view-type-list[href*='view=list'][role=tab][aria-selected=false]")
-    expect(page).to have_css("a.btn.btn-default.view-type-gallery.active[href*='view=gallery'][role=tab][aria-selected=true]")
+    expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-list[href*='view=list'][role=tab][aria-selected=false]")
+    expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-gallery.active[href*='view=gallery'][role=tab][aria-selected=true]")
 
     expect(page).to have_selector("#documents.row.documents-gallery")
     expect(page).to have_selector(".documents-gallery .document .thumbnail .caption")

--- a/spec/features/press_catalog_spec.rb
+++ b/spec/features/press_catalog_spec.rb
@@ -33,14 +33,14 @@ describe 'Press Catalog' do
         # Press catalog defaults to gallery view
         expect(page).to have_selector('#documents.row.documents-gallery')
         expect(page).to have_css(".view-type-group.btn-group[role=tablist]")
-        expect(page).to have_css("a.btn.btn-default.view-type-list[href*='view=list'][role=tab][aria-selected=false]")
-        expect(page).to have_css("a.btn.btn-default.view-type-gallery.active[href*='view=gallery'][role=tab][aria-selected=true]")
+        expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-list[href*='view=list'][role=tab][aria-selected=false]")
+        expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-gallery.active[href*='view=gallery'][role=tab][aria-selected=true]")
 
         # also check list view
         click_link 'List'
         expect(page).to have_css(".view-type-group.btn-group[role=tablist]")
-        expect(page).to have_css("a.btn.btn-default.view-type-list.active[href*='view=list'][role=tab][aria-selected=true]")
-        expect(page).to have_css("a.btn.btn-default.view-type-gallery[href*='view=gallery'][role=tab][aria-selected=false]")
+        expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-list.active[href*='view=list'][role=tab][aria-selected=true]")
+        expect(page).to have_css("a.btn.btn-outline-secondary.btn-icon.view-type-gallery[href*='view=gallery'][role=tab][aria-selected=false]")
 
         # Since this is not a search, it's a "browse" and the default
         # sort should be Sort by Publication Date (Newest First)


### PR DESCRIPTION
  * We took on some components/blacklight/response/view_type* because of a couple of a11y changes we need like role and aria-selected

Since we're using new blacklight components for the "view_types" you can see that when a view_type is selected (ie: gallery vs. list) the icon is now greyed out as in this example below. Since gallery is default, the gallery icon reflects that it's selected. This is a change from what it looks like currently.

![gallery-selected-grayed-out](https://github.com/mlibrary/heliotrope/assets/3924142/07e7e53a-de53-4a83-8451-a39e5a9da91d)
