### PR TITLE
HELIO-5053 follow-up: openssl workaround not needed on webpack >= 5

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -164,14 +164,6 @@ module Heliotrope
     # https://github.com/samvera/hyrax/blob/4c1a99a6a52c973781dff090c2c98c044ea65e42/lib/hyrax/configuration.rb#L321
     ENV['HYRAX_UPLOAD_PATH'] = Settings.uploads_path
 
-    # Allow `rails webpacker:compile` to run on node versions >= 17 (see HELIO-4624 and https://nodejs.org/en/blog/release/v17.0.0#openssl-30)
-    # note: webpacker:compile basically just runs `bin/webpack`. To see the `error:0308010C:digital envelope routines::unsupported`...
-    # messages we're avoiding with this you can run the following on a production instance:
-    # `NODE_ENV=production ./bin/webpack --progress --config config/webpack/production.js`
-    node_major_version = `node -v || nodejs -v`.to_s.scan(/\d/)[0, 2].join.to_i
-    # not sure why this doesn't work on CircleCI, TBH. Is it not actually using the version of Node we think it is?
-    ENV['NODE_OPTIONS'] = '--openssl-legacy-provider' unless node_major_version < 17 || ENV['CIRCLECI']
-
     config.to_prepare do
       # ensure overrides are loaded
       # see https://bibwild.wordpress.com/2016/12/27/a-class_eval-monkey-patching-pattern-with-prepend/


### PR DESCRIPTION
HELIO-5053 follow-up PR to remove a workaround meant to allow webpack 4.x to work with Node 17.x+

> Been a while since I dug into that thing, here is a reminder from our AI friend:
The --openssl-legacy-provider flag (line 173) was needed for webpack 4, which used MD4 hashing — an algorithm removed from OpenSSL 3 (introduced in Node 17+).
Webpack 5 already fixed this by switching away from MD4. So with webpack 5 + Node 20, the flag is almost certainly no longer needed.