### PR TITLE
HELIO-4792 Add explicit Content-Security-Policy header to response

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -6,6 +6,12 @@ class EmbedController < ApplicationController
 
   def show
     response.headers.except! 'X-Frame-Options'
+    # See HELIO-4792
+    # By default, Cloudflare is adding "X-Frame-Options: SAMEORIGIN" to all responses regardless of that
+    # header's removal above. We want anyone to be able to embed in an iframe, but we'd like to keep the Cloudflare default
+    # for the rest of Fulcrum so adding an explicit Content-Security-Policy header for only the /embed route which
+    # should take precident over any X-Frame-Options
+    response.set_header("Content-Security-Policy", "frame-ancestors 'self' *")
     @presenter = Hyrax::PresenterFactory.build_for(ids: [self.noid(params[:hdl] || "")], presenter_class: Hyrax::FileSetPresenter, presenter_args: nil).first
     if @presenter.nil?
       render 'hyrax/base/unauthorized', status: :unauthorized

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe EmbedController, type: :controller do
       it do
         expect(response).not_to have_http_status(:unauthorized)
         expect(response).to be_successful
+        expect(response.headers.key?("X-Frame-Options")).to be false
+        expect(response.headers.key?("Content-Security-Policy")).to be true
+        expect(response.headers["Content-Security-Policy"]).to eq "frame-ancestors 'self' *"
       end
     end
 


### PR DESCRIPTION
Tested this by adding the Content-Security-Policy in the Cloudflare dashboard and enabling the default security headers and it all works fine. As we predicted, Content-Security-Policy has precedence over X-Frame-Options.