### PR TITLE
HELIO-4754 - Distinguish Next >> Link from surrounding text

### DIFF
--- a/app/assets/stylesheets/application/heliotrope.scss
+++ b/app/assets/stylesheets/application/heliotrope.scss
@@ -494,6 +494,9 @@ footer.press {
 
   .page-links {
     font-size: 14px;
+    a {
+      text-decoration: underline;
+    }
   }
 
   p.authors {


### PR DESCRIPTION
Resolves HELIO-4754

Adds an underline to links within the `.page-links` container, which hold the Next >> and << Previous links used for paging on the publisher catalog pages. This is applied across the default theme and will impact all publisher pages/themes.