### PR TITLE
HELIO-5100 get resque_web working with twitter-bootstrap-rails 5.3

### DIFF
--- a/app/assets/javascripts/resque_web/application.js
+++ b/app/assets/javascripts/resque_web/application.js
@@ -1,0 +1,8 @@
+// Resque-web override: avoid twitter-bootstrap-rails Bootstrap 5 minified JS,
+// which Uglifier cannot parse in our Sprockets/Uglifier stack.
+//
+//= require jquery
+//= require jquery_ujs
+//= require bootstrap
+//= require_tree .
+

--- a/app/assets/javascripts/resque_web/bootstrap.js.coffee
+++ b/app/assets/javascripts/resque_web/bootstrap.js.coffee
@@ -1,0 +1,16 @@
+jQuery ->
+  popoverLinks = $("a[rel=popover]")
+  tooltipTargets = $(".tooltip, a[rel=tooltip]")
+
+  if $.fn.popover?
+    popoverLinks.popover()
+  else if window.bootstrap?.Popover?
+    popoverLinks.each ->
+      bootstrap.Popover.getOrCreateInstance(@)
+
+  if $.fn.tooltip?
+    tooltipTargets.tooltip()
+  else if window.bootstrap?.Tooltip?
+    tooltipTargets.each ->
+      bootstrap.Tooltip.getOrCreateInstance(@)
+

--- a/app/assets/javascripts/resque_web/failure.js.coffee
+++ b/app/assets/javascripts/resque_web/failure.js.coffee
@@ -1,0 +1,7 @@
+jQuery ->
+  $(".backtrace").click (e) ->
+    e.preventDefault()
+    $(this).next().toggle()
+
+  $("ul.failed li").hover ->
+    $(this).toggleClass "hover"

--- a/app/assets/javascripts/resque_web/jquery.relative-date.js
+++ b/app/assets/javascripts/resque_web/jquery.relative-date.js
@@ -1,0 +1,47 @@
+/**
+ * jQ plugin adapted from 37s' relative date tool
+ * Takes the format of "Jan 15, 2007 15:45:00 GMT" and converts it to a relative time
+ * @see http://37signals.com/svn/posts/1557-javascript-makes-relative-times-compatible-with-caching
+ */
+(function($, window, undefined){
+
+    $.fn.relativeDate = function(opts){
+        var defaults = {
+            dateGetter: function(el){
+                return $(el).text();
+            }
+        },
+        options = $.extend({}, defaults, opts),
+        time_ago_in_words_with_parsing = function(from) {
+            var date = new Date;
+            date.setTime(Date.parse(from));
+            return time_ago_in_words(date);
+        },
+        time_ago_in_words = function(from) {
+            return distance_of_time_in_words(new Date, from);
+        },
+        distance_of_time_in_words = function(to, from) {
+            var distance_in_seconds = ((to - from) / 1000);
+            var distance_in_minutes = Math.floor(distance_in_seconds / 60);
+
+            if (distance_in_minutes == 0) { return 'less than a minute ago'; }
+            if (distance_in_minutes == 1) { return 'a minute ago'; }
+            if (distance_in_minutes < 45) { return distance_in_minutes + ' minutes ago'; }
+            if (distance_in_minutes < 90) { return 'about 1 hour ago'; }
+            if (distance_in_minutes < 1440) { return 'about ' + Math.round(distance_in_minutes / 60) + ' hours ago'; }
+            if (distance_in_minutes < 2880) { return '1 day ago'; }
+            if (distance_in_minutes < 43200) { return Math.floor(distance_in_minutes / 1440) + ' days ago'; }
+            if (distance_in_minutes < 86400) { return 'about 1 month ago'; }
+            if (distance_in_minutes < 525960) { return Math.floor(distance_in_minutes / 43200) + ' months ago'; }
+            if (distance_in_minutes < 1051199) { return 'about 1 year ago'; }
+
+            return 'over ' + Math.floor(distance_in_minutes / 525960) + ' years ago';
+        }
+
+        return $(this).each(function(){
+            date_str = options.dateGetter(this);
+            $(this).html(time_ago_in_words_with_parsing(date_str));
+        });
+    };
+
+})(jQuery, window);

--- a/app/assets/javascripts/resque_web/jquery.relative-date.js
+++ b/app/assets/javascripts/resque_web/jquery.relative-date.js
@@ -39,7 +39,7 @@
         }
 
         return $(this).each(function(){
-            date_str = options.dateGetter(this);
+            var date_str = options.dateGetter(this);
             $(this).html(time_ago_in_words_with_parsing(date_str));
         });
     };

--- a/app/assets/javascripts/resque_web/polling.js.coffee
+++ b/app/assets/javascripts/resque_web/polling.js.coffee
@@ -1,0 +1,25 @@
+jQuery ->
+  poll_interval = 2
+
+  poll_start = (el) ->
+    href = el.attr("href")
+    el.parent().text "Starting..."
+    $("#main").addClass "polling"
+    setInterval (->
+      $.ajax
+        dataType: "text"
+        type: "get"
+        url: href
+        success: (data) ->
+          $("#main").html data
+          $("#main .time").relativeDate()
+    ), poll_interval * 1000
+    location.hash = "#poll"
+
+  # auto start if hash is poll
+  poll_start $("a[rel=poll]")  if location.hash == "#poll"
+
+  # start when click on link
+  $("a[rel=poll]").click (e) ->
+    e.preventDefault()
+    poll_start $(this)

--- a/app/assets/javascripts/resque_web/relative_date.js.coffee
+++ b/app/assets/javascripts/resque_web/relative_date.js.coffee
@@ -1,0 +1,27 @@
+jQuery ->
+  relatizer = ->
+    dt = $(this).text()
+    $(this).relativeDate()
+    relatized = $(this).text()
+    if $(this).parents("a").size() > 0 || $(this).is("a")
+      $(this).relativeDate()
+      $(this).attr("title", dt) unless $(this).attr("title")
+    else
+      $(this).html """
+        <a href='#'' class='toggle_format' title='#{dt}'>
+          <span class='date_time'>#{dt}</span>
+          <span class='relatized_time'>#{relatized}</span>
+        </a>
+      """
+
+  format_toggler = (e) ->
+    e.preventDefault()
+    $(".time a.toggle_format span").toggle()
+    $(this).attr "title", $("span:hidden", this).text()
+
+  # changed html when doom is ready
+  $(".time").each relatizer
+  $(".time a.toggle_format .date_time").hide()
+
+  # add event on click in relative time to show date_time
+  $(".time").on "click", "a.toggle_format", format_toggler

--- a/app/assets/javascripts/resque_web/relative_date.js.coffee
+++ b/app/assets/javascripts/resque_web/relative_date.js.coffee
@@ -3,12 +3,12 @@ jQuery ->
     dt = $(this).text()
     $(this).relativeDate()
     relatized = $(this).text()
-    if $(this).parents("a").size() > 0 || $(this).is("a")
+    if $(this).parents("a").length > 0 || $(this).is("a")
       $(this).relativeDate()
       $(this).attr("title", dt) unless $(this).attr("title")
     else
       $(this).html """
-        <a href='#'' class='toggle_format' title='#{dt}'>
+        <a href="#" class="toggle_format" title="#{dt}">
           <span class='date_time'>#{dt}</span>
           <span class='relatized_time'>#{relatized}</span>
         </a>
@@ -19,7 +19,7 @@ jQuery ->
     $(".time a.toggle_format span").toggle()
     $(this).attr "title", $("span:hidden", this).text()
 
-  # changed html when doom is ready
+  # changed html when DOM is ready
   $(".time").each relatizer
   $(".time a.toggle_format .date_time").hide()
 

--- a/app/assets/stylesheets/resque_web/application.css
+++ b/app/assets/stylesheets/resque_web/application.css
@@ -1,0 +1,11 @@
+/*
+ * Local override for resque-web assets.
+ *
+ * We avoid require_tree so we can explicitly include our
+ * bootstrap_and_overrides file, which no longer depends on
+ * twitter-bootstrap-static/bootstrap from twitter-bootstrap-rails.
+ *
+ *= require_self
+ *= require resque_web/bootstrap_and_overrides
+ */
+

--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -1,0 +1,145 @@
+@import "bootstrap";
+@import "font-awesome-sprockets";
+@import "font-awesome";
+
+html {
+  background: #efefef;
+}
+
+body {
+  padding-top: 70px;
+}
+
+.navbar {
+  background-color: #1a1a1a;
+  border-bottom: 5px solid #ce1212;
+}
+
+.navbar .navbar-brand {
+  color: white;
+}
+
+// resque-web's tab helper generates Bootstrap 3-style <li class="active"><a>
+// Bootstrap 5 navbar-nav needs explicit nav-link styling for these bare <a> tags
+.navbar-nav li > a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+}
+
+.navbar-nav li.active > a {
+  background: linear-gradient(to bottom, #fa2424 0%, #ce1212 100%);
+  border-radius: 3px;
+  color: white;
+}
+
+.navbar-nav li > a:hover,
+.navbar-nav li > a:focus {
+  color: white;
+}
+
+.container h1 { color:#ce1212; font-size: 24px; }
+
+.label-info[href], .badge-info[href] {
+  background-color: #3A87AD;
+}
+
+.logo {
+  float: left;
+  margin: 2px 5px;
+  width: 36px;
+  height: 36px;
+}
+
+/* The remaining CSS rules come from the legacy Resque application */
+.subnav { padding: 8px 10px 7px 10px; background:#ce1212; font-size:90%;}
+.subnav li { display:inline; line-height: 16px; }
+.subnav li a { color:#fff; text-decoration:none; margin:3px; display:inline-block; background:#dd5b5b; padding:5px; -webkit-border-radius:3px; -moz-border-radius:3px;}
+.subnav li.current a { background:#fff; font-weight:bold; color:#ce1212;}
+.subnav li a:active { background:#b00909;}
+
+.container span.hl { background:#efefef; padding:2px;}
+.container h2 { margin:10px 0; font-size:130%;}
+.container table tr th { background:#efefef; color:#888; font-size:15px; font-weight:bold; min-width: 16px; }
+.container table tr td.no-data { text-align:center; padding:40px 0; color:#999; font-style:italic; font-size:130%;}
+.container p { margin:5px 0;}
+.container p.intro { margin-bottom:15px; font-size:85%; color:#999; margin-top:0; line-height:1.3;}
+.container h1.wi { margin-bottom:5px;}
+.container p.sub { font-size:95%; color:#999;}
+
+.container table.queues { width:40%;}
+.container table.queues td.queue { font-weight:bold; width:50%;}
+.container table.queues tr.failure td { background:#ffecec; color:#d37474;}
+.container table.queues tr.failure td a{ color:#d37474;}
+.container table.queues td.failure .badge a { color: white; }
+.container table.queues tr.first_failure td { border-top:2px solid #d37474; }
+
+.container table.jobs td.class { font-family:Monaco, "Courier New", monospace; font-size:90%; width:50%;}
+.container table.jobs td.args{ width:50%;}
+
+.container table.workers td.icon {width:1%; background:#efefef;text-align:center;}
+.container table.workers td.icon img { height: 16px; width: 16px; }
+.container table.workers td.where { width:25%;}
+.container table.workers td.queues { width:35%;}
+.container table.workers td.queues.queue { width:10%;}
+.container table.workers td.process { width:35%;}
+.container table.workers td.process span.waiting { color:#999; font-size:90%;}
+.container table.workers td.process small { font-size:80%; margin-left:5px;}
+.container table.workers td.process code { font-family:Monaco, "Courier New", monospace; font-size:90%;}
+.container table.workers td.process small a { color:#999;}
+.container.polling table.workers tr.working td { background:#f4ffe4; color:#7ac312;}
+.container.polling table.workers tr.working td.where a { color:#7ac312;}
+.container.polling table.workers tr.working td.process code { font-weight:bold;}
+
+
+.container table.stats th { font-size:100%; width:40%; color:#000;}
+.container hr { border:0; border-top:5px solid #efefef;  margin:15px 0;}
+
+#footer { padding:10px 5%; background:#efefef; color:#999; font-size:85%; line-height:1.5; border-top:5px solid #ccc; padding-top:10px;}
+#footer p a { color:#999;}
+
+.container p.poll { background:url('<%= asset_path('resque_web/poll.png') %>') no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
+
+.container ul.failed {margin-top: 20px;}
+.container ul.failed li {
+  background: #efefef; /* Old browsers */
+  background: -moz-linear-gradient(top, #efefef 0%, #fff 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#efefef), color-stop(100%,#fff)); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top, #efefef 0%,#fff 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top, #efefef 0%,#fff 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top, #efefef 0%,#fff 100%); /* IE10+ */
+  background: linear-gradient(to bottom, #efefef 0%,#fff 100%); /* W3C */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#efefef', endColorstr='#fff',GradientType=0 ); /* IE6-8 */
+
+  margin-top:10px;
+  padding:10px;
+  overflow:hidden;
+  border:1px solid #ccc;
+  -webkit-border-radius:5px;
+  -moz-border-radius:5px;
+  border-radius:5px;
+}
+.container ul.failed li dl dt {font-size:80%; color:#999; width:60px; float:left; padding-top:1px; text-align:right;}
+.container ul.failed li dl dd {margin-bottom:10px; margin-left:70px;}
+.container ul.failed li dl dd .retried { float:right; text-align: right; }
+.container ul.failed li dl dd .retried .remove { display:none; margin-top: 8px; }
+.container ul.failed li.hover dl dd .retried .remove { display:block; }
+.container ul.failed li dl dd .controls { display:none; float:right; }
+.container ul.failed li.hover dl dd .controls { display:block; }
+.container ul.failed li dl dd code, .container ul.failed li dl dd pre { font-family:Monaco, "Courier New", monospace; font-size:90%; white-space: pre-wrap;}
+.container ul.failed li dl dd.error a {font-family:Monaco, "Courier New", monospace; font-size:90%; }
+.container ul.failed li dl dd.error pre { margin-top:3px; line-height:1.3;}
+
+.container p.pagination { background:#efefef; padding:10px; overflow:hidden;}
+.container p.pagination a.less { float:left;}
+.container p.pagination a.more { float:right;}
+
+.container form {float:right; margin-top:-10px;margin-left:10px;}
+
+.container .time a.toggle_format {text-decoration:none;}
+
+#failed tr.total td {background-color: #FFECEC; color: #D37474; font-size: 15px; font-weight: bold;}
+#failed .center {text-align: center;}
+#failed .failed_class { padding-left: 20px; font-size:12px; }
+

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-dark navbar-expand-md fixed-top">
   <div class="container">
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav-collapse" aria-controls="nav-collapse" aria-expanded="false" aria-label="Toggle navigation">
+<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#nav-collapse" data-bs-toggle="collapse" data-bs-target="#nav-collapse" aria-controls="nav-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>

--- a/app/views/layouts/resque_web/application.html.erb
+++ b/app/views/layouts/resque_web/application.html.erb
@@ -34,29 +34,25 @@
 </head>
 <body>
 
-<div class="navbar navbar-inverse navbar-fixed-top">
-  <div class="navbar-inner">
-    <div class="container">
-      <a class="btn btn-navbar navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </a>
-      <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>
-      <%= link_to "Resque", ResqueWeb::Engine.app.url_helpers.root_path, :class => "brand navbar-brand" %>
-      <div class="nav-collapse navbar-collapse collapse">
-        <ul class="nav navbar-nav">
-          <% tabs.each do |tab_name,path| %>
-            <%= tab tab_name,path %>
-          <% end %>
-          <% if respond_to?(:main_app) %>
-            <li><%= link_to "Return to Application", main_app.root_path, :class => "nav navbar-nav" %></li>
-          <% end %>
-        </ul>
-      </div>
+<nav class="navbar navbar-dark navbar-expand-md fixed-top">
+  <div class="container">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav-collapse" aria-controls="nav-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <%= image_tag "resque_web/lifebuoy.png", class: 'logo' %>
+    <%= link_to "Resque", ResqueWeb::Engine.app.url_helpers.root_path, :class => "navbar-brand" %>
+    <div class="collapse navbar-collapse" id="nav-collapse">
+      <ul class="navbar-nav">
+        <% tabs.each do |tab_name,path| %>
+          <%= tab tab_name,path %>
+        <% end %>
+        <% if respond_to?(:main_app) %>
+          <li class="nav-item"><%= link_to "Return to Application", main_app.root_path, :class => "nav-link" %></li>
+        <% end %>
+      </ul>
     </div>
   </div>
-</div>
+</nav>
 
 <% unless subtabs.empty? %>
 <ul class="nav subnav">


### PR DESCRIPTION
This involves aggressive overrides of the resque_web gem. I don't expact that gem will ever be updated, last update was 9 years ago, so if we're going to use it we're going to need to take ownership of big parts of it.