### PR TITLE
HELIO-4628 add google tag manager for production

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -20,6 +20,16 @@
     })(window,document,'script','dataLayer','GTM-PTZXSV7');</script>
     <% end %>
 
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K5L8F5XD');</script>
+    <!-- End Google Tag Manager -->
+    <% end %>
+
     <!-- Favicons and theme colors -->
     <%= render 'shared/favicon' %>
     <meta name="format-detection" content="telephone=no">
@@ -104,6 +114,14 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <% end %>
+
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5L8F5XD"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
 
     <%= content_for?(:body) ? yield(:body) : yield %>
 

--- a/app/views/layouts/csb_too_viewer.html.erb
+++ b/app/views/layouts/csb_too_viewer.html.erb
@@ -20,6 +20,16 @@
     })(window,document,'script','dataLayer','GTM-PTZXSV7');</script>
     <% end %>
 
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K5L8F5XD');</script>
+    <!-- End Google Tag Manager -->
+    <% end %>
+
     <!-- Favicons and theme colors -->
     <%= render 'shared/favicon' %>
     <meta name="format-detection" content="telephone=no">
@@ -125,6 +135,20 @@
 
   <%# tag.body class: press_presenter.present? ? press_presenter.press_subdomains : '' do %>
   <body>
+    <% if Settings.host == "heliotrope-preview.hydra.lib.umich.edu" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PTZXSV7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5L8F5XD"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
     <%= content_for?(:body) ? yield(:body) : yield %>
 
     <%= render 'shared/blacklight_modal' %>

--- a/app/views/layouts/csb_viewer.html.erb
+++ b/app/views/layouts/csb_viewer.html.erb
@@ -20,6 +20,16 @@
     })(window,document,'script','dataLayer','GTM-PTZXSV7');</script>
     <% end %>
 
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K5L8F5XD');</script>
+    <!-- End Google Tag Manager -->
+    <% end %>
+
     <!-- Favicons and theme colors -->
     <%= render 'shared/favicon' %>
     <meta name="format-detection" content="telephone=no">
@@ -100,6 +110,19 @@
   </head>
 
   <%= tag.body class: press_presenter.present? ? press_presenter.press_subdomains : '' do %>
+    <% if Settings.host == "heliotrope-preview.hydra.lib.umich.edu" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PTZXSV7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5L8F5XD"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
 
     <%= content_for?(:body) ? yield(:body) : yield %>
 

--- a/app/views/layouts/embedded.html.erb
+++ b/app/views/layouts/embedded.html.erb
@@ -12,6 +12,16 @@
     })(window,document,'script','dataLayer','GTM-PTZXSV7');</script>
     <% end %>
 
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K5L8F5XD');</script>
+    <!-- End Google Tag Manager -->
+    <% end %>
+
     <!-- Ensure all links open outside the iframe, in a new tab -->
     <base target="_blank">
     <!-- CSS -->
@@ -32,6 +42,13 @@
     <% if Settings.host == "heliotrope-preview.hydra.lib.umich.edu" %>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PTZXSV7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5L8F5XD"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <% end %>

--- a/app/views/layouts/mozilla-pdf-viewer.html.erb
+++ b/app/views/layouts/mozilla-pdf-viewer.html.erb
@@ -11,6 +11,16 @@
     })(window,document,'script','dataLayer','GTM-PTZXSV7');</script>
     <% end %>
 
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K5L8F5XD');</script>
+    <!-- End Google Tag Manager -->
+    <% end %>
+
     <!-- Citation metadata for Google Scholar -->
     <%= render 'shared/metadata' %>
 
@@ -28,6 +38,20 @@
     <%= render 'shared/ga4' %>
   </head>
   <body id="outerContainer">
+    <% if Settings.host == "heliotrope-preview.hydra.lib.umich.edu" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PTZXSV7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
+    <% if Settings.host == "www.fulcrum.org" %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K5L8F5XD"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
     <%= content_for?(:body) ? yield(:body) : yield %>
   </body>
 </html>


### PR DESCRIPTION
Added tag manager for production and preview (which was incomplete). On preview I've verified that tag manager is present on:

- Press catalog pages
- Monograph catalog pages
- FileSet show pages
- EPUB reader pages
- PDF reader pages

