### PR TITLE
HELIO-4823 Temp skip OPDS schema validation specs due to bad schema

### DIFF
--- a/spec/models/opds/publication_spec.rb
+++ b/spec/models/opds/publication_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
           it { expect(subject[:images]).to include({ href: "#{Riiif::Engine.routes.url_helpers.image_url(monograph.cover.noid, host: Rails.application.routes.url_helpers.root_url, size: "#{width_size},", format: 'jpg')}", width: width_size, type: 'image/jpeg' }) }
         end
 
-        it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+        xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
       end
 
       context 'only epub' do
@@ -87,7 +87,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
         it { expect(subject[:links]).to include({ rel: 'http://opds-spec.org/acquisition/open-access', href: Rails.application.routes.url_helpers.download_ebook_url(epub.noid), type: 'application/epub+zip' }) }
         it { expect(subject[:links]).not_to include({ rel: 'http://opds-spec.org/acquisition/open-access', href: Rails.application.routes.url_helpers.download_ebook_url(pdf.noid), type: 'application/pdf' }) }
 
-        it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+        xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
       end
 
       context 'only pdf' do
@@ -102,7 +102,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
         it { expect(subject[:links]).not_to include({ rel: 'http://opds-spec.org/acquisition/open-access', href: Rails.application.routes.url_helpers.download_ebook_url(epub.noid), type: 'application/epub+zip' }) }
         it { expect(subject[:links]).to include({ rel: 'http://opds-spec.org/acquisition/open-access', href: Rails.application.routes.url_helpers.download_ebook_url(pdf.noid), type: 'application/pdf' }) }
 
-        it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+        xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
       end
 
       context 'metadata' do
@@ -135,7 +135,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
           it { expect(subject[:metadata].keys.count).to eq(7) }
           it { expect(subject[:metadata]).to include(author: 'Author') }
           it { expect(subject[:metadata]).to include(editor: 'Editor') }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
 
           context 'when multiple authors and editors' do
             before do
@@ -152,7 +152,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
             it { expect(subject[:metadata].keys.count).to eq(7) }
             it { expect(subject[:metadata][:author]).to contain_exactly('Author1', 'Author2') }
             it { expect(subject[:metadata][:editor]).to contain_exactly('Editor1', 'Editor2') }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
         end
 
@@ -162,7 +162,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
             it { expect(subject[:metadata].keys.count).to eq(5) }
             it { expect(subject[:metadata]).not_to have_key(:belongsTo) }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
 
           describe '#series' do
@@ -170,7 +170,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
             it { expect(subject[:metadata].keys.count).to eq(6) }
             it { expect(subject[:metadata]).to include(belongsTo: { series: 'Series' }) }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
         end
 
@@ -179,7 +179,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
           it { expect(subject[:metadata].keys.count).to eq(5) }
           it { expect(subject[:metadata]).to include(description: '<div>Description<br><a href="http://citable.link.org">View on Fulcrum platform.</a></div>') }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
         end
 
         describe '#identifier' do
@@ -187,7 +187,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
           it { expect(subject[:metadata].keys.count).to eq(6) }
           it { expect(subject[:metadata]).to include(identifier: 'https://Identifier') }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
         end
 
         describe '#language' do
@@ -197,14 +197,14 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
           it { expect(subject[:metadata].keys.count).to eq(5) }
           it { expect(subject[:metadata]).to include(language: 'eng') }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
 
           context 'multiple languages' do
             let(:languages) { %w[en eng english fr frc french espanol] }
 
             it { expect(subject[:metadata].keys.count).to eq(5) }
             it { expect(subject[:metadata][:language]).to contain_exactly('eng', 'frc', 'spa') }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
         end
 
@@ -216,7 +216,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
             it { expect(subject[:metadata].keys.count).to eq(5) }
             it { expect(subject[:metadata]).to include(modified: date_published.iso8601) }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
 
             context 'when published and modified' do
               before { allow(monograph).to receive(:modified).and_return(date_modified) }
@@ -225,7 +225,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
               it { expect(subject[:metadata].keys.count).to eq(5) }
               it { expect(subject[:metadata]).to include(modified: date_modified.iso8601) }
-              it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+              xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
             end
           end
         end
@@ -238,7 +238,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
           it { expect(subject[:metadata].keys.count).to eq(6) }
           it { expect(subject[:metadata]).to include(published: date.iso8601) }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
         end
 
         describe '#publisher' do
@@ -246,7 +246,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
           it { expect(subject[:metadata].keys.count).to eq(6) }
           it { expect(subject[:metadata]).to include(publisher: 'Publishing House') }
-          it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+          xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
         end
 
         describe '#subject' do
@@ -255,7 +255,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
             it { expect(subject[:metadata].keys.count).to eq(6) }
             it { expect(subject[:metadata]).to include(subject: 'Subject') }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
 
           context 'plural' do
@@ -263,7 +263,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
 
             it { expect(subject[:metadata].keys.count).to eq(6) }
             it { expect(subject[:metadata]).to include(subject: ['Subject A', 'Subject B']) }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
         end
 
@@ -271,7 +271,7 @@ RSpec.describe Opds::Publication, type: [:model, :json_schema] do
           describe "##{method}" do
             it { expect(subject[:metadata].keys.count).to eq(5) }
             it { expect(subject[:metadata]).not_to have_key(method) }
-            it { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
+            xit { expect(schemer_validate?(opds_publication_schemer, JSON.parse(subject.to_json))).to be true }
           end
         end
       end

--- a/spec/requests/api/opds/V2/feeds_spec.rb
+++ b/spec/requests/api/opds/V2/feeds_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_amherst_path, headers: headers
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(1)
             expect(response_body['publications'].first).to eq(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id)).to_json))
           end
@@ -229,7 +229,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_bigten_path, headers: headers
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(1)
             expect(response_body['publications'].first).to eq(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id)).to_json))
           end
@@ -302,7 +302,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_leverpress_path, headers: headers
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(1)
             expect(response_body['publications'].first).to eq(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id)).to_json))
           end
@@ -429,7 +429,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_umpebc_path, headers: headers
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(2)
             expect(response_body['publications']).to contain_exactly(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id)).to_json), JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id)).to_json))
           end
@@ -438,7 +438,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_umpebc_oa_path, headers: headers
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(1)
             expect(response_body['publications'].first).to eq(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id)).to_json))
           end
@@ -504,7 +504,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
         get api_opds_amherst_path, headers: headers, params: { filterByEntityId: entity_id }
         expect(response.content_type).to eq("application/opds+json")
         expect(response).to have_http_status(:ok)
-        expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+        # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
         expect(response_body['publications'].count).to eq(1)
         expect(response_body['publications'].first).to eq(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id), entity_id).to_json))
         expect(response_body['publications'].first["links"].first["href"]).to eq "http://test.host/ebooks/#{epub.id}/download?entityID=https%3A%2F%2Fshibboleth.umich.edu%2Fidp%2Fshibboleth"
@@ -588,7 +588,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
         get api_opds_umpebc_path, headers: headers, params: { filterByEntityId: entity_id }
         expect(response.content_type).to eq("application/opds+json")
         expect(response).to have_http_status(:ok)
-        expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+        # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
         expect(response_body['publications'].count).to eq(2)
         expect(response_body['publications']).to contain_exactly(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_2020.id), entity_id).to_json),
                                                                  JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id), entity_id).to_json))
@@ -683,7 +683,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
           get api_opds_heb_path, headers: headers
           expect(response.content_type).to eq("application/opds+json")
           expect(response).to have_http_status(:ok)
-          expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+          # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
           expect(response_body['publications'].count).to eq(2)
           expect(response_body['publications']).to contain_exactly(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id)).to_json),
                                                                    JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id)).to_json))
@@ -702,7 +702,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_heb_path, headers: headers, params: { filterByEntityId: entity_id }
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(2)
             expect(response_body['publications']).to contain_exactly(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph.id), entity_id).to_json),
                                                                      JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id), entity_id).to_json))
@@ -714,7 +714,7 @@ RSpec.describe "OPDS Feeds", type: [:request, :json_schema]  do
             get api_opds_heb_path, headers: headers, params: { filterByEntityId: entity_id }
             expect(response.content_type).to eq("application/opds+json")
             expect(response).to have_http_status(:ok)
-            expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
+            # expect(schemer_validate?(opds_feed_schemer, response_body)).to be true
             expect(response_body['publications'].count).to eq(1)
             expect(response_body['publications']).to contain_exactly(JSON.parse(Opds::Publication.new_from_monograph(Sighrax.from_noid(monograph_oa.id), entity_id).to_json))
           end


### PR DESCRIPTION
This will likely be temporary until the JSON in https://readium.org/webpub-manifest/schema/metadata.schema.json is fixed.