### PR TITLE
HELIO-4933 manual fix for dependabot update to bootstrap 4.6.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,9 @@ gem 'bootsnap', '~> 1.18'
 # This is installed via yarn instead for heliotrope so it's in package.json
 # But there's *something* in the stack that needs it here.
 # I suspect it's related to resque-web
-gem 'bootstrap', '~> 4.0'
+# gem 'bootstrap', '~> 4.0'
+# https://github.com/mlibrary/heliotrope/security/dependabot/136
+gem 'bootstrap', '~> 4.6.2.1'
 
 # Canister provides containers
 gem 'canister', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     anyway_config (2.6.2)
       ruby-next-core (~> 1.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.16.0)
+    autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     awesome_nested_set (3.6.0)
       activerecord (>= 4.0.0, < 7.2)
@@ -189,10 +189,9 @@ GEM
       rexml
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    bootstrap (4.6.2)
+    bootstrap (4.6.2.1)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.16.1, < 2)
-      sassc-rails (>= 2.0.0)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (1.3.0)
       addressable (~> 2.5)
@@ -1288,7 +1287,7 @@ DEPENDENCIES
   bagit
   blacklight_oai_provider (~> 7.0.2)
   bootsnap (~> 1.18)
-  bootstrap (~> 4.0)
+  bootstrap (~> 4.6.2.1)
   byebug
   canister (~> 0.9.0)
   capybara (~> 3.29)


### PR DESCRIPTION
 https://github.com/mlibrary/heliotrope/security/dependabot/136

I put this on preview and it seems to be fine