### PR TITLE
HELIO-4864 build_kbart_job first_author_last_name rescues errors

### DIFF
--- a/app/jobs/build_kbart_job.rb
+++ b/app/jobs/build_kbart_job.rb
@@ -308,6 +308,9 @@ class BuildKbartJob < ApplicationJob
 
     # creators are "Lastname, Firstname\nLastname, Firstname"
     monograph.solr_document["creator_tesim"]&.first.split(",")[0] || ""
+  rescue StandardError => e
+    MarcLogger.error("Error in BuildKbartJob.first_author_last_name for #{monograph.id}: #{e}")
+    ""
   end
 
   def title_id(monograph)


### PR DESCRIPTION
This is in production as 4.18.1