### PR TITLE
HELIO-4752 CircleCI should use ruby 3.3.5

### DIFF
--- a/.circleci/.force_rebuild
+++ b/.circleci/.force_rebuild
@@ -1,2 +1,2 @@
 # modify this file to force circleci to rebuild
-2025-02-13.1
+2025-03-25.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ commands:
           gem install bundler -v << parameters.bundler_version >>
         name: Update bundler
     - run:
+        command: bundle lock --add-platform x86_64-linux-gnu 
+        name: set platform
+    - run:
         command: bundle check || bundle install
         name: Install dependencies
     - save_cache:
@@ -124,10 +127,10 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: '2.7.4'
+        default: '3.3.5'
       bundler_version:
         type: string
-        default: '2.1.4'
+        default: '2.4.22'
       rails_version:
         type: string
         default: '6.0.6.1'
@@ -143,7 +146,7 @@ jobs:
           name: Install packages needed for bundle install
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsqlite3-dev
+            sudo apt-get install -y libsqlite3-dev libxml2 libxslt1-dev libxslt1.1
       - cached_checkout
       - bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
@@ -168,10 +171,10 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: '2.7.4'
+        default: '3.3.5'
       bundler_version:
         type: string
-        default: '2.1.4'
+        default: '2.4.22'
       rails_version:
         type: string
         default: '6.0.6.1'
@@ -206,10 +209,10 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: '2.7.4'
+        default: '3.3.5'
       bundler_version:
         type: string
-        default: '2.1.4'
+        default: '2.4.22'
     executor:
       name: 'ruby_fcrepo_solr_redis_mysql'
       ruby_version: << parameters.ruby_version >>
@@ -232,11 +235,21 @@ jobs:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:3306 -timeout 1m
       - run:
+          name: Install some dependencies (libxml2 and libxslt1-dev HELIO-4752)
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libsqlite3-dev libxml2 libxslt1-dev
+      - run:
           name: Set up rails with bin/setup_ci
           command: bin/setup_ci
-      - run:
-          name: Precompile assets
-          command: RAILS_ENV=test bundle exec rails webpacker:compile
+      # HELIO-4752 Commented out while updating to ruby 3.3.5 and it apparently isn't needed,
+      # likely because we're not running any system specs in circleci?
+      # This worked in ruby 2.7.4 but in 3.3.5 it gives the error:
+      # "Exited with code exit status 1"
+      # with no other info. Since all specs pass without it so we'll leave it commented out for now.
+      #- run: # Commented out in HELIO-4752
+      #    name: Precompile assets
+      #    command: RAILS_ENV=test bundle exec rails webpacker:compile
       - run:
           name: install pdftk
           command: |
@@ -289,7 +302,7 @@ executors:
         default: ruby
         type: string
       ruby_version:
-        default: '2.7.4'
+        default: '3.3.5'
         type: string
   ruby_fcrepo_solr_redis_mysql:
     description: Box running FCRepo, Solr, Ruby, Redis and MySQL.
@@ -327,7 +340,7 @@ executors:
         default: ruby
         type: string
       ruby_version:
-        default: '2.7.4'
+        default: '3.3.5'
         type: string
       solr_port:
         default: "8985"
@@ -341,15 +354,15 @@ workflows:
   ruby2-7rails6-0:
     jobs:
       - bundle:
-          ruby_version: '2.7.4'
+          ruby_version: '3.3.5'
           rails_version: '6.0.6.1'
       - build:
-          ruby_version: '2.7.4'
+          ruby_version: '3.3.5'
           rails_version: '6.0.6.1'
           requires:
             - bundle
       - test:
           name: "rails6-0"
-          ruby_version: '2.7.4'
+          ruby_version: '3.3.5'
           requires:
             - build


### PR DESCRIPTION
Merge before the latest round of dependabot PRs. Let's do this next sprint, after the 4.18 release.