### PR TITLE
FOPS-922 - hotfix for npp modal close button

### DIFF
--- a/app/assets/stylesheets/application/themes.scss
+++ b/app/assets/stylesheets/application/themes.scss
@@ -15038,6 +15038,11 @@ $npp-highlight-dark: #FFDF00;
     .modal__header h3,
     .modal__header button {
       color: #FFF;
+
+      .modal__close::before {
+        color: #fff;
+      }
+
     }
 
     // PDF loading progress bar


### PR DESCRIPTION
FOPS-922 follow-up to fix CSB modal close button styles.
Already in production as hot fix release [4.35.3](https://github.com/mlibrary/heliotrope/releases/tag/4.35.3).
