### PR TITLE
HELIO-4726 Forward users from /counter_reports to scholarlyiq

### DIFF
--- a/app/services/scholarlyiq_redirect_url_service.rb
+++ b/app/services/scholarlyiq_redirect_url_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ScholarlyiqRedirectUrlService
+  def self.encrypted_url(config, institutions)
+    yaml = YAML.safe_load(File.read(config))
+    url = yaml["siq_portal_url"]
+    secret = yaml["siq_shared_secret"] # AES-128-GCM requires a 16-byte key
+    iv = SecureRandom.random_bytes(12) # AES-128-GCM require a 12 byte nonce
+
+    cipher = OpenSSL::Cipher.new("aes-128-gcm")
+    cipher.encrypt
+    cipher.key = secret
+    cipher.iv = iv
+
+    payload = {}
+    payload["siteIds"] = []
+    institutions.each do |inst|
+      payload["siteIds"] << inst.identifier
+    end
+
+    encrypted_payload = cipher.update(payload.to_json) + cipher.final
+    auth_tag = cipher.auth_tag
+
+    encoded_encrypted_payload = Base64.strict_encode64(encrypted_payload + auth_tag)
+    encoded_nonce = Base64.strict_encode64(iv)
+
+    url_encoded_encrypted_payload = CGI.escape(encoded_encrypted_payload)
+    url_encoded_nonce = CGI.escape(encoded_nonce)
+
+    token = "#{url_encoded_nonce}:#{url_encoded_encrypted_payload}"
+    url + "?token=#{token}"
+  end
+end

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Add fulcrum specific flipflop features here
+
+Flipflop.configure do
+  feature :scholarlyiq_counter_redirect,
+          default: false,
+          description: "Redirect known users from /counter_report to scholarlyiq"
+end

--- a/config/scholarlyiq.yml.sample
+++ b/config/scholarlyiq.yml.sample
@@ -4,3 +4,7 @@ Bucket: "s3 bucket"
 BucketRegion: "s3 bucket region"
 AwsAccessKeyId: 123456789XYZ
 AwsSecretAccessKey: AwsSecretAccessKeyAwsSecretAccessKey
+
+# HELIO-4726 for redirecting users to SIQ to see their reports
+siq_portal_url: 'scholarlyiq.com'
+siq_shared_secret: 'some-shared-secret'

--- a/spec/requests/counter_reports_spec.rb
+++ b/spec/requests/counter_reports_spec.rb
@@ -154,10 +154,31 @@ RSpec.describe "Customers Counter Reports", type: :request do
       end
 
       describe "GET /counter_reports" do
-        it do
-          get counter_reports_path
-          expect(response).to have_http_status(:ok)
-          expect(response).to render_template(:index)
+        context "with scholarlyiq redirect" do
+          before do
+            allow(Flipflop).to receive(:scholarlyiq_counter_redirect?).and_return(true)
+            allow(File).to receive(:exist?).and_return(true)
+            allow(File).to receive(:read).and_return(true)
+            allow(YAML).to receive(:safe_load).and_return(yaml)
+          end
+
+          let(:yaml) { { 'siq_portal_url' => 'http://test.scholarlyiq.com', 'siq_shared_secret' => '0123456789123456' } }
+          it do
+            get counter_reports_path
+            expect(response).to have_http_status(:found)
+          end
+        end
+
+        context "without scholarlyiq redirect" do
+          before do
+            allow(Flipflop).to receive(:scholarlyiq_counter_redirect?).and_return(false)
+          end
+
+          it do
+            get counter_reports_path
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template(:index)
+          end
         end
       end
 

--- a/spec/services/scholarlyiq_redirect_url_service_spec.rb
+++ b/spec/services/scholarlyiq_redirect_url_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScholarlyiqRedirectUrlService do
+  describe "#encrypted_url" do
+    let(:institutions) do
+      [
+        create(:institution, identifier: "1"),
+        create(:institution, identifier: "10")
+      ]
+    end
+
+    let(:shared_secret) { "0123456789123456" } # 16 byte shared secret
+    let(:nonce) { "012345678912" } # 12 byte nonce
+    let(:yaml) { { "siq_portal_url" => "http://test.scholarlyiq.com", "siq_shared_secret" => shared_secret } }
+    let(:config) { double("config") }
+
+    before do
+      allow(File).to receive(:read).and_return(true)
+      allow(YAML).to receive(:safe_load).and_return(yaml)
+      allow(SecureRandom).to receive(:random_bytes).with(12).and_return(nonce)
+    end
+
+    it "correctly builds the encrypted url" do
+      # Just a check that the payload we encrpyted decrypts correctly
+      redirect_url = described_class.encrypted_url(config, institutions)
+
+      # Extract the token from the URL
+      token_param = redirect_url.match(/token=([^&]+)/)[1]
+
+      # Split the token into nonce and encrypted payload parts
+      url_encoded_nonce, url_encoded_encrypted_payload = token_param.split(':')
+
+      # URL-decode and Base64 decode the nonce and the encrypted payload
+      iv = Base64.decode64(CGI.unescape(url_encoded_nonce))
+      encrypted_payload_with_auth_tag = Base64.decode64(CGI.unescape(url_encoded_encrypted_payload))
+
+      # Extract the ciphertext and authentication tag
+      auth_tag = encrypted_payload_with_auth_tag[-16..-1]
+      encrypted_payload = encrypted_payload_with_auth_tag[0..-17]
+
+      # Create a Cipher for AES-128-GCM decryption
+      cipher = OpenSSL::Cipher.new('aes-128-gcm')
+      cipher.decrypt
+      cipher.key = shared_secret
+      cipher.iv = iv # use the decoded 12-byte nonce
+      cipher.auth_tag = auth_tag
+
+      # Decrypt the payload
+      decrypted_payload = cipher.update(encrypted_payload) + cipher.final
+
+      expect(iv).to eq nonce
+      expect(JSON.parse(decrypted_payload)).to eq({ "siteIds" => ["1", "10"] })
+    end
+  end
+end


### PR DESCRIPTION
I've got this behind Flipflop with disabled by default. I've put it on preview, enabled and it's working there.