### PR TITLE
HELIO-1967 - enable multiple language captions

### DIFF
--- a/app/jobs/output_monograph_files_job.rb
+++ b/app/jobs/output_monograph_files_job.rb
@@ -1,27 +1,37 @@
 # frozen_string_literal: true
 
 class OutputMonographFilesJob < ApplicationJob
-  # @param [noid] NOID of Monograph whose files are being extracted
-  # @param [path] string, path of directory to extract to
   def perform(noid, path) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     monograph = Sighrax.from_noid(noid)
 
     monograph.children.each do |member|
       presenter = Sighrax.hyrax_presenter(member)
-
-      # The importer is written to exit on zero-size files. We shouldn't have any in the system in future, see:
-      # https://tools.lib.umich.edu/jira/browse/HELIO-2246
-      next if presenter.external_resource_url.present? || presenter.file_size.blank? || presenter.file_size.zero?
-      filename = CGI.unescape(presenter&.original_name&.first)
-      next if filename.blank?
-
-      begin
-        File.open File.join(path, filename), "wb" do |dest|
-          FileSet.find(member.noid).original_file.stream.each { |chunk| dest.write(chunk) }
+      unless presenter.external_resource_url.present? || presenter.file_size.blank? || presenter.file_size.zero?
+        filename = CGI.unescape(presenter&.original_name&.first)
+        if filename.present?
+          begin
+            File.open File.join(path, filename), "wb" do |dest|
+              FileSet.find(member.noid).original_file.stream.each { |chunk| dest.write(chunk) }
+            end
+          rescue NoMemoryError => e
+            Rails.logger.error "OutputMonographFilesJob failed with NoMemoryError: #{e}"
+          end
         end
-      rescue NoMemoryError => e
-        Rails.logger.error "OutputMonographFilesJob failed with NoMemoryError: #{e}"
       end
+
+      write_metadata_files(member, path)
     end
   end
+
+  private
+
+    def write_metadata_files(member, path)
+      file_set = FileSet.find(member.noid)
+      METADATA_FIELDS.select { |field| field[:object] == :file_set && field[:multivalued] == :yes_file }.each do |field|
+        values = file_set.public_send(field[:metadata_name]).to_a
+        WebvttService.export_filenames(member.noid, field[:metadata_name], values).each_with_index do |filename, index|
+          File.write(File.join(path, filename), values[index])
+        end
+      end
+    end
 end

--- a/app/models/concerns/solr_document_extensions/file_set.rb
+++ b/app/models/concerns/solr_document_extensions/file_set.rb
@@ -53,7 +53,8 @@ module SolrDocumentExtensions
     end
 
     def closed_captions
-      Array(self['closed_captions_tesim']).first
+      # NB: this is a multi-value field (one WebVTT "file" per language). See WebvttService.
+      Array(self['closed_captions_tesim'])
     end
 
     def content_type
@@ -117,7 +118,8 @@ module SolrDocumentExtensions
     end
 
     def visual_descriptions
-      Array(self['visual_descriptions_tesim']).first
+      # NB: this is a multi-value field (one WebVTT "file" per language). See WebvttService.
+      Array(self['visual_descriptions_tesim'])
     end
   end
 end

--- a/app/overrides/hyrax/downloads_controller_overrides.rb
+++ b/app/overrides/hyrax/downloads_controller_overrides.rb
@@ -7,9 +7,9 @@ Hyrax::DownloadsController.class_eval do # rubocop:disable Metrics/BlockLength
 
     def show # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       if closed_captions?
-        render plain: presenter.closed_captions
+        render plain: WebvttService.for_language(presenter.closed_captions, params[:lang])
       elsif visual_descriptions?
-        render plain: presenter.visual_descriptions
+        render plain: WebvttService.for_language(presenter.visual_descriptions, params[:lang])
       elsif embed_css?
         # try to prevent browsers caching these tiny CSS files, so that any changes will be picked up immediately
         response.set_header('Last-Modified', Time.now.httpdate)

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -53,6 +53,16 @@ module Hyrax
     # HELIO-4634
     delegate :member_of_collection_ids, to: :parent
 
+    # Parsed, per-language WebVTT "tracks" used to write <track> elements in the media partials.
+    # See WebvttService and app/overrides/hyrax/downloads_controller_overrides.rb
+    def closed_caption_tracks
+      WebvttService.parse(closed_captions)
+    end
+
+    def visual_description_tracks
+      WebvttService.parse(visual_descriptions)
+    end
+
     def monograph_id
       Array(solr_document['monograph_id_ssim']).first
     end

--- a/app/services/webvtt_service.rb
+++ b/app/services/webvtt_service.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Our `closed_captions` and `visual_descriptions` FileSet metadata fields hold one or more WebVTT
+# "files" (as plain text), which are served up by the overridden Hyrax::DownloadsController as though
+# they were real derivative downloads (see app/overrides/hyrax/downloads_controller_overrides.rb).
+#
+# To support more than one language per field we expect each entry (except a lone, single entry, for
+# backwards-compatibility) to declare its IETF/BCP-47 language tag in the WebVTT header, e.g.:
+#
+#   WEBVTT
+#   Language: fr
+#
+# This is valid WebVTT, so all pre-existing single-entry captions (which just start with `WEBVTT`)
+# continue to work untouched and are assumed to be English.
+class WebvttService
+  DEFAULT_LANGUAGE_TAG = 'en'
+
+  # A small, dependency-free map of the language tags we actually expect to see. Unknown tags fall
+  # back to the tag itself as a label (see `label_for`), so this only needs to grow as needed. Full
+  # BCP-47 display-name resolution (CLDR etc.) would be overkill for this slowly-growing feature.
+  LANGUAGE_LABELS = {
+    'ar' => 'Arabic',
+    'de' => 'German',
+    'el' => 'Greek',
+    'en' => 'English',
+    'es' => 'Spanish',
+    'fa' => 'Persian',
+    'fr' => 'French',
+    'he' => 'Hebrew',
+    'hi' => 'Hindi',
+    'it' => 'Italian',
+    'ja' => 'Japanese',
+    'ko' => 'Korean',
+    'la' => 'Latin',
+    'nl' => 'Dutch',
+    'pl' => 'Polish',
+    'pt' => 'Portuguese',
+    'ru' => 'Russian',
+    'tr' => 'Turkish',
+    'uk' => 'Ukrainian',
+    'zh' => 'Chinese'
+  }.freeze
+
+  # Captures a BCP-47 language tag from a case-insensitive Language key-value header line. The tag
+  # has a 2-3 letter primary subtag with optional additional subtags (`fr`, `fr-CA`, `zh-Hant`).
+  LANGUAGE_METADATA_REGEXP = /\A[ \t]*Language[ \t]*:[ \t]*(?<tag>[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)[ \t]*\z/i
+  CUE_TIMESTAMP_REGEXP = /\A[ \t]*(?:\d{2}:)?\d{2}:\d{2}\.\d{3}[ \t]+-->/
+
+  # Parse a multi-value field's array of raw WebVTT strings into an ordered array of track hashes:
+  #   [{ language_tag: 'en', label: 'English', body: "WEBVTT..." }, ...]
+  # A lone entry with no declared tag is assumed to be the default (English); subsequent untagged
+  # entries get a nil tag/label (they can still be served as the fallback, but won't render a <track>).
+  def self.parse(entries)
+    entries = Array(entries).reject(&:blank?)
+
+    entries.map.with_index do |vtt, index|
+      tag = language_tag(vtt)
+      tag = DEFAULT_LANGUAGE_TAG if tag.blank? && index.zero?
+
+      { language_tag: tag, label: label_for(tag), body: vtt }
+    end
+  end
+
+  # Return the WebVTT body string for the requested language tag, falling back to the first entry
+  # when the tag is blank or not found (which preserves the pre-multi-language behaviour).
+  def self.for_language(entries, tag)
+    parsed = parse(entries)
+    return if parsed.empty?
+
+    match = parsed.find { |track| track[:language_tag] == tag } if tag.present?
+    (match || parsed.first)[:body]
+  end
+
+  # Extract the IETF/BCP-47 language tag from a single WebVTT string's header, or nil.
+  def self.language_tag(vtt)
+    lines = vtt.to_s.lines
+    lines.shift
+
+    lines.each do |line|
+      break if CUE_TIMESTAMP_REGEXP.match?(line)
+
+      match = LANGUAGE_METADATA_REGEXP.match(line.strip)
+      return match[:tag] if match
+    end
+
+    nil
+  end
+
+  def self.label_for(tag)
+    return if tag.blank?
+
+    LANGUAGE_LABELS[tag] || LANGUAGE_LABELS[tag.split('-').first] || tag
+  end
+
+  # Generate stable names for WebVTT metadata files in an extracted monograph.
+  def self.export_filenames(noid, metadata_name, entries)
+    counts = Hash.new(0)
+
+    Array(entries).map do |body|
+      tag = language_tag(body)
+      basename = [noid, metadata_name, tag].compact.reject(&:blank?).join('_')
+      basename = "#{basename}.vtt"
+      counts[basename] += 1
+      counts[basename] == 1 ? basename : basename.sub('.vtt', "_#{counts[basename]}.vtt")
+    end
+  end
+end

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -31,8 +31,8 @@
         <%= f.input :display_date, as: :multi_value, label: 'Display Date', input_html: { class: 'form-control' } %>
         <%= f.input :keyword, as: :multi_value, input_html: { class: 'form-control' } %>
         <%= f.input :language, as: :multi_value, input_html: { class: 'form-control' } %>
-        <%= f.input :closed_captions, as: :text, input_html: { multiple: true, value: curation_concern.closed_captions.first, class: 'form-control' } %>
-        <%= f.input :visual_descriptions, as: :text, input_html: { multiple: true, value: curation_concern.visual_descriptions.first, class: 'form-control' } %>
+        <%= f.input :closed_captions, as: :multi_value_textarea, input_html: { rows: 4, class: 'form-control' } %>
+        <%= f.input :visual_descriptions, as: :multi_value_textarea, input_html: { rows: 4, class: 'form-control' } %>
         <%= f.input :transcript, as: :text, input_html: { class: 'form-control' } %>
         <%= f.input :translation, as: :text, input_html: { multiple: true, value: curation_concern.translation.first, class: 'form-control' } %>
         <%= f.input :section_title, as: :multi_value, input_html: { class: 'form-control' } %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -17,8 +17,8 @@
        data-skin="2020"
        <%= raw file_set.closed_captions.present? ? 'data-transcript-div="audio-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
   <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
-  <% if file_set.closed_captions.present? %>
-   <track kind="captions" src="<%= hyrax.download_path(file_set, file: 'captions_vtt') %>" srclang="en" label="English" />
+  <% file_set.closed_caption_tracks.each do |track| %>
+   <track kind="captions" src="<%= hyrax.download_path(file_set, file: 'captions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
   Your browser does not support the audio tag.
 </audio>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -18,11 +18,11 @@
        poster="<%= hyrax.download_path(file_set, file: 'jpeg') %>"
        <%= raw file_set.closed_captions.present? ? 'data-transcript-div="video-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
   <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-  <% if file_set.closed_captions.present? %><%# kind="subtitles" not "captions" due to https://github.com/mlibrary/heliotrope/issues/1234 %>
-    <track kind="subtitles" src="<%= hyrax.download_path(file_set, file: 'captions_vtt') %>" srclang="en" label="English"  />
+  <% file_set.closed_caption_tracks.each do |track| %><%# kind="subtitles" not "captions" due to https://github.com/mlibrary/heliotrope/issues/1234 %>
+    <track kind="subtitles" src="<%= hyrax.download_path(file_set, file: 'captions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
-  <% if file_set.visual_descriptions.present? %>
-    <track kind="descriptions" src="<%= hyrax.download_path(file_set, file: 'descriptions_vtt') %>" srclang="en" label="English"  />
+  <% file_set.visual_description_tracks.each do |track| %>
+    <track kind="descriptions" src="<%= hyrax.download_path(file_set, file: 'descriptions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
   Your browser does not support the video tag.
 </video>

--- a/app/views/hyrax/file_sets/media_display_embedded/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display_embedded/_audio.html.erb
@@ -21,8 +21,8 @@
        data-heading-level="0" <%# see HELIO-4718 %>
        <%= raw file_set.closed_captions.present? ? 'data-transcript-div="audio-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
   <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
-  <% if file_set.closed_captions.present? %>
-    <track kind="captions" src="<%= hyrax.download_path(file_set, file: 'captions_vtt') %>" srclang="en" label="English" />
+  <% file_set.closed_caption_tracks.each do |track| %>
+    <track kind="captions" src="<%= hyrax.download_path(file_set, file: 'captions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
   Your browser does not support the audio tag.
 </audio>

--- a/app/views/hyrax/file_sets/media_display_embedded/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display_embedded/_video.html.erb
@@ -48,11 +48,11 @@
        poster="<%= hyrax.download_path(file_set.id, file: 'jpeg') %>"
        <%= raw file_set.closed_captions.present? ? 'data-transcript-div="video-hidden-transcript-container" data-lyrics-mode' : 'data-include-transcript="false"' %>>
   <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-  <% if file_set.closed_captions.present? %><%# kind="subtitles" not "captions" due to https://github.com/mlibrary/heliotrope/issues/1234 %>
-    <track kind="subtitles" src="<%= hyrax.download_path(file_set.id, file: 'captions_vtt') %>" srclang="en" label="English"  />
+  <% file_set.closed_caption_tracks.each do |track| %><%# kind="subtitles" not "captions" due to https://github.com/mlibrary/heliotrope/issues/1234 %>
+    <track kind="subtitles" src="<%= hyrax.download_path(file_set.id, file: 'captions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
-  <% if file_set.visual_descriptions.present? %>
-    <track kind="descriptions" src="<%= hyrax.download_path(file_set, file: 'descriptions_vtt') %>" srclang="en" label="English"  />
+  <% file_set.visual_description_tracks.each do |track| %>
+    <track kind="descriptions" src="<%= hyrax.download_path(file_set, file: 'descriptions_vtt', lang: track[:language_tag]) %>" srclang="<%= track[:language_tag] %>" label="<%= track[:label] %>" />
   <% end %>
   Your browser does not support the video tag.
 </video>

--- a/lib/export/exporter.rb
+++ b/lib/export/exporter.rb
@@ -197,6 +197,8 @@ module Export
           # note: this is a multi-valued field but we're only using the first one to hold a string containing...
           #       ordered, newline-separated values. Need such to be semi-colon-separated in a cell once again
           value.first.split(/\r\n?|\n/).reject(&:blank?).join('; ')
+        elsif multivalued == :yes_file
+          WebvttService.export_filenames(item.id, metadata_name, value.to_a).join('; ')
         else
           # https://tools.lib.umich.edu/jira/browse/HELIO-2321
           metadata_name == 'doi' ? 'https://doi.org/' + value : value

--- a/lib/import/csv_parser.rb
+++ b/lib/import/csv_parser.rb
@@ -26,7 +26,7 @@ module Import
                puts "Parsing file: #{file}"
                CSV.read(file, headers: true, skip_blanks: true).delete_if { |row| row.to_hash.values.all?(&:blank?) }
              end
-      row_data = RowData.new(@reuse_noids)
+      row_data = RowData.new(@reuse_noids, file && File.dirname(file))
 
       # look for unexpected column names which will be ignored. note: 'File Name' is not in METADATA_FIELDS.
       unexpecteds = rows[0].to_h.keys.map { |k| k&.strip } - (METADATA_FIELDS.pluck :field_name) - ['File Name']

--- a/lib/import/row_data.rb
+++ b/lib/import/row_data.rb
@@ -8,8 +8,9 @@ module Import
   class RowData
     attr_reader :row, :attrs, :reuse_noids
 
-    def initialize(reuse_noids = false)
+    def initialize(reuse_noids = false, root_dir = nil)
       @reuse_noids = reuse_noids
+      @root_dir = root_dir
     end
 
     def field_values(object, row, attrs, errors = {}, row_num = 0) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -65,9 +66,25 @@ module Import
           sheet_value.split(';').map!(&:strip).reject(&:empty?)
         elsif is_multivalued == :yes_multiline
           Array(sheet_value.split(';').map!(&:strip).reject(&:empty?).join("\n"))
+        elsif is_multivalued == :yes_file
+          file_contents(sheet_value)
         else
           # force array for uniformity, ease of iteration in subsequent methods
           Array.wrap(sheet_value.strip)
+        end
+      end
+
+      def file_contents(sheet_value)
+        filenames = sheet_value.split(/[;\r\n]+/).map(&:strip).reject(&:empty?)
+        return filenames if @root_dir.blank?
+
+        filenames.map do |filename|
+          matches = Dir.glob(File.join(@root_dir, '**', filename))
+          next filename if matches.empty?
+          next "More than one file found with name: '#{filename}'" if matches.count > 1
+          next nil if File.zero?(matches.first)
+
+          File.read(matches.first)
         end
       end
 

--- a/lib/metadata_fields.rb
+++ b/lib/metadata_fields.rb
@@ -6,6 +6,7 @@ I18n.load_path += Dir[Rails.root.join("config", "locales", "heliotrope.en.yml").
 # something to note is that the multivalued :yes/:no values mirror the model, such that assignment will work properly as a scalar or array...
 # :yes_split means that this is a field we actually want to *use* as multivalued, and so will split the CSV field on semicolons to do so
 # :yes_multiline means we only want to use <fieldname>.first of a multi-valued field to store all our values, which will be separated with a new line within that string
+# :yes_file means the CSV value contains one or more filenames whose contents should be stored as metadata
 
 # ActiveFedora fields not really 'settable' by users, needed in the import-export-edit-import cycle
 ADMIN_METADATA_FIELDS ||=
@@ -70,8 +71,8 @@ METADATA_FIELDS ||=
     { object: :file_set, field_name: 'Translation', metadata_name: 'translation', required: false, multivalued: :yes, description: I18n.t('csv.descriptions.translation') },
     { object: :universal, field_name: 'DOI', metadata_name: 'doi', required: false, multivalued: :no, description: I18n.t('csv.descriptions.doi') },
     { object: :universal, field_name: 'Handle', metadata_name: 'hdl', required: false, multivalued: :no, description: I18n.t('csv.descriptions.hdl') },
-    { object: :file_set, field_name: 'Closed Captions', metadata_name: 'closed_captions', required: false, multivalued: :yes, description: I18n.t('csv.descriptions.closed_captions') },
-    { object: :file_set, field_name: 'Visual Descriptions', metadata_name: 'visual_descriptions', required: false, multivalued: :yes, description: I18n.t('csv.descriptions.visual_descriptions') },
+    { object: :file_set, field_name: 'Closed Captions', metadata_name: 'closed_captions', required: false, multivalued: :yes_file, description: I18n.t('csv.descriptions.closed_captions') },
+    { object: :file_set, field_name: 'Visual Descriptions', metadata_name: 'visual_descriptions', required: false, multivalued: :yes_file, description: I18n.t('csv.descriptions.visual_descriptions') },
     { object: :universal, field_name: 'Tombstone?', metadata_name: 'tombstone', required: false, multivalued: :no, description: I18n.t('csv.descriptions.tombstone') },
     { object: :universal, field_name: 'Tombstone Message', metadata_name: 'tombstone_message', required: false, multivalued: :no, description: I18n.t('csv.descriptions.tombstone_message') },
     { object: :monograph, field_name: 'Volume', metadata_name: 'volume', required: false, multivalued: :no, description: I18n.t('csv.descriptions.volume') },

--- a/spec/features/file_set_cardinality_spec.rb
+++ b/spec/features/file_set_cardinality_spec.rb
@@ -86,8 +86,11 @@ describe 'FileSet Cardinality' do
       expect(find('#file_set_caption')[:class]).not_to include 'multi-text-field'
 
       expect(cover.closed_captions).to match_array(['This is a closed caption'])
-      expect(doc.closed_captions).to eql 'This is a closed caption'
-      expect(find('#file_set_closed_captions')[:class]).not_to include 'multi-text-field'
+      expect(doc.closed_captions).to eql ['This is a closed caption']
+      # note our home-spun MultiValueTextareaInput from app/inputs/multi_value_textarea_input.rb actually assigns...
+      # unique ids (with index suffixed) to each textarea, unlike the default Hyrax::MultiValueTextInput which...
+      # assigns an id only to the first textarea and then gives up on the rest.
+      expect(find('#file_set_closed_captions_0')[:class]).to include 'multi-text-field'
 
       expect(cover.content_type).to match_array(['drawing', 'illustration'])
       expect(doc.content_type).to match_array(['drawing', 'illustration'])
@@ -178,8 +181,11 @@ describe 'FileSet Cardinality' do
       expect(find('#file_set_translation')[:class]).not_to include 'multi-text-field'
 
       expect(cover.visual_descriptions).to match_array(['This is a visual description'])
-      expect(doc.visual_descriptions).to eql 'This is a visual description'
-      expect(find('#file_set_visual_descriptions')[:class]).not_to include 'multi-text-field'
+      expect(doc.visual_descriptions).to eql ['This is a visual description']
+      # note our home-spun MultiValueTextareaInput from app/inputs/multi_value_textarea_input.rb actually assigns...
+      # unique ids (with index suffixed) to each textarea, unlike the default Hyrax::MultiValueTextInput which...
+      # assigns an id only to the first textarea and then gives up on the rest.
+      expect(find('#file_set_visual_descriptions_0')[:class]).to include 'multi-text-field'
     end
   end
 end

--- a/spec/lib/import/row_data_yes_file_spec.rb
+++ b/spec/lib/import/row_data_yes_file_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'import/row_data'
+require 'metadata_fields' unless defined?(MONO_FILENAME_FLAG)
+
+RSpec.describe Import::RowData do
+  let(:root_dir) { Dir.mktmpdir }
+  let(:row_data) { described_class.new(false, root_dir) }
+  let(:attrs) { {} }
+  let(:errors) { {} }
+
+  after { FileUtils.remove_entry(root_dir) }
+
+  it 'keeps importing when referenced WebVTT files are missing, duplicated, or empty' do
+    File.write(File.join(root_dir, 'duplicate.vtt'), 'first')
+    FileUtils.mkdir_p(File.join(root_dir, 'nested'))
+    File.write(File.join(root_dir, 'nested', 'duplicate.vtt'), 'second')
+    FileUtils.touch(File.join(root_dir, 'empty.vtt'))
+
+    row = {
+      'File Name' => 'asset.jpg',
+      'Title' => 'Asset',
+      'Closed Captions' => "missing.vtt; duplicate.vtt\nempty.vtt"
+    }
+
+    row_data.field_values(:file_set, row, attrs, errors)
+
+    expect(attrs['closed_captions']).to eq([
+      'missing.vtt',
+      'More than one file found with name: \'duplicate.vtt\'',
+      nil
+    ])
+  end
+
+  it 'stores the contents of an existing non-empty file in metadata' do
+    contents = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nLorem ipsum\n"
+    File.write(File.join(root_dir, 'captions.vtt'), contents)
+
+    row_data.field_values(:file_set, { 'Closed Captions' => 'captions.vtt' }, attrs, errors)
+
+    expect(attrs['closed_captions']).to eq([contents])
+  end
+end

--- a/spec/services/webvtt_export_filename_spec.rb
+++ b/spec/services/webvtt_export_filename_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WebvttService do
+  let(:english) { "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nLorem ipsum\n\n00:00:03.000 --> 00:00:04.000\ndolor sit amet\n" }
+  let(:french) { "WEBVTT\nLanguage: fr\n\n00:00:01.000 --> 00:00:02.000\nLorem francais\n\n00:00:03.000 --> 00:00:04.000\ndolor sit amet\n" }
+
+  it 'names exported entries with the NOID, field, and language' do
+    expect(described_class.export_filenames('999999999', 'closed_captions', [english, french])).to eq(
+      ['999999999_closed_captions.vtt', '999999999_closed_captions_fr.vtt']
+    )
+  end
+
+  it 'adds an index when language-derived names collide' do
+    expect(described_class.export_filenames('999999999', 'closed_captions', [english, english])).to eq(
+      ['999999999_closed_captions.vtt', '999999999_closed_captions_2.vtt']
+    )
+  end
+end

--- a/spec/services/webvtt_service_spec.rb
+++ b/spec/services/webvtt_service_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WebvttService do
+  let(:english) { "WEBVTT\n\n1\n00:00:01.000 --> 00:00:04.000\nHello world" }
+  let(:french)  { "WEBVTT\nLanguage: fr\n\n1\n00:00:01.000 --> 00:00:04.000\nBonjour le monde" }
+  let(:regional) { "WEBVTT\nLanguage: fr-CA\n\n1\n00:00:01.000 --> 00:00:04.000\nBonjour" }
+  let(:metadata_language) do
+    "WEBVTT\nKind: captions\n\nLANGUAGE:fr\n\n1\n00:00:01.000 --> 00:00:04.000\nBonjour le monde"
+  end
+
+  describe '.language_tag' do
+    it 'returns nil for a bare WEBVTT signature' do
+      expect(described_class.language_tag(english)).to be_nil
+    end
+
+    it 'reads a tag with subtags' do
+      expect(described_class.language_tag(regional)).to eq('fr-CA')
+    end
+
+    it 'reads a case-insensitive Language metadata label without a space after the colon' do
+      expect(described_class.language_tag(metadata_language)).to eq('fr')
+    end
+
+    it 'reads Language metadata after other header lines' do
+      vtt = metadata_language.sub("LANGUAGE:fr", "Kind: captions\nLanguage: fr-CA")
+      expect(described_class.language_tag(vtt)).to eq('fr-CA')
+    end
+
+    it 'ignores language text on the WEBVTT signature line' do
+      expect(described_class.language_tag("WEBVTT - fr\n\n1\n00:00:01.000 --> 00:00:04.000\nBonjour")).to be_nil
+      expect(described_class.language_tag("WEBVTT es\n\n1\n00:00:01.000 --> 00:00:04.000\nHola")).to be_nil
+    end
+
+    it 'does not read Language metadata from cue text' do
+      vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:04.000\nLanguage: fr"
+      expect(described_class.language_tag(vtt)).to be_nil
+    end
+
+
+    it 'handles blank/nil input' do
+      expect(described_class.language_tag(nil)).to be_nil
+      expect(described_class.language_tag('')).to be_nil
+    end
+  end
+
+  describe '.label_for' do
+    it 'maps a known tag to a human label' do
+      expect(described_class.label_for('fr')).to eq('French')
+    end
+
+    it 'maps a regional tag via its primary subtag' do
+      expect(described_class.label_for('fr-CA')).to eq('French')
+    end
+
+    it 'falls back to the tag itself when unknown' do
+      expect(described_class.label_for('xx')).to eq('xx')
+    end
+
+    it 'returns nil for a blank tag' do
+      expect(described_class.label_for(nil)).to be_nil
+    end
+  end
+
+  describe '.parse' do
+    it 'returns [] for blank input' do
+      expect(described_class.parse(nil)).to eq([])
+      expect(described_class.parse([])).to eq([])
+      expect(described_class.parse([''])).to eq([])
+    end
+
+    it 'assumes a lone untagged entry is the default (English) for backwards-compatibility' do
+      expect(described_class.parse([english])).to eq(
+        [{ language_tag: 'en', label: 'English', body: english }]
+      )
+    end
+
+    it 'parses multiple tagged entries' do
+      expect(described_class.parse([english, french])).to eq(
+        [
+          { language_tag: 'en', label: 'English', body: english },
+          { language_tag: 'fr', label: 'French', body: french }
+        ]
+      )
+    end
+
+    it 'gives a nil tag/label to a secondary untagged entry' do
+      expect(described_class.parse([french, english])).to eq(
+        [
+          { language_tag: 'fr', label: 'French', body: french },
+          { language_tag: nil, label: nil, body: english }
+        ]
+      )
+    end
+  end
+
+  describe '.for_language' do
+    it 'returns nil when there are no entries' do
+      expect(described_class.for_language([], 'en')).to be_nil
+    end
+
+    it 'returns the matching entry body' do
+      expect(described_class.for_language([english, french], 'fr')).to eq(french)
+    end
+
+    it 'falls back to the first entry when the tag is not found' do
+      expect(described_class.for_language([english, french], 'de')).to eq(english)
+    end
+
+    it 'falls back to the first entry when the tag is blank (legacy single-caption behaviour)' do
+      expect(described_class.for_language([english], nil)).to eq(english)
+    end
+  end
+end


### PR DESCRIPTION
HELIO-1967 - enable multiple language captions

also implements the importing of one or more files' contents into a metadata field, using the new `multivalue: yes_file` value in `lib/metadata_fields`, which is something specified in these near-duplicate tickets:
HELIO-4908
FULCRUMOPS-618