### PR TITLE
HELIO-5061 - remove unsupported aria labels

### DIFF
--- a/app/components/blacklight/facet_field_component.html.erb
+++ b/app/components/blacklight/facet_field_component.html.erb
@@ -12,7 +12,7 @@
       <%= label %>
     </button>
   </span>
-  <div id="<%= @facet_field.html_id %>" aria-labelledby="<%= @facet_field.html_id %>-header" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
+  <div id="<%= @facet_field.html_id %>" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
     <div class="card-body">
       <%= body %>
 

--- a/app/components/user_access_facet_component.html.erb
+++ b/app/components/user_access_facet_component.html.erb
@@ -19,7 +19,7 @@
       Access
     </button>
   </span>
-  <div id="<%= @facet_field.html_id %>" aria-labelledby="<%= @facet_field.html_id %>-header" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
+  <div id="<%= @facet_field.html_id %>" class="panel-collapse facet-content collapse <%= "show" unless @facet_field.collapsed? %>">
     <div class="card-body">
       <ul class="facet-values list-unstyled">
         <li>

--- a/app/views/kaminari/blacklight/_page.html.erb
+++ b/app/views/kaminari/blacklight/_page.html.erb
@@ -1,0 +1,18 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% page_display = number_with_delimiter(page.to_s) %>
+
+<li class="page-item <%= 'active' if page.current? %>">
+  <% if page.current? %>
+    <span class="page-link" aria-current="true"><%= page_display %></span>
+  <% else %>
+    <%= link_to page_display, url, :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_page', page: page_display) } %>
+  <% end %>
+</li>

--- a/app/views/press_catalog/_index_gallery_monograph.html.erb
+++ b/app/views/press_catalog/_index_gallery_monograph.html.erb
@@ -18,7 +18,7 @@
       <p class="authors"><%= render_markdown presenter.authors %></p>
       <% if presenter.date_created.present? %>
         <% pub_year = press.subdomain == 'barpublishing' ? "(#{presenter.date_created.first})" : presenter.date_created.first %>
-        <span class="pub-date"><%= pub_year %></span><% if presenter.edition_name.present? %><span aria-label="edition name" class="edition-name"><%= sanitize presenter.edition_name %></span><% end %>
+        <span class="pub-date"><%= pub_year %></span><% if presenter.edition_name.present? %><span class="edition-name"><%= sanitize presenter.edition_name %></span><% end %>
       <% end %>
       <% if presenter.bar_number&.length&.positive? %>
         <span class="bar-number"><strong><%= t('bar_number') %>:</strong> <%= presenter.bar_number %></span>

--- a/app/views/press_catalog/_index_list_monograph.html.erb
+++ b/app/views/press_catalog/_index_list_monograph.html.erb
@@ -17,7 +17,7 @@
     <p class="authors"><%= render_markdown presenter.authors %></p>
     <% if presenter.date_created.present? %>
       <% pub_year = press.subdomain == 'barpublishing' ? "(#{presenter.date_created.first})" : presenter.date_created.first %>
-      <span class="pub-date"><%= pub_year %></span><% if presenter.edition_name.present? %><span aria-label="edition name" class="edition-name"><%= sanitize presenter.edition_name %></span><% end %>
+      <span class="pub-date"><%= pub_year %></span><% if presenter.edition_name.present? %><span class="edition-name"><%= sanitize presenter.edition_name %></span><% end %>
     <% end %>
     <% if presenter.bar_number&.length&.positive? %>
       <span class="bar-number"><strong><%= t('bar_number') %>:</strong> <%= presenter.bar_number %></span>


### PR DESCRIPTION
Resolves HELIO-5061

Removes aria attributes on non-interactive elements or on unsupported elements that were identified as WCAG violations by SiteImprove.