### PR TITLE
HELIO-4644 authorization from products, not noid lists which can be slow

### DIFF
--- a/app/controllers/press_catalog_controller.rb
+++ b/app/controllers/press_catalog_controller.rb
@@ -37,6 +37,16 @@ class PressCatalogController < ::CatalogController
     super
   end
 
+  instrument_method
+  def index
+    super
+  end
+
+  instrument_method
+  def show
+    super
+  end
+
   # If the params specify a view, then store it in the session. If the params
   # do not specify the view, set the view parameter to the value stored in the
   # session. This enables a user with a session to do subsequent searches and have

--- a/app/models/sighrax/monograph.rb
+++ b/app/models/sighrax/monograph.rb
@@ -72,6 +72,12 @@ module Sighrax
       Greensub::Product.containing_monograph(noid)
     end
 
+    def product_ids
+      # We could do this as above via Greensub::Product.containing_monograph(noid)
+      # but I think this works too and is faster since it's already on the monograph
+      vector('products_lsim')
+    end
+
     def publication_year
       match = /(\d{4})/.match(scalar('date_created_tesim'))
       return match[1] if match.present?

--- a/app/policies/e_pub_policy.rb
+++ b/app/policies/e_pub_policy.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class EPubPolicy < ApplicationPolicy
+  include Skylight::Helpers
+
   def initialize(actor, target, share = false)
     super(actor, target)
     @share = share
   end
 
+  instrument_method
   def show?
     return true if !ebook.tombstone? && share
 

--- a/app/policies/ebook_operation.rb
+++ b/app/policies/ebook_operation.rb
@@ -2,23 +2,28 @@
 
 class EbookOperation < ApplicationPolicy
   include AbilityHelpers
+  include Skylight::Helpers
 
   protected
 
     alias_attribute :ebook, :target
 
+    instrument_method
     def accessible_online?
       ebook.published? && !ebook.tombstone?
     end
 
+    instrument_method
     def accessible_offline?
       ebook.allow_download? && accessible_online?
     end
 
+    instrument_method
     def unrestricted?
       ebook.open_access? || !ebook.restricted?
     end
 
+    instrument_method
     def licensed_for?(entitlement) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       licenses = authority.licenses_for(actor, ebook)
 

--- a/app/policies/ebook_reader_operation.rb
+++ b/app/policies/ebook_reader_operation.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class EbookReaderOperation < EbookOperation
+  include Skylight::Helpers
+
+  instrument_method
   def allowed?
     return true if can? :read
 

--- a/spec/models/auth_spec.rb
+++ b/spec/models/auth_spec.rb
@@ -304,19 +304,19 @@ RSpec.describe Auth, type: :model do
     context 'subscribing institutions' do
       let(:press) { create(:press) }
       let(:publisher) { Sighrax::Publisher.from_press(press) }
-      let(:noids) { ['validnoid'] }
+      let(:product_ids) { [] }
       let(:institutions) { ['institution'] }
 
       before do
-        allow(publisher).to receive(:work_noids).with(true).and_return(noids)
-        allow_any_instance_of(Auth).to receive(:subscribing_institutions).and_return([])
-        allow_any_instance_of(Auth).to receive(:subscribing_institutions).with(noids).and_return(institutions)
+        allow_any_instance_of(Auth).to receive(:subscribing_institutions_from_product_ids).and_return(institutions)
+        allow_any_instance_of(Auth).to receive(:subscribing_institutions_from_product_ids).with(product_ids).and_return(institutions)
       end
 
       it { is_expected.to be_empty }
 
       context 'Publisher' do
         let(:entity) { publisher }
+        let(:product_ids) { ['1', '2'] }
 
         it { is_expected.to be institutions }
       end
@@ -388,14 +388,18 @@ RSpec.describe Auth, type: :model do
       let(:institutions) { ['institution'] }
 
       before do
-        allow_any_instance_of(Auth).to receive(:subscribing_institutions).and_return([])
-        allow_any_instance_of(Auth).to receive(:subscribing_institutions).with(monograph.noid).and_return(institutions)
+        allow_any_instance_of(Auth).to receive(:subscribing_institutions_from_product_ids).and_return([])
       end
 
       it { is_expected.to be_empty }
 
       context 'Monograph' do
         let(:entity) { monograph }
+
+        before do
+          allow(monograph).to receive(:product_ids)
+          allow_any_instance_of(Auth).to receive(:subscribing_institutions_from_product_ids).with(monograph.product_ids).and_return(institutions)
+        end
 
         it { is_expected.to be institutions }
       end

--- a/spec/models/sighrax/monograph_spec.rb
+++ b/spec/models/sighrax/monograph_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Sighrax::Monograph, type: :model do
     end
   end
 
-  describe '#open_access?, #products, and #unrestricted?' do
+  describe '#open_access?, #products, #product_ids, and #unrestricted?' do
     subject { Sighrax.from_noid(monograph.id) }
 
     let(:monograph) { create(:public_monograph) }
@@ -155,6 +155,7 @@ RSpec.describe Sighrax::Monograph, type: :model do
 
       it 'has expected values' do
         expect(subject.products).to be_empty
+        expect(subject.product_ids).to eq [0] # 0 is the default fake No Product product
         expect(subject.restricted?).to be false
         expect(subject.open_access?).to be false
       end
@@ -170,6 +171,7 @@ RSpec.describe Sighrax::Monograph, type: :model do
         it 'has expected values' do
           expect(subject.products).not_to be_empty
           expect(subject.products).to eq(Greensub::Product.containing_monograph(monograph.id))
+          expect(subject.product_ids).to eq [product.id]
           expect(subject.restricted?).to be true
           expect(subject.open_access?).to be false
         end
@@ -183,6 +185,7 @@ RSpec.describe Sighrax::Monograph, type: :model do
           it 'has expected values' do
             expect(subject.products).not_to be_empty
             expect(subject.products).to eq(Greensub::Product.containing_monograph(monograph.id))
+            expect(subject.product_ids).to eq [-1, product.id]  # -1 is the Open Access fake product
             expect(subject.restricted?).to be true
             expect(subject.open_access?).to be true
           end


### PR DESCRIPTION
HELIO-4644

The purpose of this is to replace a few methods in auth.rb to make them faster. There shouldn't be any changes in functionality.

Previously "publisher_restricted_content?" and "subscribing_institutions" were getting all noids in a press from solr. Those lists of noids can get big and take a while to fetch. Then the list is put into a sql query via IN that can also be very large. This pattern will just get slower as more books are added to a press.

Instead of getting lists of noids, we'll get lists of products. Using the product ids, we can determine the question of "publisher_restricted_content?" and replace "subscribing_institutions(big_list_of_noids)" with "subscribing_institutions_from_product_ids(small_list_of_products)" and still get the same answers. This is possible because a monograph knows what products it's in via the products_lsim solr field. We can get a list of unique products for an entire press using a solr query and facets and turn a 300ms query into 3ms.

The PR adds a lot of skylight instrumentation that I'd like to keep in place so we can monitor performance in production. If it's too confusing I can put it in a separate PR.
